### PR TITLE
Fix HTTP header parse for space

### DIFF
--- a/net/http/headers.cpp
+++ b/net/http/headers.cpp
@@ -170,7 +170,8 @@ int HeadersBase::parse() {
     Parser p({m_buf, m_buf_size});
     while(p[0] != '\r') {
         auto k = p.extract_until_char(':');
-        p.skip_string(": ");
+        p.skip_chars(':');
+        p.skip_chars(' ', true);
         auto v = p.extract_until_char('\r');
         p.skip_string("\r\n");
         if (kv_add({k, v}) == nullptr)

--- a/net/http/parser.h
+++ b/net/http/parser.h
@@ -32,9 +32,13 @@ public:
     {
         if (estring_view(_ptr, _end - _ptr).starts_with(sv)) _ptr += sv.length();
     }
-    void skip_chars(char c)
+    void skip_chars(char c, bool continuously = false)
     {
-        if (*_ptr == c) _ptr++;
+        while (*_ptr == c) {
+            _ptr++;
+            if (!continuously)
+                return;
+        }
     }
     void skip_until_string(const std::string& s)
     {


### PR DESCRIPTION
HTTP protocol said that the spaces before each header's value should be ignored.

Even though most HTTP client will format the header as `KEY: VALUE`, but there are still some clients who didn't add the  space. 

The previous implementation has a bug when processing `KEY:VALUE`.