### PR TITLE
Add `#include <memory>` to curl.cpp

### DIFF
--- a/net/curl.cpp
+++ b/net/curl.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 #include <openssl/err.h>
 #include <shared_mutex>
 #include <vector>
+#include <memory>
 
 #include <photon/common/alog.h>
 #include <photon/common/event-loop.h>


### PR DESCRIPTION
Fix compilation error for g++ (GCC) 11.3.0
#29 