### PR TITLE
mutex lock add retries

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1453,8 +1453,11 @@ R"(
     }
     int mutex::lock(uint64_t timeout)
     {
-        if (try_lock() == 0)
-            return 0;
+        for (int tries = 0; tries < MaxTries; ++tries) {
+            if (try_lock() == 0)
+                return 0;
+            thread_yield();
+        }
         splock.lock();
         if (try_lock() == 0) {
             splock.unlock();

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -235,6 +235,7 @@ namespace photon
         }
 
     protected:
+        static constexpr const int MaxTries = 100;
         std::atomic<thread*> owner{nullptr};
         spinlock splock;
     };


### PR DESCRIPTION
经过验证：给mutex增加重试后，对多线程程序的整体性能有帮助。

使用rocksdb的db_bench做测试，关闭compaction，数据全在block cache(内存)，启动8个线程做读IO测试。通过观察OPS，比较跨线程锁的开销。

原生多线程版本：OPS = 3.7 Million ， CPU 800%
未改动的Photon协程版本，启动8个thread，配8个vcpu： OPS = 2.9 Million  ，CPU 720%

给mutex增加重试后： OPS = 3.6 Millon，CPU 800%


TODO:
1. 选取合理的retry number。在单线程和多线程程序做一些取舍。会在单线程多协程的场景稍微增加一些开销；而在多线程的场景下，相当于是用富余的CPU计算换取更高的cacheline命中率，降低锁延时。
2. 将原先代码里的一些spinlock换成新的mutex。如thread_pool里面的，当时也是为了多线程优化改的spinlock