### PR TITLE
Refactor thread_create11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /.clang_complete
 /.ccls*
 /.cquery*
+/.cache
+/compile_commands.json
 
 # alimake
 /.dep_create/

--- a/common/tuple-assistance.h
+++ b/common/tuple-assistance.h
@@ -16,22 +16,156 @@ limitations under the License.
 
 #pragma once
 
+#include <functional>
 #include <tuple>
 #include <utility>
 
 namespace tuple_assistance {
 
-#if cplusplus__ < 201700
+#if __cplusplus < 201703L
+
+namespace detail {
+
+// See https://en.cppreference.com/w/cpp/utility/functional/invoke
+// See https://en.cppreference.com/w/cpp/types/result_of
+
+template <typename...> using void_t = void;
+
+template <class>
+struct is_reference_wrapper : std::false_type {};
+
+template <class U>
+struct is_reference_wrapper<std::reference_wrapper<U>> : std::true_type {};
+
+template <class T>
+struct invoke_impl {
+    template <class F, class... Args>
+    static auto call(F&& f, Args&&... args)
+        -> decltype(std::forward<F>(f)(std::forward<Args>(args)...));
+};
+
+template <class B, class MT>
+struct invoke_impl<MT B::*> {
+    template <
+        class T, class Td = typename std::decay<T>::type,
+        class = typename std::enable_if<std::is_base_of<B, Td>::value>::type>
+    static auto get(T&& t) -> T&&;
+
+    template <
+        class T, class Td = typename std::decay<T>::type,
+        class = typename std::enable_if<is_reference_wrapper<Td>::value>::type>
+    static auto get(T&& t) -> decltype(t.get());
+
+    template <
+        class T, class Td = typename std::decay<T>::type,
+        class = typename std::enable_if<!std::is_base_of<B, Td>::value>::type,
+        class = typename std::enable_if<!is_reference_wrapper<Td>::value>::type>
+    static auto get(T&& t) -> decltype(*std::forward<T>(t));
+
+    template <
+        class T, class... Args, class MT1,
+        class = typename std::enable_if<std::is_function<MT1>::value>::type>
+    static auto call(MT1 B::*pmf, T&& t, Args&&... args)
+        -> decltype((invoke_impl::get(std::forward<T>(t)).*
+                     pmf)(std::forward<Args>(args)...));
+
+    template <class T>
+    static auto call(MT B::*pmd, T&& t)
+        -> decltype(invoke_impl::get(std::forward<T>(t)).*pmd);
+};
+
+template <class F, class... Args, class Fd = typename std::decay<F>::type>
+auto INVOKE(F&& f, Args&&... args)
+    -> decltype(invoke_impl<Fd>::call(std::forward<F>(f),
+                                      std::forward<Args>(args)...));
+
+template <typename AlwaysVoid, typename, typename...>
+struct invoke_result {};
+
+template <typename F, typename... Args>
+struct invoke_result<decltype(void(
+                         INVOKE(std::declval<F>(), std::declval<Args>()...))),
+                     F, Args...> {
+    using type = decltype(INVOKE(std::declval<F>(), std::declval<Args>()...));
+};
+
+template <typename Result, typename Ret, bool = std::is_void<Ret>::value,
+          typename = void>
+struct is_invocable_impl : std::false_type {};
+
+// Used for valid INVOKE and INVOKE<void> expressions.
+template <typename Result, typename Ret>
+struct is_invocable_impl<Result, Ret,
+                         /* is_void<_Ret> = */ true,
+                         void_t<typename Result::type>> : std::true_type {
+};
+
+template <class C, class Pointed, class T1, class... Args,
+          std::enable_if_t<std::is_function<Pointed>::value &&
+                               std::is_base_of<C, std::decay_t<T1>>::value,
+                           void*> = nullptr>
+constexpr decltype(auto) invoke_memptr(Pointed C::*f, T1&& t1, Args&&... args) {
+    return (std::forward<T1>(t1).*f)(std::forward<Args>(args)...);
+}
+
+template <class C, class Pointed, class T1, class... Args,
+          std::enable_if_t<std::is_function<Pointed>::value &&
+                               is_reference_wrapper<std::decay_t<T1>>::value,
+                           void*> = nullptr>
+constexpr decltype(auto) invoke_memptr(Pointed C::*f, T1&& t1, Args&&... args) {
+    return (t1.get().*f)(std::forward<Args>(args)...);
+}
+
+template <class C, class Pointed, class T1, class... Args,
+          std::enable_if_t<std::is_function<Pointed>::value &&
+                               !std::is_base_of<C, std::decay_t<T1>>::value &&
+                               !is_reference_wrapper<std::decay_t<T1>>::value,
+                           void*> = nullptr>
+constexpr decltype(auto) invoke_memptr(Pointed C::*f, T1&& t1, Args&&... args) {
+    return ((*std::forward<T1>(t1)).*f)(std::forward<Args>(args)...);
+}
+
+}  // namespace detail
+
+// std::invoke_result for C++14
+template <class F, class... ArgTypes>
+struct invoke_result : detail::invoke_result<void, F, ArgTypes...> {};
+
+template <class F, class... Args>
+using invoke_result_t = typename invoke_result<F, Args...>::type;
+
+// std::is_invocable for C++14
+template <typename F, typename... Args>
+struct is_invocable
+    : detail::is_invocable_impl<invoke_result<F, Args...>, void>::type {};
+
+
+// std::invoke for C++14
+template <class F, class... Args,
+          std::enable_if_t<std::is_member_pointer<std::decay_t<F>>::value,
+                           void*> = nullptr>
+constexpr invoke_result_t<F, Args...> invoke(F&& f, Args&&... args) {
+    return detail::invoke_memptr(f, std::forward<Args>(args)...);
+}
+
+template <class F, class... Args,
+          std::enable_if_t<!std::is_member_pointer<std::decay_t<F>>::value,
+                           void*> = nullptr>
+constexpr invoke_result_t<F, Args...> invoke(F&& f, Args&&... args) {
+    return std::forward<F>(f)(std::forward<Args>(args)...);
+}
+
+
 template <typename F, typename Tuple, std::size_t... I>
-constexpr static decltype(auto) apply_impl(F&& f, Tuple&& t,
+constexpr decltype(auto) apply_impl(F&& f, Tuple&& t,
                                            std::index_sequence<I...>) {
-    return std::__invoke(std::forward<F>(f), 
+    return invoke(std::forward<F>(f), 
                         std::get<I>(std::forward<Tuple>(t))...);
 }
 
 // Implementation of a simplified std::apply from C++17
 template <typename F, typename Tuple>
-constexpr static decltype(auto) apply(F&& f, Tuple&& t) {
+constexpr decltype(auto) apply(F&& f, Tuple&& t) {
     return apply_impl(
         std::forward<F>(f), std::forward<Tuple>(t),
         std::make_index_sequence<
@@ -39,8 +173,19 @@ constexpr static decltype(auto) apply(F&& f, Tuple&& t) {
 }
 
 #else
-template <typename F, typename Tuple>
-using template std::apply<F, Tuple>;
+
+using std::invoke;
+using std::apply;
+
+template <typename F, typename... Args>
+using invoke_result = std::invoke_result<F, Args...>;
+
+template <typename F, typename... Args>
+using invoke_result_t = std::invoke_result_t<F, Args...>;
+
+template <typename F, typename... Args>
+using is_invocable = std::is_invocable<F, Args...>;
+
 #endif
 
 template <typename P, size_t I, typename... Ts>

--- a/examples/simple/simple.cpp
+++ b/examples/simple/simple.cpp
@@ -78,7 +78,7 @@ int main() {
 
     // So the thread is actually a coroutine. Photon threads run on top of vcpu(native OS threads).
     // We create a Photon thread to run socket server. Pass some local variables to the new thread as arguments.
-    auto server_thread = photon::std::thread(run_socket_server, server, file, alloc, cv, mu, got_msg);
+    auto server_thread = photon::std::thread(run_socket_server, server, file, std::ref(alloc), std::ref(cv), std::ref(mu), std::ref(got_msg));
 
     // Create a watcher thread to wait the go_msg flag
     auto watcher_thread = photon::std::thread([&] {

--- a/fs/test/test_throttledfile.cpp
+++ b/fs/test/test_throttledfile.cpp
@@ -191,7 +191,7 @@ TEST(ThrottledFile, huge_scope_que) {
     using namespace fs;
     StatisticsQueue q(1024, 128);
     auto start = photon::now;
-    photon::thread_create11(enq_thread, q);
+    photon::thread_create11(enq_thread, std::ref(q));
     do { photon::thread_yield_to(nullptr); q.try_pop(); } while (q.sum()>0);
     EXPECT_EQ(0UL, q.sum());
     EXPECT_GE(photon::now - start, 4UL*1000*1000);

--- a/thread/thread11.h
+++ b/thread/thread11.h
@@ -29,7 +29,7 @@ namespace photon {
 
 template<class F, class... Args, size_t I0, size_t... I>
 void __thread_execute(std::tuple<F, Args...>& t, std::index_sequence<I0, I...>) {
-    std::__invoke(std::move(std::get<I0>(t)), std::move(std::get<I>(t))...);
+    tuple_assistance::invoke(std::move(std::get<I0>(t)), std::move(std::get<I>(t))...);
 }
 
 template <class Tuple>
@@ -44,7 +44,7 @@ void* __thread_proxy(void* vp) {
 // NOTICE: The arguments to the thread function are moved or copied by
 // value. If a reference argument needs to be passed to the thread function,
 // it has to be wrapped (e.g., with std::ref or std::cref).
-template <class F, class... Args, typename = std::enable_if_t<std::__is_invocable<F&&, Args&&...>::value>>
+template <class F, class... Args, typename = std::enable_if_t<tuple_assistance::is_invocable<F, Args...>::value>>
 thread* thread_create11(uint64_t stack_size, F&& f, Args&&... args) {
     using Gp = std::tuple<typename std::decay<F>::type, typename std::decay<Args>::type...>;
     std::unique_ptr<Gp> p(new Gp(std::forward<F>(f), std::forward<Args>(args)...));
@@ -58,7 +58,7 @@ thread* thread_create11(uint64_t stack_size, F&& f, Args&&... args) {
 // NOTICE: The arguments to the thread function are moved or copied by
 // value. If a reference argument needs to be passed to the thread function,
 // it has to be wrapped (e.g., with std::ref or std::cref).
-template <class F, class... Args, typename = std::enable_if_t<std::__is_invocable<F&&, Args&&...>::value>>
+template <class F, class... Args, typename = std::enable_if_t<tuple_assistance::is_invocable<F, Args...>::value>>
 thread* thread_create11(F&& f, Args&&... args) {
     return thread_create11(DEFAULT_STACK_SIZE, std::forward<F>(f), std::forward<Args>(args)...);
 }


### PR DESCRIPTION
1. https://github.com/alibaba/PhotonLibOS/issues/98

2. 
    ```cpp
    // NOTICE: The arguments to the thread function are moved or copied by
    // value. If a reference argument needs to be passed to the thread function,
    // it has to be wrapped (e.g., with std::ref or std::cref).
    ```
    之前的设计，不满足上述注释，`tuple`的类型不对，应该对`Args`进行`decay_t`
    有一个测试也有点小问题

- 本次重构参考`clang`的`std::thread`的实现，`gcc`的实现方式为虚函数，`clang`为`template`，个人认为`clang`实现更优，欢迎提出不同的意见！
- 由于没有`clang-format`，代码风格不是很统一，见谅
