### PR TITLE
Fix thread-pool join threads in multiple vCPUs

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -2,9 +2,9 @@ name: Linux ARM
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   centos8-gcc921-epoll-release:

--- a/.github/workflows/ci.linux.x86.yml
+++ b/.github/workflows/ci.linux.x86.yml
@@ -2,9 +2,9 @@ name: Linux x86
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   centos8-gcc921-epoll-release:

--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -2,9 +2,9 @@ name: macOS ARM
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   macOS-clang-debug:

--- a/.github/workflows/ci.macos.yml
+++ b/.github/workflows/ci.macos.yml
@@ -2,9 +2,9 @@ name: macOS
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   macOS-12-Monterey-debug:

--- a/common/identity-pool.cpp
+++ b/common/identity-pool.cpp
@@ -49,8 +49,8 @@ void IdentityPoolBase::put(void* obj)
             m_mtx.lock();
         }
         --m_refcnt;
+        m_cvar.notify_all();
     }
-    m_cvar.notify_all();
     assert(m_size <= m_capacity);
 }
 

--- a/thread/thread-pool.cpp
+++ b/thread/thread-pool.cpp
@@ -29,9 +29,37 @@ namespace photon
             pCtrl->joining = false;
             pCtrl->start = start;
             pCtrl->arg = arg;
+            pCtrl->cvar.notify_one();
         }
-        pCtrl->cvar.notify_one();
         return pCtrl;
+    }
+    bool ThreadPoolBase::wait_for_work(TPControl &ctrl)
+    {
+        SCOPED_LOCK(ctrl.m_mtx);
+        while (!ctrl.start)                     // wait for `create()` to give me
+            ctrl.cvar.wait(ctrl.m_mtx);           // thread_entry and argument
+
+        if (ctrl.start == &stub)
+            return false;
+
+        ((partial_thread*) CURRENT)->tls = nullptr;
+        return true;
+    }
+    bool ThreadPoolBase::after_work_done(TPControl &ctrl)
+    {
+        SCOPED_LOCK(ctrl.m_mtx);
+        auto ret = !ctrl.joining;
+        if (ctrl.joining) {
+            assert(ctrl.joinable);
+            ctrl.cvar.notify_all();
+        } else if (ctrl.joinable) {
+            ctrl.joining = true;
+            ctrl.cvar.wait(ctrl.m_mtx);
+        }
+        ctrl.joinable = false;
+        ctrl.joining = false;
+        ctrl.start = nullptr;
+        return ret;
     }
     void* ThreadPoolBase::stub(void* arg)
     {
@@ -39,52 +67,43 @@ namespace photon
         auto th = *(thread**)arg;
         *(TPControl**)arg = &ctrl;              // tell ctor where my `ctrl` is
         thread_yield_to(th);
-        while(true)
+        while(wait_for_work(ctrl))
         {
-            {
-                SCOPED_LOCK(ctrl.m_mtx);
-                while (!ctrl.start)                     // wait for `create()` to give me
-                    ctrl.cvar.wait(ctrl.m_mtx);           // thread_entry and argument
-
-                if (ctrl.start == &stub)
-                    break;
-                ((partial_thread*) CURRENT)->tls = nullptr;
-            }
             ctrl.start(ctrl.arg);
             deallocate_tls();
-            {
-                SCOPED_LOCK(ctrl.m_mtx);
-                if (ctrl.joining) {
-                    assert(ctrl.joinable);
-                    ctrl.cvar.notify_all();
-                } else if (ctrl.joinable) {
-                    ctrl.joining = true;
-                    ctrl.cvar.wait(ctrl.m_mtx);
-                }
-                ctrl.joinable = false;
-                ctrl.joining = false;
-                ctrl.start = nullptr;
+            auto should_put = after_work_done(ctrl);
+            if (should_put) {
+                // if has no other joiner waiting
+                // collect it into pool
+                ctrl.pool->put(&ctrl);
             }
-            ctrl.pool->put(&ctrl);
         }
         return nullptr;
     }
-    void ThreadPoolBase::join(TPControl* pCtrl)
+    bool ThreadPoolBase::do_thread_join(TPControl* pCtrl)
     {
         SCOPED_LOCK(pCtrl->m_mtx);
         if (!pCtrl->joinable)
-            LOG_ERROR_RETURN(EINVAL, , "thread is not joinable");
+            LOG_ERROR_RETURN(EINVAL, false, "thread is not joinable");
         if (!pCtrl->start)
-            LOG_ERROR_RETURN(EINVAL, , "thread is not running");
+            LOG_ERROR_RETURN(EINVAL, false, "thread is not running");
         if (pCtrl->start == &stub)
-            LOG_ERROR_RETURN(EINVAL, , "thread is dying");
+            LOG_ERROR_RETURN(EINVAL, false, "thread is dying");
 
+        auto ret = !pCtrl->joining;
         if (pCtrl->joining) {
             pCtrl->cvar.notify_one();
         } else {
             pCtrl->joining = true;
             pCtrl->cvar.wait(pCtrl->m_mtx);
         }
+        return ret;
+    }
+    void ThreadPoolBase::join(TPControl* pCtrl)
+    {
+        auto should_put = do_thread_join(pCtrl);
+        if (should_put)
+            pCtrl->pool->put(pCtrl);
     }
     int ThreadPoolBase::ctor(ThreadPoolBase* pool, TPControl** out)
     {

--- a/thread/thread-pool.h
+++ b/thread/thread-pool.h
@@ -67,6 +67,9 @@ namespace photon
         static void* stub(void* arg);
         static int ctor(ThreadPoolBase*, TPControl**);
         static int dtor(ThreadPoolBase*, TPControl*);
+        static bool wait_for_work(TPControl &ctrl);
+        static bool after_work_done(TPControl &ctrl);
+        static bool do_thread_join(TPControl* pCtrl);
         void init(uint64_t stack_size)
         {
             set_ctor({this, &ctor});


### PR DESCRIPTION
The thread-pool does not work well joining threads that running in another vCPU.

Since the pool put action is not surely ordering after joiner wake-up, when joiner and work-thread are not in same vCPU, there is a race condition that thread may going to collect and destructor routine before the returning of `join()` call.

This fix solved this problem.