### PR TITLE
add a new function recv_at_least() to socket stream

### DIFF
--- a/net/basic_socket.cpp
+++ b/net/basic_socket.cpp
@@ -266,6 +266,10 @@ ssize_t ISocketStream::recv_mutable(struct iovec *iov, int iovcnt, int flags) {
     return recv(iov, iovcnt, flags);
 }
 
+ssize_t ISocketStream::send_mutable(struct iovec *iov, int iovcnt, int flags) {
+    return send(iov, iovcnt, flags);
+}
+
 ssize_t ISocketStream::recv_at_least(void* buf, size_t count, size_t least, int flags) {
     size_t n = 0;
     if (least > count) least = count;

--- a/net/basic_socket.cpp
+++ b/net/basic_socket.cpp
@@ -262,6 +262,23 @@ bool ISocketStream::skip_read(size_t count) {
     return true;
 }
 
+ssize_t ISocketStream::recv_mutable(struct iovec *iov, int iovcnt, int flags) {
+    return recv(iov, iovcnt, flags);
+}
+
+ssize_t ISocketStream::recv_at_least(void* buf, size_t count, size_t least, int flags) {
+    size_t n = 0;
+    if (least > count) least = count;
+    while (true) {
+        ssize_t ret = this->recv(buf, count, flags);
+        if (ret < 0) return ret;
+        if (ret == 0) break;    // EOF
+        if ((n += ret) >= least) break;
+        count -= ret;
+    }
+    return n;
+}
+
 int do_get_name(int fd, Getter getter, EndPoint& addr) {
     sockaddr_storage storage;
     socklen_t len = storage.get_max_socklen();

--- a/net/socket.h
+++ b/net/socket.h
@@ -230,6 +230,7 @@ namespace net {
         // may block once at most, when there's no free space in the socket's internal buffer;
         virtual ssize_t send(const void *buf, size_t count, int flags = 0) = 0;
         virtual ssize_t send(const struct iovec *iov, int iovcnt, int flags = 0) = 0;
+        virtual ssize_t send_mutable(struct iovec *iov, int iovcnt, int flags = 0);
 
         virtual ssize_t sendfile(int in_fd, off_t offset, size_t count) = 0;
     };

--- a/net/socket.h
+++ b/net/socket.h
@@ -216,23 +216,10 @@ namespace net {
         // may block once at most, when there's no data yet in the socket;
         virtual ssize_t recv(void *buf, size_t count, int flags = 0) = 0;
         virtual ssize_t recv(const struct iovec *iov, int iovcnt, int flags = 0) = 0;
-        virtual ssize_t recv_mutable(struct iovec *iov, int iovcnt, int flags = 0) {
-            return recv(iov, iovcnt, flags);
-        }
+        virtual ssize_t recv_mutable(struct iovec *iov, int iovcnt, int flags = 0);
 
         // recv at `least` bytes to buffer (`buf`, `count`)
-        ssize_t recv_at_least(void* buf, size_t count, size_t least, int flags = 0) {
-            size_t n = 0;
-            if (least > count) least = count;
-            while (true) {
-                ssize_t ret = this->recv(buf, count, flags);
-                if (ret < 0) return ret;
-                if (ret == 0) break;    // EOF
-                if ((n += ret) >= least) break;
-                count -= ret;
-            }
-            return n;
-        }
+        ssize_t recv_at_least(void* buf, size_t count, size_t least, int flags = 0);
 
         // read count bytes and drop them
         // return true/false for success/failure

--- a/net/socket.h
+++ b/net/socket.h
@@ -216,10 +216,10 @@ namespace net {
         // may block once at most, when there's no data yet in the socket;
         virtual ssize_t recv(void *buf, size_t count, int flags = 0) = 0;
         virtual ssize_t recv(const struct iovec *iov, int iovcnt, int flags = 0) = 0;
-        virtual ssize_t recv_mutable(struct iovec *iov, int iovcnt, int flags = 0);
 
         // recv at `least` bytes to buffer (`buf`, `count`)
         ssize_t recv_at_least(void* buf, size_t count, size_t least, int flags = 0);
+        ssize_t recv_at_least_mutable(struct iovec *iov, int iovcnt, size_t least, int flags = 0);
 
         // read count bytes and drop them
         // return true/false for success/failure
@@ -230,7 +230,6 @@ namespace net {
         // may block once at most, when there's no free space in the socket's internal buffer;
         virtual ssize_t send(const void *buf, size_t count, int flags = 0) = 0;
         virtual ssize_t send(const struct iovec *iov, int iovcnt, int flags = 0) = 0;
-        virtual ssize_t send_mutable(struct iovec *iov, int iovcnt, int flags = 0);
 
         virtual ssize_t sendfile(int in_fd, off_t offset, size_t count) = 0;
     };


### PR DESCRIPTION
to recv at least a number of bytes from socket stream, so as to reduce the # of syscalls