### PR TITLE
compile apply error usin gcc 11.3.2 or clang 14 on ubuntu 22

### DIFF
--- a/common/tuple-assistance.h
+++ b/common/tuple-assistance.h
@@ -91,8 +91,15 @@ constexpr inline decltype(auto) apply(F&& f, Tuple&& t) {
 }
 
 #else
-template <typename F, typename Tuple>
-using template std::apply<F, Tuple>;
+// template <typename F, typename Tuple>
+// using template std::apply<F, Tuple>;
+ 
+
+template <typename F, typename Tuple> 
+constexpr  decltype(auto) apply(F && f, Tuple && t){
+    return std::apply(std::forward<F>(f), std::forward<Tuple>(t)); 
+}
+
 #endif
 
 template <typename P, size_t I, typename... Ts>

--- a/thread/thread11.h
+++ b/thread/thread11.h
@@ -25,10 +25,11 @@ limitations under the License.
 #include <photon/common/callback.h>
 
 namespace photon {
-    template<typename Pair>
+    template<  typename F, typename SavedArgs>
     static void* __stub11(void*) {
+        using Pair = std::pair<F, SavedArgs>;
         auto p = thread_reserved_space<Pair>(CURRENT);
-        tuple_assistance::apply(p->first, p->second);
+        tuple_assistance::apply(p->first, SavedArgs{p->second});
         return nullptr;
     }
 
@@ -39,7 +40,7 @@ namespace photon {
     thread* __thread_create11(uint64_t stack_size, F&& f, ARGUMENTS&&...args) {
         using Pair = std::pair<F, SavedArgs>;
         static_assert(sizeof(Pair) < UINT16_MAX, "...");
-        auto th = thread_create(&__stub11<Pair>, nullptr, stack_size, sizeof(Pair));
+        auto th = thread_create(&__stub11<F, SavedArgs>, nullptr, stack_size, sizeof(Pair));
         auto p  = thread_reserved_space<Pair>(th);
         new (p) Pair{std::forward<F>(f), SavedArgs{std::forward<ARGUMENTS>(args)...}};
         return th;

--- a/thread/thread11.h
+++ b/thread/thread11.h
@@ -29,7 +29,7 @@ namespace photon {
     static void* __stub11(void*) {
         using Pair = std::pair<F, SavedArgs>;
         auto p = thread_reserved_space<Pair>(CURRENT);
-        tuple_assistance::apply(p->first, SavedArgs{p->second});
+        tuple_assistance::apply(p->first, SavedArgs{std::move(p->second)});
         return nullptr;
     }
 
@@ -49,9 +49,10 @@ namespace photon {
     template<typename FUNCTOR, typename...ARGUMENTS>
     struct FunctorWrapper {
         typename std::decay<FUNCTOR>::type _obj;
+        using result_type = typename  std::result_of<FUNCTOR(ARGUMENTS...)>::type; 
         __attribute__((always_inline))
-        void operator()(ARGUMENTS&&...args) {
-            _obj(std::forward<ARGUMENTS>(args)...);
+        result_type operator()(ARGUMENTS&&...args) {
+            return   _obj(std::forward<ARGUMENTS>(args)...);
         }
     };
 


### PR DESCRIPTION
the lambda form when using thread_create11 can't be compiled using gcc : 

thread_create11([&](int, double) { return -1; }, 10, 3.1415926);

In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:37:
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/tuple:1858:14: error: no matching function for call to '__invoke'
      return std::__invoke(std::forward<_Fn>(__f),
             ^~~~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/tuple:1869:19: note: in instantiation of function template specialization 'std::__apply_impl<photon::FunctorWrapper<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double> &, std::tuple<int, double> &, 0UL, 1UL>' requested here
      return std::__apply_impl(std::forward<_Fn>(__f),
                  ^
/home/arthur/work/photondemo/opt/PhotonLibOS/include/photon/common/tuple-assistance.h:100:17: note: in instantiation of function template specialization 'std::apply<photon::FunctorWrapper<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double> &, std::tuple<int, double> &>' requested here
    return std::apply(std::forward<F>(f), std::forward<Tuple>(t));
                ^
/home/arthur/work/photondemo/opt/PhotonLibOS/include/photon/thread/thread11.h:33:27: note: in instantiation of function template specialization 'tuple_assistance::apply<photon::FunctorWrapper<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double> &, std::tuple<int, double> &>' requested here
        tuple_assistance::apply(p->first, p->second);//compile failed on gcc 11/clang 14
                          ^
/home/arthur/work/photondemo/opt/PhotonLibOS/include/photon/thread/thread11.h:45:34: note: in instantiation of function template specialization 'photon::__stub11<photon::FunctorWrapper<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double>, std::tuple<int, double>>' requested here
        auto th = thread_create(&__stub11<F, SavedArgs>, nullptr, stack_size, sizeof(Pair));
                                 ^
/home/arthur/work/photondemo/opt/PhotonLibOS/include/photon/thread/thread11.h:111:16: note: in instantiation of function template specialization 'photon::__thread_create11<photon::FunctorWrapper<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double>, std::tuple<int, double>, int, double>' requested here
        return __thread_create11<Wrapper, SavedArgs, ARGUMENTS...>(
               ^
/home/arthur/work/photondemo/opt/PhotonLibOS/include/photon/thread/thread11.h:119:16: note: in instantiation of function template specialization 'photon::thread_create11<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double>' requested here
        return thread_create11<FUNCTOR, ARGUMENTS...>(DEFAULT_STACK_SIZE,
               ^
/home/arthur/work/photondemo/samples/testthrd.cpp:77:5: note: in instantiation of function template specialization 'photon::thread_create11<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double>' requested here
    thread_create11([&](int, double) { return -1; }, 10, 3.1415926);
    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:90:5: note: candidate template ignored: substitution failure [with _Callable = photon::FunctorWrapper<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double> &, _Args = <int &, double &>]: no type named 'type' in 'std::__invoke_result<photon::FunctorWrapper<(lambda at /home/arthur/work/photondemo/samples/testthrd.cpp:77:21), int, double> &, int &, double &>'
    __invoke(_Callable&& __fn, _Args&&... __args)
