### PR TITLE
Fix compile fail

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -109,9 +109,7 @@ public:
         return length() >= len &&
             memcmp(data(), x.data(), len) == 0;
     }
-    bool istarts_with(estring_view x) {
-        return strncasecmp(data(), x.data(), x.size()) == 0;
-    }
+
     bool ends_with(estring_view x)
     {
         auto len = x.size();
@@ -119,6 +117,11 @@ public:
             memcmp(&*end() - len, x.data(), len) == 0;
     }
 #endif
+
+    bool istarts_with(estring_view x) {
+        return strncasecmp(data(), x.data(), x.size()) == 0;
+    }
+
     template<typename Separator>
     struct _split
     {

--- a/fs/filecopy.cpp
+++ b/fs/filecopy.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "filecopy.h"
 
+#include <cstdlib>
 #include <stddef.h>
 #include <sys/stat.h>
 

--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <unistd.h>
 
 #include <thread>
+#include <string>
 
 #include <photon/common/alog.h>
 #include <photon/io/signal.h>

--- a/thread/test/test.cpp
+++ b/thread/test/test.cpp
@@ -207,7 +207,7 @@ thread_local photon::mutex aMutex;
 void* thread_test_function(void* arg)
 {
     LOG_DEBUG(VALUE(CURRENT), " before lock");
-    scoped_lock aLock(aMutex);
+    photon::scoped_lock aLock(aMutex);
     LOG_DEBUG(VALUE(CURRENT), " after lock");
 
     uint32_t* result = (uint32_t*)arg;


### PR DESCRIPTION
- 将`cmake`中的`CMAKE_CXX_STANDARD`改为17和20，将会编译失败
- 本条PR修复`CMAKE_CXX_STANDARD`为17和20编译时的报错