### PR TITLE
Update iouring-wrapper.cpp

### DIFF
--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -465,12 +465,13 @@ private:
 
     static void set_submit_wait_function() {
         // The submit_and_wait_timeout API is more efficient than setting up a timer and waiting for it.
-        // But there is a kernel bug before 5.17, so choose appropriate function here.
+        // But there is a kernel bug before 5.15, so choose appropriate function here.
         // See https://git.kernel.dk/cgit/linux-block/commit/?h=io_uring-5.17&id=228339662b398a59b3560cd571deb8b25b253c7e
+        // and https://www.spinics.net/lists/stable/msg620268.html
         if (m_submit_wait_func)
             return;
         int result;
-        if (kernel_version_compare("5.17", result) == 0 && result >= 0) {
+        if (kernel_version_compare("5.15", result) == 0 && result >= 0) {
             m_submit_wait_func = submit_wait_by_api;
         } else {
             m_submit_wait_func = submit_wait_by_timer;


### PR DESCRIPTION
The io_uring wait timeout bug has been backport to kernel 5.15 in earlier 2023