### PR TITLE
fix compile in c++17 onward

### DIFF
--- a/common/tuple-assistance.h
+++ b/common/tuple-assistance.h
@@ -91,8 +91,7 @@ constexpr inline decltype(auto) apply(F&& f, Tuple&& t) {
 }
 
 #else
-template <typename F, typename Tuple>
-using template std::apply<F, Tuple>;
+using std::apply;
 #endif
 
 template <typename P, size_t I, typename... Ts>

--- a/thread/thread11.h
+++ b/thread/thread11.h
@@ -28,7 +28,7 @@ namespace photon {
     template<typename Pair>
     static void* __stub11(void*) {
         auto p = thread_reserved_space<Pair>(CURRENT);
-        tuple_assistance::apply(p->first, p->second);
+        tuple_assistance::apply(std::move(p->first), std::move(p->second));
         return nullptr;
     }
 


### PR DESCRIPTION
Fix `thread_create11` when using photon with C++17 standard, delivering parameters by move.