### PR TITLE
aarch64 cycle count with frequency

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -973,8 +973,11 @@ R"(
         return (hi << 12) | (low >> 20);
     #elif defined(__aarch64__)
         uint64_t val;
+        uint64_t freq;
         asm volatile("mrs %0, cntvct_el0" : "=r" (val));
-        return (uint32_t)(val >> 20);
+        asm volatile("mrs %0, cntfrq_el0" : "=r" (freq));
+        // cycles * microsec_per_sec / frequency = microsec
+        return (val << 10) / freq;
     #endif
     }
     static uint32_t last_tsc = 0;


### PR DESCRIPTION
AArch64 CPU may using off-core timer as source of `cntvct_el0` registers, so the counter may not fit CPU working frequency. The timer frequency on Apple M1 is 24MHz, much lower than CPU working frequency, that may make `photon::now` timestamp update about every 40ms, may makes photon thread sleeps longer than it should be.

The fix uses `cntvct_el0` as a fast check whether should update time stamp, calculate with `cntfrq_el0` as timer frequency, make it able to update timestamp as it designed to.