### PR TITLE
notify_all should in critical zone, because cvar may destruct before …

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,48 +66,51 @@ Conclusion: Photon is faster than fio under this circumstance.
 
 #### 2.1 TCP
 
-Compare Photon with other libs / languages frameworks in regard to TCP echo server performance, in descending order.
+Compare Photon with other libs / languages in regard to TCP echo server performance, in descending order.
 
 Client Mode: Streaming
 
-|                                                                       | Language / Coroutine Type | Buffer Size | Conn Num |  QPS  | Bandwidth | CPU util |
-|:---------------------------------------------------------------------:|:-------------------------:|:-----------:|:--------:|:-----:|:---------:|:--------:|
-|                                Photon                                 |      C++ / Stackful       |  512 Bytes  |    4     | 1604K |  6.12Gb   |   99%    |
-|           [cocoyaxi](https://github.com/idealvin/cocoyaxi)            |      C++ / Stackful       |  512 Bytes  |    4     | 1545K |  5.89Gb   |   99%    |
-|                      [tokio](https://tokio.rs/)                       |     Rust / Stackless      |  512 Bytes  |    4     | 1384K |  5.28Gb   |   98%    |
-| [acl/lib_fiber](https://github.com/acl-dev/acl/tree/master/lib_fiber) |      C++ / Stackful       |  512 Bytes  |    4     | 1240K |  4.73Gb   |   94%    |
-|                                  Go                                   |     Golang / Stackful     |  512 Bytes  |    4     | 1083K |  4.13Gb   |   100%   |
-|              [libgo](https://github.com/yyzybb537/libgo)              |      C++ / Stackful       |  512 Bytes  |    4     | 770K  |  2.94Gb   |   99%    |
-|             [boost::asio](https://think-async.com/Asio/)              |   C++ / Async-callback    |  512 Bytes  |    4     | 634K  |  2.42Gb   |   97%    |
-|               [libco](https://github.com/Tencent/libco)               |      C++ / Stackful       |  512 Bytes  |    4     | 432K  |  1.65Gb   |   96%    |
-|              [zab](https://github.com/Donald-Rupin/zab)               |     C++20 / Stackless     |  512 Bytes  |    4     | 412K  |  1.57Gb   |   99%    |
-|             [asyncio](https://github.com/netcan/asyncio)              |     C++20 / Stackless     |  512 Bytes  |    4     | 163K  |  0.60Gb   |   98%    |
+|                                                                       | Language |  Concurrency Model  | Buffer Size | Conn Num |  QPS  | Bandwidth | CPU util |
+|:---------------------------------------------------------------------:|:--------:|:-------------------:|:-----------:|:--------:|:-----:|:---------:|:--------:|
+|                                Photon                                 |   C++    | Stackful Coroutine  |  512 Bytes  |    4     | 1604K |  6.12Gb   |   99%    |
+|           [cocoyaxi](https://github.com/idealvin/cocoyaxi)            |   C++    | Stackful Coroutine  |  512 Bytes  |    4     | 1545K |  5.89Gb   |   99%    |
+|                      [tokio](https://tokio.rs/)                       |   Rust   | Stackless Coroutine |  512 Bytes  |    4     | 1384K |  5.28Gb   |   98%    |
+| [acl/lib_fiber](https://github.com/acl-dev/acl/tree/master/lib_fiber) |   C++    | Stackful Coroutine  |  512 Bytes  |    4     | 1240K |  4.73Gb   |   94%    |
+|                                  Go                                   |  Golang  | Stackful Coroutine  |  512 Bytes  |    4     | 1083K |  4.13Gb   |   100%   |
+|              [libgo](https://github.com/yyzybb537/libgo)              |   C++    | Stackful Coroutine  |  512 Bytes  |    4     | 770K  |  2.94Gb   |   99%    |
+|             [boost::asio](https://think-async.com/Asio/)              |   C++    |   Async Callback    |  512 Bytes  |    4     | 634K  |  2.42Gb   |   97%    |
+|               [libco](https://github.com/Tencent/libco)               |   C++    | Stackful Coroutine  |  512 Bytes  |    4     | 432K  |  1.65Gb   |   96%    |
+|              [zab](https://github.com/Donald-Rupin/zab)               |  C++20   | Stackless Coroutine |  512 Bytes  |    4     | 412K  |  1.57Gb   |   99%    |
+|             [asyncio](https://github.com/netcan/asyncio)              |  C++20   | Stackless Coroutine |  512 Bytes  |    4     | 163K  |  0.60Gb   |   98%    |
 
 Client Mode: Ping-pong
 
-|                                                                       | Language / Coroutine Type | Buffer Size | Conn Num | QPS  | Bandwidth | CPU util |
-|:---------------------------------------------------------------------:|:-------------------------:|:-----------:|:--------:|:----:|:---------:|:--------:|
-|                                Photon                                 |      C++ / Stackful       |  512 Bytes  |   1000   | 412K |  1.57Gb   |   100%   |
-|             [boost::asio](https://think-async.com/Asio/)              |   C++ / Async-callback    |  512 Bytes  |   1000   | 393K |  1.49Gb   |   100%   |
-|               [evpp](https://github.com/Qihoo360/evpp)                |   C++ / Async-callback    |  512 Bytes  |   1000   | 378K |  1.44Gb   |   100%   |
-|                      [tokio](https://tokio.rs/)                       |     Rust / Stackless      |  512 Bytes  |   1000   | 365K |  1.39Gb   |   100%   |
-|                                  Go                                   |     Golang / Stackful     |  512 Bytes  |   1000   | 331K |  1.26Gb   |   100%   |
-| [acl/lib_fiber](https://github.com/acl-dev/acl/tree/master/lib_fiber) |      C++ / Stackful       |  512 Bytes  |   1000   | 327K |  1.25Gb   |   100%   |
-|            [swoole](https://github.com/swoole/swoole-src)             |      PHP / Stackful       |  512 Bytes  |   1000   | 325K |  1.24Gb   |   99%    |
-|              [zab](https://github.com/Donald-Rupin/zab)               |     C++20 / Stackless     |  512 Bytes  |   1000   | 317K |  1.21Gb   |   100%   |
-|           [cocoyaxi](https://github.com/idealvin/cocoyaxi)            |      C++ / Stackful       |  512 Bytes  |   1000   | 279K |  1.06Gb   |   98%    |
-|               [libco](https://github.com/Tencent/libco)               |      C++ / Stackful       |  512 Bytes  |   1000   | 260K |  0.99Gb   |   96%    |
-|              [libgo](https://github.com/yyzybb537/libgo)              |      C++ / Stackful       |  512 Bytes  |   1000   | 258K |  0.98Gb   |   156%   |
-|             [asyncio](https://github.com/netcan/asyncio)              |     C++20 / Stackless     |  512 Bytes  |   1000   | 142K |  0.54Gb   |   99%    |
+|                                                                       | Language |  Concurrency Model  | Buffer Size | Conn Num | QPS  | Bandwidth | CPU util |
+|:---------------------------------------------------------------------:|:--------:|:-------------------:|:-----------:|:--------:|:----:|:---------:|:--------:|
+|                                Photon                                 |   C++    | Stackful Coroutine  |  512 Bytes  |   1000   | 412K |  1.57Gb   |   100%   |
+|             [boost::asio](https://think-async.com/Asio/)              |   C++    |   Async Callback    |  512 Bytes  |   1000   | 393K |  1.49Gb   |   100%   |
+|               [evpp](https://github.com/Qihoo360/evpp)                |   C++    |   Async Callback    |  512 Bytes  |   1000   | 378K |  1.44Gb   |   100%   |
+|                      [tokio](https://tokio.rs/)                       |   Rust   | Stackless Coroutine |  512 Bytes  |   1000   | 365K |  1.39Gb   |   100%   |
+|                                  Go                                   |  Golang  | Stackful Coroutine  |  512 Bytes  |   1000   | 331K |  1.26Gb   |   100%   |
+| [acl/lib_fiber](https://github.com/acl-dev/acl/tree/master/lib_fiber) |   C++    | Stackful Coroutine  |  512 Bytes  |   1000   | 327K |  1.25Gb   |   100%   |
+|            [swoole](https://github.com/swoole/swoole-src)             |   PHP    | Stackful Coroutine  |  512 Bytes  |   1000   | 325K |  1.24Gb   |   99%    |
+|              [zab](https://github.com/Donald-Rupin/zab)               |  C++20   | Stackless Coroutine |  512 Bytes  |   1000   | 317K |  1.21Gb   |   100%   |
+|           [cocoyaxi](https://github.com/idealvin/cocoyaxi)            |   C++    | Stackful Coroutine  |  512 Bytes  |   1000   | 279K |  1.06Gb   |   98%    |
+|               [libco](https://github.com/Tencent/libco)               |   C++    | Stackful Coroutine  |  512 Bytes  |   1000   | 260K |  0.99Gb   |   96%    |
+|              [libgo](https://github.com/yyzybb537/libgo)              |   C++    | Stackful Coroutine  |  512 Bytes  |   1000   | 258K |  0.98Gb   |   156%   |
+|                              TypeScript                               |  nodejs  |   Async Callback    |  512 Bytes  |   1000   | 192K |  0.75Gb   |   100%   |
+|             [asyncio](https://github.com/netcan/asyncio)              |  C++20   | Stackless Coroutine |  512 Bytes  |   1000   | 142K |  0.54Gb   |   99%    |
 
 <details><summary>Note</summary><p>
 
-- The Streaming client is to measure echo server performance when handling high throughput. We will set up 4 client processes,
+- The Streaming client is to measure echo server performance when handling high throughput. A similar scenario in the
+real world is the multiplexing technology used by RPC and HTTP 2.0. We will set up 4 client processes,
 and each of them will create only one connection. Send coroutine and recv coroutine are running their loops separately.
 - The Ping-pong client is to measure echo server performance when handling large amounts of connections.
-We will set up 10 client processes, and each of them will create 100 connections. For a single connection, it has to send before recv.
-- Server and client are all cloud VMs, 64Core 128GB, Intel Platinum CPU 2.70GHz. Kernel version is 5.15. The network bandwidth (unilateral) is 32Gb.
+We will set up 10 client processes, and each of them will create 100 connections. For a single connection, it has to send first, then receive.
+- Server and client are all cloud VMs, 64Core 128GB, Intel Platinum CPU 2.70GHz. Kernel version is 6.0.7. The network bandwidth (unilateral) is 32Gb.
 - This test was only meant to compare per-core QPS, so we limited the thread number to 1, for instance, set GOMAXPROCS=1.
+- Some libs didn't provide an easy way to configure the number of bytes we would receive in server, which was required by the Streaming test. So we only had their Ping-pong tests run.
 
 </p></details>
 

--- a/thread/thread-pool.cpp
+++ b/thread/thread-pool.cpp
@@ -117,8 +117,8 @@ namespace photon
                 pCtrl->m_mtx.lock();
             }
             pCtrl->start = &stub;
+            pCtrl->cvar.notify_all();
         }
-        pCtrl->cvar.notify_all();
         thread_yield();
         return 0;
     }


### PR DESCRIPTION
…notify done