### PR TITLE
Fix and improves

### DIFF
--- a/common/executor/executor.h
+++ b/common/executor/executor.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <photon/common/callback.h>
 #include <photon/common/executor/stdlock.h>
+#include <photon/photon.h>
 
 #include <atomic>
 #include <type_traits>
@@ -26,14 +27,12 @@ namespace photon {
 
 class ExecutorImpl;
 
-ExecutorImpl *_new_executor();
-void _delete_executor(ExecutorImpl *e);
-void _issue(ExecutorImpl *e, Delegate<void> cb);
-
 class Executor {
 public:
-    ExecutorImpl *e = _new_executor();
-    ~Executor() { _delete_executor(e); }
+    ExecutorImpl *e;
+    Executor(int init_ev = photon::INIT_EVENT_DEFAULT,
+             int init_io = photon::INIT_IO_DEFAULT);
+    ~Executor();
 
     template <
         typename Context = StdContext, typename Func,
@@ -68,8 +67,8 @@ public:
     // The task object will be delete after work done
     template <typename Context = StdContext, typename Func>
     void async_perform(Func *task) {
-        void (*func)(void*);
-        func = [](void* task_) {
+        void (*func)(void *);
+        func = [](void *task_) {
             using Task = decltype(task);
             auto t = (Task)task_;
             (*t)();
@@ -78,8 +77,14 @@ public:
         _issue(e, {func, task});
     }
 
+    static Executor* export_as_executor();
+
 protected:
-    static constexpr int64_t kCondWaitMaxTime = 1000L * 1000;
+    static constexpr int64_t kCondWaitMaxTime = 100L * 1000;
+
+    struct create_on_current_vcpu {};
+
+    Executor(create_on_current_vcpu);
 
     template <typename Context>
     struct AsyncOp {
@@ -107,6 +112,8 @@ protected:
             wait_for_completion();
         }
     };
+
+    static void _issue(ExecutorImpl *e, Delegate<void> cb);
 };
 
 }  // namespace photon

--- a/common/executor/test/test_export_as_executor.cpp
+++ b/common/executor/test/test_export_as_executor.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <photon/common/executor/executor.h>
+#include <photon/common/utility.h>
+#include <photon/common/alog.h>
+#include <photon/photon.h>
+#include <photon/thread/thread.h>
+
+#include <thread>
+
+TEST(enter_as_executor, test) {
+    // set global default logger output to null
+    set_log_output(log_output_null);
+
+    // create own logger
+    ALogLogger logger;
+    // set log_output to stdout, log level as info
+    logger.log_output = log_output_stdout;
+    logger.log_level = ALOG_INFO;
+
+    photon::init();
+    DEFER(photon::fini());
+    // do some ready work in this photon environment
+    auto vcpu = photon::get_vcpu();
+    auto e = photon::Executor::export_as_executor();
+    DEFER(delete e);
+
+    std::thread([&logger, e, vcpu] {
+        e->perform([&logger, vcpu] {
+            logger << LOG_INFO("Hello from a normal thread");
+            auto cvcpu = photon::get_vcpu();
+            logger << LOG_INFO("executor at `, current on `, `", vcpu, cvcpu,
+                               vcpu == cvcpu ? "EQ" : "NEQ");
+        });
+    }).detach();
+
+    photon::thread_usleep(1UL * 1024 * 1024);
+}

--- a/common/expirecontainer.h
+++ b/common/expirecontainer.h
@@ -80,7 +80,7 @@ protected:
     intrusive_list<Item> _list;
     uint64_t _expiration;
     photon::Timer _timer;
-    photon::spinlock _lock;
+    photon::spinlock _lock; // protect _list/_set operations
 
     using ItemPtr = Item*;
     struct ItemHash {
@@ -177,6 +177,7 @@ public:
     template <typename... Gs>
     iterator insert(const InterfaceKey& key, Gs&&... xs) {
         auto item = new Item(key, std::forward<Gs>(xs)...);
+        SCOPED_LOCK(_lock);
         auto pr = Base::insert(item);
         if (!pr.second) {
             delete item;

--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -531,6 +531,10 @@ namespace common {
  * photon thread when queue is empty, and once it got object by recv, it will
  * trying using `thread_yield` instead of semaphore, to get better performance
  * and load balancing.
+ * Watch out that `recv` should run in photon environment (because it has to)
+ * use photon semaphore to be notified that new item has sended. `send` could
+ * running in photon or std::thread environment (needs to set template `Pause` as
+ * `ThreadPause`).
  *
  * @tparam QueueType shoulde be one of LockfreeMPMCRingQueue,
  * LockfreeBatchMPMCRingQueue, or LockfreeSPSCRingQueue, with their own template
@@ -541,7 +545,8 @@ class RingChannel : public QueueType {
 protected:
     photon::semaphore queue_sem;
     std::atomic<uint64_t> idler{0};
-    static constexpr uint64_t BUSY_YIELD_TIMEOUT = 1024;
+    uint64_t m_busy_yield_turn;
+    uint64_t m_busy_yield_timeout;
 
     using T = decltype(std::declval<QueueType>().recv());
 
@@ -553,21 +558,36 @@ public:
     using QueueType::read_available;
     using QueueType::write_available;
 
+    /**
+     * @brief Construct a new Ring Channel object
+     *
+     * @param busy_yield_timeout setting yield timeout, default is template
+     * parameter DEFAULT_BUSY_YIELD_TIMEOUT. Ring Channel will try busy yield
+     * in `busy_yield_timeout` usecs.
+     */
+    RingChannel(uint64_t busy_yield_turn = 64,
+                uint64_t busy_yield_timeout = 1024)
+        : m_busy_yield_turn(busy_yield_turn),
+          m_busy_yield_timeout(busy_yield_timeout) {}
+
+    template <typename Pause = ThreadPause>
     void send(const T& x) {
         while (!push(x)) {
-            if (!full()) photon::thread_yield();
+            if (!full()) Pause::pause();
         }
-        uint64_t idle = idler.exchange(0, std::memory_order_acq_rel);
-        queue_sem.signal(idle);
+        queue_sem.signal(idler.load(std::memory_order_acquire));
     }
     T recv() {
         T x;
-        Timeout yield_timeout(BUSY_YIELD_TIMEOUT);
+        Timeout yield_timeout(m_busy_yield_timeout);
+        int yield_turn = m_busy_yield_turn;
+        idler.fetch_add(1, std::memory_order_acq_rel);
+        DEFER(idler.fetch_sub(1, std::memory_order_acq_rel));
         while (!pop(x)) {
-            if (photon::now < yield_timeout.expire()) {
+            if (yield_turn > 0 && photon::now < yield_timeout.expire()) {
+                yield_turn--;
                 photon::thread_yield();
             } else {
-                idler.fetch_add(1, std::memory_order_acq_rel);
                 queue_sem.wait(1);
             }
         }

--- a/common/metric-meter/metrics.h
+++ b/common/metric-meter/metrics.h
@@ -59,9 +59,9 @@ public:
         if (now - time > m_interval * 2) {
             reset();
         } else if (now - time > m_interval) {
-            sum = photon::sat_sub(sum, sum * (now - time) / m_interval);
-            cnt = photon::sat_sub(cnt, cnt * (now - time) / m_interval);
-            time = now;
+            sum = photon::sat_sub(sum, sum * (now - time - m_interval) / m_interval);
+            cnt = photon::sat_sub(cnt, cnt * (now - time - m_interval) / m_interval);
+            time = now - m_interval;
         }
     }
     void put(int64_t val) {
@@ -95,8 +95,8 @@ public:
             reset();
         } else if (now - time > m_interval) {
             counter =
-                photon::sat_sub(counter, counter * (now - time) / m_interval);
-            time = now;
+                photon::sat_sub(counter, counter * (now - time - m_interval) / m_interval);
+            time = now - m_interval;
         }
     }
     void put(int64_t val = 1) {

--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -54,7 +54,7 @@ public:
 
     template <typename T>
     ISocketStream* dial(const T& x, uint64_t timeout = -1UL) {
-        return dial(x.host(), x.port(), x.secure(), timeout);
+        return dial(x.host_no_port(), x.port(), x.secure(), timeout);
     }
 };
 

--- a/net/http/cookie_jar.cpp
+++ b/net/http/cookie_jar.cpp
@@ -118,8 +118,9 @@ public:
         return m_cookie[host]->get_cookies_from_headers(message);
     }
     int set_cookies_to_headers(Request* request) override {
-        if (request->host().empty()) return -1;
-        return m_cookie[request->host()]->set_cookies_to_headers(request);
+        auto host = request->host();
+        if (host.empty()) return -1;
+        return m_cookie[host]->set_cookies_to_headers(request);
     }
 };
 

--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -309,7 +309,7 @@ int Request::reset(Verb v, std::string_view url, bool enable_proxy) {
     if ((size_t)m_buf_capacity <= u.target().size() + 21 + verbstr[v].size())
         LOG_ERROR_RETURN(ENOBUFS, -1, "out of buffer");
 
-    LOG_DEBUG("requst reset ", VALUE(u.host()), VALUE(u.host_port()), VALUE(enable_proxy));
+    LOG_DEBUG("requst reset ", VALUE(u.host()), VALUE(enable_proxy));
 
     Message::reset();
     make_request_line(v, u, enable_proxy);

--- a/net/http/message.h
+++ b/net/http/message.h
@@ -176,7 +176,17 @@ public:
     uint16_t port() const {
         return m_port;
     }
+    std::string_view host_no_port() const {
+        // only contains host, without port
+        auto tmp = headers["Host"];
+        auto pos = tmp.find(":");
+        if (pos == std::string_view::npos) {
+            return tmp;
+        }
+        return tmp.substr(0, pos);
+    }
     std::string_view host() const {
+        // the original "Host" in header
         return headers["Host"];
     }
     std::string_view abs_path() const {

--- a/net/http/test/CMakeLists.txt
+++ b/net/http/test/CMakeLists.txt
@@ -11,10 +11,10 @@ target_link_libraries(server_perf PRIVATE photon_shared ${testing_libs})
 add_executable(pure_libcurl pure_libcurl.cpp)
 target_link_libraries(pure_libcurl PRIVATE photon_shared ${testing_libs})
 
-#add_executable(client_function_test client_function_test.cpp)
-#target_link_libraries(client_function_test PRIVATE photon_shared ${testing_libs})
-#add_test(NAME client_function_test COMMAND $<TARGET_FILE:client_function_test>)
-#
+add_executable(client_function_test client_function_test.cpp)
+target_link_libraries(client_function_test PRIVATE photon_shared ${testing_libs})
+add_test(NAME client_function_test COMMAND $<TARGET_FILE:client_function_test>)
+
 add_executable(server_function_test server_function_test.cpp)
 target_link_libraries(server_function_test PRIVATE photon_shared ${testing_libs})
 add_test(NAME server_function_test COMMAND $<TARGET_FILE:server_function_test>)

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -535,11 +535,13 @@ int main(int argc, char** arg) {
     if (photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE))
         return -1;
     DEFER(photon::fini());
+#ifdef __linux__
     if (et_poller_init() < 0) {
         LOG_ERROR("et_poller_init failed");
         exit(EAGAIN);
     }
     DEFER(et_poller_fini());
+#endif
     set_log_output_level(ALOG_DEBUG);
     ::testing::InitGoogleTest(&argc, arg);
     LOG_DEBUG("test result:`", RUN_ALL_TESTS());

--- a/net/http/test/headers_test.cpp
+++ b/net/http/test/headers_test.cpp
@@ -183,12 +183,13 @@ TEST(headers, resp_header) {
     } while (!exceed_stream.done());
 }
 TEST(headers, url) {
-    RequestHeadersStored<> headers(Verb::UNKNOWN, "https://domain.com/dir1/dir2/file?key1=value1&key2=value2");
-    LOG_DEBUG(VALUE(headers.target()));
-    LOG_DEBUG(VALUE(headers.host()));
-    LOG_DEBUG(VALUE(headers.secure()));
-    LOG_DEBUG(VALUE(headers.query()));
-    LOG_DEBUG(VALUE(headers.port()));
+    RequestHeadersStored<> headers(Verb::UNKNOWN, "https://domain.com:8888/dir1/dir2/file?key1=value1&key2=value2");
+    EXPECT_EQ(true, headers.target() =="/dir1/dir2/file?key1=value1&key2=value2");
+    EXPECT_EQ(true, headers.host() == "domain.com:8888");
+    EXPECT_EQ(headers.port(), 8888);
+    EXPECT_EQ(true, headers.host_no_port() == "domain.com");
+    EXPECT_EQ(headers.secure(), 1);
+    EXPECT_EQ(true, headers.query() == "key1=value1&key2=value2");
     RequestHeadersStored<> new_headers(Verb::UNKNOWN, "");
     if (headers.secure())
         new_headers.headers.insert("Referer", http_url_scheme);
@@ -198,6 +199,7 @@ TEST(headers, url) {
     new_headers.headers.value_append(headers.target());
     auto Referer_value = new_headers.headers["Referer"];
     LOG_DEBUG(VALUE(Referer_value));
+    EXPECT_EQ(true, Referer_value == "http://domain.com:8888/dir1/dir2/file?key1=value1&key2=value2");
 }
 
 TEST(ReqHeaders, redirect) {

--- a/net/http/url.h
+++ b/net/http/url.h
@@ -73,6 +73,7 @@ public:
     }
 
     std::string_view host() const { return m_url | m_host; }
+    std::string_view host_no_port() const { return host(); }
     std::string_view host_port() const { return m_url | m_host_port;}
     uint16_t port() const { return m_port; }
     bool secure() const { return m_secure; }

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -111,6 +111,30 @@ namespace photon
         }
     };
 
+    void* default_photon_thread_stack_alloc(void*, size_t stack_size) {
+        char* ptr = nullptr;
+        int err = posix_memalign((void**)&ptr, PAGE_SIZE, stack_size);
+        if (unlikely(err))
+            LOG_ERROR_RETURN(err, nullptr, "Failed to allocate photon stack! ",
+                             ERRNO(err));
+#if defined(__linux__)
+        madvise(ptr, stack_size, MADV_NOHUGEPAGE);
+#endif
+        return ptr;
+    }
+
+    void default_photon_thread_stack_dealloc(void*, void* ptr, size_t size) {
+#ifndef __aarch64__
+        madvise(ptr, size, MADV_DONTNEED);
+#endif
+        free(ptr);
+    }
+
+    Delegate<void*, size_t> photon_thread_alloc(
+        &default_photon_thread_stack_alloc, nullptr);
+    Delegate<void, void*, size_t> photon_thread_dealloc(
+        &default_photon_thread_stack_dealloc, nullptr);
+
     struct vcpu_t;
     struct thread;
     class Stack
@@ -257,11 +281,9 @@ namespace photon
         }
         void dispose() {
             assert(state == states::DONE);
-            register auto b = buf; //store in register to prevent from being deleted by madvise
-#ifndef __aarch64__
-            madvise(b, stack_size, MADV_DONTNEED);
-#endif
-            free(b);
+            // `buf` and `stack_size` will always store on register
+            // when calling deallocating.
+            photon_thread_dealloc(buf, stack_size);
         }
     };
 
@@ -816,13 +838,7 @@ R"(
             LOG_ERROR_RETURN(ENOSYS, nullptr, "Photon not initialized in this vCPU (OS thread)");
         size_t randomizer = (rand() % 32) * (1024 + 8);
         stack_size = align_up(randomizer + stack_size + sizeof(thread), PAGE_SIZE);
-        char* ptr = nullptr;
-        int err = posix_memalign((void**)&ptr, PAGE_SIZE, stack_size);
-        if (unlikely(err))
-            LOG_ERROR_RETURN(err, nullptr, "Failed to allocate photon stack! ", ERRNO(err));
-#if defined(__linux__)
-        madvise(ptr, stack_size, MADV_NOHUGEPAGE);
-#endif
+        char* ptr = (char*)photon_thread_alloc(stack_size);
         auto p = ptr + stack_size - sizeof(thread) - randomizer;
         (uint64_t&)p &= ~63;
         auto th = new (p) thread;

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -32,8 +32,6 @@ namespace photon
     int wait_all();
     int timestamp_updater_init();
     int timestamp_updater_fini();
-    void* stackful_malloc(size_t size);
-    void stackful_free(void* ptr);
 
 
     struct thread;
@@ -432,6 +430,23 @@ namespace photon
 
     bool is_master_event_engine_default();
     void reset_master_event_engine_default();
+
+    // alloc space on rear end of current thread stack,
+    // helps allocating when using hybrid C++20 style coroutine
+    void* stackful_malloc(size_t size);
+    void stackful_free(void* ptr);
+
+    // Set photon allocator/deallocator for photon thread stack
+    // this is a hook for thread allocation, both alloc and dealloc
+    // helps user to do more works like mark GC while allocating
+    void* default_photon_thread_stack_alloc(void*, size_t stack_size);
+    void default_photon_thread_stack_dealloc(void*, void* stack_ptr,
+                                             size_t stack_size);
+    void set_photon_thread_stack_allocator(
+        Delegate<void*, size_t> photon_thread_alloc = {
+            &default_photon_thread_stack_alloc, nullptr},
+        Delegate<void, void*, size_t> photon_thread_dealloc = {
+            &default_photon_thread_stack_dealloc, nullptr});
 
     // Saturating addition, primarily for timeout caculation
     __attribute__((always_inline)) inline uint64_t sat_add(uint64_t x,

--- a/thread/workerpool.cpp
+++ b/thread/workerpool.cpp
@@ -66,7 +66,7 @@ public:
     }
 
     void enqueue(Delegate<void> call) {
-        ring.send(call);
+        ring.send<PhotonPause>(call);
     }
 
     void do_call(Delegate<void> call) {


### PR DESCRIPTION
We have dig in PhotonLibOS, and now provides bug fix and features

Fix:
* `ExpireContainer<T>` insert should keep in protect by lock, in case of using in multi-vcpu condition.
* `libaio_adaptor` may stuck if `io_submit` failed, but no more libaio actions submitted.

Improves:
* `RingChannel` now has better waiting strategy, able to reduce send-recv latency.
  * `Executor`, `WorkPool` are now using `RingChannel`
* `URL` add new method, able to get host path without port part
* Hook of photon thread stack allocation, to help using custom allocator
  * Some GC framework needs to mark memory usage, here is a way to add such kind of mark. #150 