### PR TITLE
Fix libcurl comaptible

### DIFF
--- a/net/curl.cpp
+++ b/net/curl.cpp
@@ -173,7 +173,8 @@ protected:
         for (int i = 0; i < cnt; i++) {
             int fd = cbs[i] >> 2;
             int ev = cbs[i] & 0b11;
-            if (fd != CURL_SOCKET_BAD && ev != 0) do_action(fd, ev);
+            if (fd != CURL_SOCKET_BAD && ev != 0)
+                photon::thread_create11(&do_action, fd, ev);
         }
         return 0;
     }


### PR DESCRIPTION
In some version of libcurl, call `curl_multi_socket_action` during callbacks will be checked and prevented by libcurl recursive check, and got a failure that not expected.

Make calling `do_action` asynchronous, make it be called from photon thread stub, will never cause this kind of situation.