### PR TITLE
Some fixes for networking

### DIFF
--- a/.github/workflows/ci.linux.x86.yml
+++ b/.github/workflows/ci.linux.x86.yml
@@ -108,17 +108,14 @@ jobs:
         run: |
           dnf install -y git gcc-c++ cmake
           dnf install -y gcc-toolset-9-gcc-c++
-          dnf install -y openssl-devel libcurl-devel
-          dnf install -y epel-release
-          dnf install -y fuse-devel libgsasl-devel e2fsprogs-devel
+          dnf install -y autoconf automake libtool
 
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-9/enable
           cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel \
-            -D PHOTON_BUILD_DEPENDENCIES=ON -D PHOTON_BUILD_TESTING=ON \
-            -D PHOTON_ENABLE_SASL=ON -D PHOTON_ENABLE_FUSE=ON \
-            -D PHOTON_ENABLE_EXTFS=ON \
+            -D PHOTON_BUILD_DEPENDENCIES=ON \
+            -D PHOTON_BUILD_TESTING=ON \
             -D PHOTON_ENABLE_URING=ON
           cmake --build build -j -- VERBOSE=1
 

--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -1,4 +1,5 @@
 # Note: Be aware of the differences between CMake project and Makefile project.
+# Makefile project is not able to get BINARY_DIR at configuration.
 
 set(actually_built)
 
@@ -53,9 +54,12 @@ function(build_from_src [dep])
                 CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_POSITION_INDEPENDENT_CODE=ON
                 INSTALL_COMMAND ""
         )
+        if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+            set(POSTFIX "_debug")
+        endif ()
         ExternalProject_Get_Property(gflags BINARY_DIR)
         set(GFLAGS_INCLUDE_DIRS ${BINARY_DIR}/include PARENT_SCOPE)
-        set(GFLAGS_LIBRARIES ${BINARY_DIR}/lib/libgflags.a ${BINARY_DIR}/lib/libgflags_nothreads.a PARENT_SCOPE)
+        set(GFLAGS_LIBRARIES ${BINARY_DIR}/lib/libgflags${POSTFIX}.a ${BINARY_DIR}/lib/libgflags_nothreads${POSTFIX}.a PARENT_SCOPE)
 
     elseif (dep STREQUAL "googletest")
         ExternalProject_Add(
@@ -70,6 +74,48 @@ function(build_from_src [dep])
         set(GOOGLETEST_INCLUDE_DIRS ${SOURCE_DIR}/googletest/include ${SOURCE_DIR}/googlemock/include PARENT_SCOPE)
         set(GOOGLETEST_LIBRARIES ${BINARY_DIR}/lib/libgmock.a ${BINARY_DIR}/lib/libgmock_main.a
                 ${BINARY_DIR}/lib/libgtest.a ${BINARY_DIR}/lib/libgtest_main.a PARENT_SCOPE)
+
+    elseif (dep STREQUAL "openssl")
+        set(BINARY_DIR ${PROJECT_BINARY_DIR}/openssl-build)
+        ExternalProject_Add(
+                openssl
+                URL ${PHOTON_OPENSSL_SOURCE}
+                URL_MD5 bad68bb6bd9908da75e2c8dedc536b29
+                BUILD_IN_SOURCE ON
+                CONFIGURE_COMMAND ./config -fPIC no-unit-test no-shared --openssldir=${BINARY_DIR} --prefix=${BINARY_DIR}
+                BUILD_COMMAND make depend -j ${NumCPU} && make -j ${NumCPU}
+                INSTALL_COMMAND make install
+        )
+        ExternalProject_Get_Property(openssl SOURCE_DIR)
+        set(OPENSSL_ROOT_DIR ${SOURCE_DIR} PARENT_SCOPE)
+        set(OPENSSL_INCLUDE_DIRS ${BINARY_DIR}/include PARENT_SCOPE)
+        set(OPENSSL_LIBRARIES ${BINARY_DIR}/lib/libssl.a ${BINARY_DIR}/lib/libcrypto.a PARENT_SCOPE)
+
+    elseif (dep STREQUAL "curl")
+        if (${OPENSSL_ROOT_DIR} STREQUAL "")
+            message(FATAL_ERROR "OPENSSL_ROOT_DIR not exist")
+        endif ()
+        set(BINARY_DIR ${PROJECT_BINARY_DIR}/curl-build)
+        ExternalProject_Add(
+                curl
+                URL ${PHOTON_CURL_SOURCE}
+                URL_MD5 a66270f11e3fbfad709600bbd1686704
+                BUILD_IN_SOURCE ON
+                CONFIGURE_COMMAND export CC=${CMAKE_C_COMPILER} && export CXX=${CMAKE_CXX_COMPILER} &&
+                    export LD=${CMAKE_LINKER} && export CFLAGS=-fPIC &&
+                    autoreconf -i && ./configure --with-ssl=${OPENSSL_ROOT_DIR}
+                    --without-libssh2 --enable-static --enable-shared=no --enable-optimize
+                    --disable-manual --without-libidn
+                    --disable-ftp --disable-file --disable-ldap --disable-ldaps
+                    --disable-rtsp --disable-dict --disable-telnet --disable-tftp
+                    --disable-pop3 --disable-imap --disable-smb --disable-smtp
+                    --disable-gopher --without-nghttp2 --enable-http
+                    --with-pic=PIC --prefix=${BINARY_DIR}
+                BUILD_COMMAND make -j ${NumCPU}
+                INSTALL_COMMAND make install
+        )
+        set(CURL_INCLUDE_DIRS ${BINARY_DIR}/include PARENT_SCOPE)
+        set(CURL_LIBRARIES ${BINARY_DIR}/lib/libcurl.a PARENT_SCOPE)
     endif ()
 
     list(APPEND actually_built ${dep})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ option(PHOTON_ENABLE_EXTFS "enable extfs" OFF)
 option(PHOTON_BUILD_DEPENDENCIES "" OFF)
 set(PHOTON_AIO_SOURCE "https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz" CACHE STRING "")
 set(PHOTON_ZLIB_SOURCE "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz" CACHE STRING "")
-set(PHOTON_OPENSSL_SOURCE "" CACHE STRING "")
-set(PHOTON_CURL_SOURCE "" CACHE STRING "")
+set(PHOTON_OPENSSL_SOURCE "https://github.com/openssl/openssl/archive/refs/heads/OpenSSL_1_0_2-stable.tar.gz" CACHE STRING "")
+set(PHOTON_CURL_SOURCE "https://github.com/curl/curl/archive/refs/tags/curl-7_42_1.tar.gz" CACHE STRING "")
 set(PHOTON_URING_SOURCE "https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz" CACHE STRING "")
 set(PHOTON_FUSE_SOURCE "" CACHE STRING "")
 set(PHOTON_GSASL_SOURCE "" CACHE STRING "")
@@ -96,7 +96,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/output)
 ################################################################################
 
 # There are two ways to handle dependencies:
-#   1. Find locally installed packages. (Static lib is suggested)
+#   1. Find locally installed packages.
 #   2. Build it from source. (Only when PHOTON_BUILD_DEPENDENCIES is set, and PHOTON_XXX_SOURCE is not empty)
 #
 # The naming conventions MUST obey:
@@ -196,21 +196,22 @@ endif ()
 
 # An object library compiles source files but does not archive or link their object files.
 add_library(photon_obj OBJECT ${PHOTON_SRC})
-target_include_directories(photon_obj PUBLIC include ${OPENSSL_INCLUDE_DIRS} ${AIO_INCLUDE_DIRS}
-        ${ZLIB_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS})
+target_include_directories(photon_obj PRIVATE include ${OPENSSL_INCLUDE_DIRS} ${AIO_INCLUDE_DIRS}
+        ${ZLIB_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS}
+)
 target_compile_definitions(photon_obj PRIVATE _FILE_OFFSET_BITS=64 FUSE_USE_VERSION=29)
 if (PHOTON_ENABLE_URING)
-    target_include_directories(photon_obj PUBLIC ${URING_INCLUDE_DIRS})
+    target_include_directories(photon_obj PRIVATE ${URING_INCLUDE_DIRS})
     target_compile_definitions(photon_obj PRIVATE PHOTON_URING=on)
 endif()
 if (PHOTON_ENABLE_MIMIC_VDSO)
     target_compile_definitions(photon_obj PRIVATE ENABLE_MIMIC_VDSO=on)
 endif()
 if (PHOTON_ENABLE_FSTACK_DPDK)
-    target_include_directories(photon_obj PUBLIC ${FSTACK_INCLUDE_DIRS})
+    target_include_directories(photon_obj PRIVATE ${FSTACK_INCLUDE_DIRS})
 endif()
 if (PHOTON_ENABLE_EXTFS)
-    target_include_directories(photon_obj PUBLIC ${LIBE2FS_INCLUDE_DIRS})
+    target_include_directories(photon_obj PRIVATE ${LIBE2FS_INCLUDE_DIRS})
 endif()
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
     # This option is enabled by default after -std=c++17
@@ -226,9 +227,9 @@ endif ()
 set(static_deps
         easy_weak
         fstack_weak
-        ${ZLIB_LIBRARIES}
-        ${OPENSSL_LIBRARIES}
         ${CURL_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        ${ZLIB_LIBRARIES}
 )
 set(shared_deps
         -lpthread
@@ -256,8 +257,8 @@ if (PHOTON_ENABLE_EXTFS)
     list(APPEND static_deps ${E2FS_LIBRARIES})
 endif ()
 
-# It's OK to have some `shared_deps` duplicated in `static_deps`.
-# Even though .a is suggested, we may still probably find .so in local installed dir.
+# Find out dynamic libs and append to `shared_deps`.
+# Because if not built from source, we won't know the local packages are static or shared.
 # This is for the max compatability.
 if (NOT APPLE)
     set(suffix "\.so$")
@@ -271,9 +272,6 @@ foreach (dep ${static_deps})
             break()
         endif ()
     endforeach ()
-    if (dep MATCHES "\.a$")
-        list(APPEND static_deps_archive ${dep})
-    endif ()
 endforeach ()
 
 set(version_scripts)
@@ -284,6 +282,7 @@ list(APPEND version_scripts "-Wl,--version-script=${PROJECT_SOURCE_DIR}/tools/li
 # Link photon shared lib
 add_library(photon_shared SHARED $<TARGET_OBJECTS:photon_obj>)
 set_target_properties(photon_shared PROPERTIES OUTPUT_NAME photon)
+target_include_directories(photon_shared PUBLIC include ${CURL_INCLUDE_DIRS})
 if (NOT APPLE)
     target_link_libraries(photon_shared
             PRIVATE ${version_scripts} -Wl,--whole-archive ${static_deps} -Wl,--no-whole-archive
@@ -299,32 +298,39 @@ endif ()
 # Link photon static lib
 add_library(photon_static STATIC $<TARGET_OBJECTS:photon_obj>)
 set_target_properties(photon_static PROPERTIES OUTPUT_NAME photon_sole)
+target_include_directories(photon_static PUBLIC include ${CURL_INCLUDE_DIRS})
 target_link_libraries(photon_static
         PUBLIC ${shared_deps}
         PRIVATE ${static_deps}
 )
 
-# Merge static libs into libphoton.a
-# Do NOT use this target directly.
+# Merge static libs into libphoton.a for manual distribution.
+# Do NOT link to this target directly.
 if (NOT APPLE)
-    set(merge_command ar -crT libphoton.a)
+    add_custom_target(_photon_static_archive ALL
+            COMMAND rm -rf libphoton.a
+            COMMAND ar -qcT libphoton.a $<TARGET_FILE:photon_static> $<TARGET_FILE:easy_weak> $<TARGET_FILE:fstack_weak>
+            COMMAND ar -M < ${PROJECT_SOURCE_DIR}/tools/libphoton.mri
+            DEPENDS photon_static
+            WORKING_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+            VERBATIM
+    )
 else ()
-    set(merge_command libtool -static -o libphoton.a)
+    add_custom_target(_photon_static_archive ALL
+            COMMAND rm -rf libphoton.a
+            COMMAND libtool -static -o libphoton.a $<TARGET_FILE:photon_static> $<TARGET_FILE:easy_weak> $<TARGET_FILE:fstack_weak>
+            DEPENDS photon_static
+            WORKING_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+            VERBATIM
+    )
 endif ()
-add_custom_target(_photon_static_archive ALL
-        COMMAND rm -rf libphoton.a
-        COMMAND ${merge_command} $<TARGET_FILE:photon_static> $<TARGET_FILE:easy_weak> $<TARGET_FILE:fstack_weak>
-        DEPENDS photon_static
-        WORKING_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
-        VERBATIM
-)
 
 # Build test cases
 if (PHOTON_BUILD_TESTING)
     include(CTest)
 
-    set(testing_libs ${GFLAGS_LIBRARIES} ${GOOGLETEST_LIBRARIES})
-    include_directories(${GFLAGS_INCLUDE_DIRS} ${GOOGLETEST_INCLUDE_DIRS})
+    include_directories(photon_static ${GFLAGS_INCLUDE_DIRS} ${GOOGLETEST_INCLUDE_DIRS})
+    link_libraries(${GFLAGS_LIBRARIES} ${GOOGLETEST_LIBRARIES})
 
     add_subdirectory(examples)
     add_subdirectory(common/checksum/test)

--- a/common/checksum/test/CMakeLists.txt
+++ b/common/checksum/test/CMakeLists.txt
@@ -1,8 +1,6 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 SET(TEST_WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}/)
 ADD_DEFINITIONS(-w -DDATA_DIR=${TEST_WORKING_DIR})
 
 add_executable(test-checksum test_checksum.cpp)
-target_link_libraries(test-checksum PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-checksum PRIVATE photon_shared)
 add_test(NAME test-checksum COMMAND $<TARGET_FILE:test-checksum>)

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -1,32 +1,30 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 SET(TEST_WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}/)
 ADD_DEFINITIONS(-w -DDATA_DIR=${TEST_WORKING_DIR})
 
 add_executable(test-objcache test_objcache.cpp)
-target_link_libraries(test-objcache PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-objcache PRIVATE photon_shared)
 add_test(NAME test-objcache COMMAND $<TARGET_FILE:test-objcache>)
 
 add_executable(test-common test.cpp)
-target_link_libraries(test-common PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-common PRIVATE photon_shared)
 add_test(NAME test-common COMMAND $<TARGET_FILE:test-common>)
 
 add_executable(test-scalepool test_scalepool.cpp)
-target_link_libraries(test-scalepool PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-scalepool PRIVATE photon_shared)
 add_test(NAME test-scalepool COMMAND $<TARGET_FILE:test-scalepool>)
 
 add_executable(test-throttle test_throttle.cpp)
-target_link_libraries(test-throttle PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-throttle PRIVATE photon_shared)
 add_test(NAME test-throttle COMMAND $<TARGET_FILE:test-throttle>)
 
 add_executable(test-constexprstr test_constexprstr.cpp)
-target_link_libraries(test-constexprstr PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-constexprstr PRIVATE photon_shared)
 add_test(NAME test-constexprstr COMMAND $<TARGET_FILE:test-constexprstr>)
 
 #add_executable(test-lockfree test_lockfree.cpp)
-#target_link_libraries(test-lockfree PRIVATE photon_shared ${testing_libs})
+#target_link_libraries(test-lockfree PRIVATE photon_shared)
 #add_test(NAME test-lockfree COMMAND $<TARGET_FILE:test-lockfree>)
 
 add_executable(test-alog test_alog.cpp x.cpp)
-target_link_libraries(test-alog PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-alog PRIVATE photon_shared)
 add_test(NAME test-alog COMMAND $<TARGET_FILE:test-alog>)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,22 +1,19 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-
 add_executable(simple-example simple/simple.cpp)
 target_link_libraries(simple-example PRIVATE photon_static)
 
 add_executable(net-perf perf/net-perf.cpp)
-target_link_libraries(net-perf PRIVATE photon_static ${testing_libs})
+target_link_libraries(net-perf PRIVATE photon_static)
 
 add_executable(rpc-example-client rpc/client.cpp rpc/client_main.cpp)
-target_link_libraries(rpc-example-client PRIVATE photon_static ${testing_libs})
+target_link_libraries(rpc-example-client PRIVATE photon_static)
 
 add_executable(rpc-example-server rpc/server.cpp rpc/server_main.cpp)
-target_link_libraries(rpc-example-server PRIVATE photon_static ${testing_libs})
+target_link_libraries(rpc-example-server PRIVATE photon_static)
 
 add_executable(sync-primitive sync-primitive/sync-primitive.cpp)
-target_link_libraries(sync-primitive PRIVATE photon_static ${testing_libs})
+target_link_libraries(sync-primitive PRIVATE photon_static)
 
 if (ENABLE_FSTACK_DPDK)
     add_executable(fstack-dpdk-demo fstack-dpdk/fstack-dpdk-demo.cpp)
-    target_link_libraries(fstack-dpdk-demo PRIVATE fstack_dpdk photon_static ${testing_libs})
+    target_link_libraries(fstack-dpdk-demo PRIVATE fstack_dpdk photon_static)
 endif ()

--- a/fs/extfs/test/CMakeLists.txt
+++ b/fs/extfs/test/CMakeLists.txt
@@ -1,8 +1,6 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-extfs test.cpp)
-target_link_libraries(test-extfs PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-extfs PRIVATE photon_shared)
 
 add_test(NAME test-extfs COMMAND $<TARGET_FILE:test-extfs>)

--- a/fs/test/CMakeLists.txt
+++ b/fs/test/CMakeLists.txt
@@ -1,19 +1,17 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-fs test.cpp)
-target_link_libraries(test-fs PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-fs PRIVATE photon_shared)
 add_test(NAME test-fs COMMAND $<TARGET_FILE:test-fs>)
 
 # add_executable(test-exportfs test_exportfs.cpp)
-# target_link_libraries(test-exportfs PRIVATE photon_static ${testing_libs})
+# target_link_libraries(test-exportfs PRIVATE photon_static)
 # add_test(NAME test-exportfs COMMAND $<TARGET_FILE:test-exportfs>)
 
 add_executable(test-filecopy test_filecopy.cpp)
-target_link_libraries(test-filecopy PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-filecopy PRIVATE photon_shared)
 add_test(NAME test-filecopy COMMAND $<TARGET_FILE:test-filecopy>)
 
 add_executable(test-throttled test_throttledfile.cpp)
-target_link_libraries(test-throttled PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-throttled PRIVATE photon_shared)
 add_test(NAME test-throttled COMMAND $<TARGET_FILE:test-throttled>)

--- a/io/test/CMakeLists.txt
+++ b/io/test/CMakeLists.txt
@@ -1,21 +1,19 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(signalfdtest signalfdtest.cpp)
-target_link_libraries(signalfdtest PRIVATE photon_shared ${testing_libs})
+target_link_libraries(signalfdtest PRIVATE photon_shared)
 add_test(NAME signalfdtest COMMAND $<TARGET_FILE:signalfdtest>)
 
 add_executable(signalfdboom signalfdboom.cpp)
-target_link_libraries(signalfdboom PRIVATE photon_shared ${testing_libs})
+target_link_libraries(signalfdboom PRIVATE photon_shared)
 add_test(NAME signalfdboom COMMAND $<TARGET_FILE:signalfdboom>)
 
 if (NOT APPLE)
 add_executable(test-syncio test-syncio.cpp)
-target_link_libraries(test-syncio PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-syncio PRIVATE photon_shared)
 add_test(NAME test-syncio COMMAND $<TARGET_FILE:test-syncio>)
 
 add_executable(test-iouring test-iouring.cpp)
-target_link_libraries(test-iouring PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-iouring PRIVATE photon_shared)
 add_test(NAME test-iouring COMMAND $<TARGET_FILE:test-iouring>)
 endif ()

--- a/net/http/client.h
+++ b/net/http/client.h
@@ -133,7 +133,7 @@ protected:
 };
 
 //A Client without cookie_jar would ignore all response-header "Set-Cookies"
-Client* new_http_client(ICookieJar *cookie_jar = nullptr, bool ipv6 = false);
+Client* new_http_client(ICookieJar *cookie_jar = nullptr);
 
 ICookieJar* new_simple_cookie_jar();
 

--- a/net/http/test/CMakeLists.txt
+++ b/net/http/test/CMakeLists.txt
@@ -1,28 +1,26 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(client_perf client_perf.cpp)
-target_link_libraries(client_perf PRIVATE photon_shared ${testing_libs})
+target_link_libraries(client_perf PRIVATE photon_static)
 
 add_executable(server_perf server_perf.cpp)
-target_link_libraries(server_perf PRIVATE photon_shared ${testing_libs})
+target_link_libraries(server_perf PRIVATE photon_shared)
 
 add_executable(pure_libcurl pure_libcurl.cpp)
-target_link_libraries(pure_libcurl PRIVATE photon_shared ${testing_libs})
+target_link_libraries(pure_libcurl PRIVATE photon_static)
 
 add_executable(client_function_test client_function_test.cpp)
-target_link_libraries(client_function_test PRIVATE photon_shared ${testing_libs})
+target_link_libraries(client_function_test PRIVATE photon_shared)
 add_test(NAME client_function_test COMMAND $<TARGET_FILE:client_function_test>)
 
 add_executable(server_function_test server_function_test.cpp)
-target_link_libraries(server_function_test PRIVATE photon_shared ${testing_libs})
+target_link_libraries(server_function_test PRIVATE photon_shared)
 add_test(NAME server_function_test COMMAND $<TARGET_FILE:server_function_test>)
 
 add_executable(cookie_jar_test cookie_jar_test.cpp)
-target_link_libraries(cookie_jar_test PRIVATE photon_shared ${testing_libs})
+target_link_libraries(cookie_jar_test PRIVATE photon_shared)
 add_test(NAME cookie_jar_test COMMAND $<TARGET_FILE:cookie_jar_test>)
 
 add_executable(headers_test headers_test.cpp)
-target_link_libraries(headers_test PRIVATE photon_shared ${testing_libs})
+target_link_libraries(headers_test PRIVATE photon_shared)
 add_test(NAME headers_test COMMAND $<TARGET_FILE:headers_test>)

--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 #include <photon/thread/thread11.h>
 #include <photon/thread/list.h>
 #include <photon/thread/timer.h>
+#include <photon/common/estring.h>
 #include <photon/common/utility.h>
 #include <photon/common/event-loop.h>
 #include <photon/net/basic_socket.h>
@@ -58,22 +59,6 @@ limitations under the License.
 #ifndef AF_SMC
 #define AF_SMC 43
 #endif
-
-LogBuffer& operator<<(LogBuffer& log, const in_addr& iaddr) {
-    return log << photon::net::IPAddr(iaddr);
-}
-LogBuffer& operator<<(LogBuffer& log, const in6_addr& iaddr) {
-    return log << photon::net::IPAddr(iaddr);
-}
-LogBuffer& operator<<(LogBuffer& log, const sockaddr_in& addr) {
-    return log << photon::net::sockaddr_storage(addr).to_endpoint();
-}
-LogBuffer& operator<<(LogBuffer& log, const sockaddr_in6& addr) {
-    return log << photon::net::sockaddr_storage(addr).to_endpoint();
-}
-LogBuffer& operator<<(LogBuffer& log, const sockaddr& addr) {
-    return log << photon::net::sockaddr_storage(addr).to_endpoint();
-}
 
 namespace photon {
 namespace net {
@@ -240,7 +225,12 @@ protected:
     ISocketStream* do_connect(const sockaddr* remote, socklen_t len_remote,
                               const sockaddr* local = nullptr, socklen_t len_local = 0) {
         auto stream = create_stream();
-        std::unique_ptr<KernelSocketStream> ptr(stream);
+        auto deleter = [&](KernelSocketStream*) {
+            auto errno_backup = errno;
+            delete stream;
+            errno = errno_backup;
+        };
+        std::unique_ptr<KernelSocketStream, decltype(deleter)> ptr(stream, deleter);
         if (!ptr || ptr->fd < 0) {
             LOG_ERROR_RETURN(0, nullptr, "Failed to create socket fd");
         }
@@ -983,25 +973,6 @@ protected:
 
 /* ET Socket - End */
 
-LogBuffer& operator<<(LogBuffer& log, const IPAddr addr) {
-    if (addr.is_ipv4())
-        return log.printf(addr.a, '.', addr.b, '.', addr.c, '.', addr.d);
-    else {
-        if (log.size < INET6_ADDRSTRLEN)
-            return log;
-        inet_ntop(AF_INET6, &addr.addr, log.ptr, INET6_ADDRSTRLEN);
-        log.consume(strlen(log.ptr));
-        return log;
-    }
-}
-
-LogBuffer& operator<<(LogBuffer& log, const EndPoint ep) {
-    if (ep.is_ipv4())
-        return log << ep.addr << ':' << ep.port;
-    else
-        return log << '[' << ep.addr << "]:" << ep.port;
-}
-
 extern "C" ISocketClient* new_tcp_socket_client() {
     return new KernelSocketClient(AF_INET, true);
 }
@@ -1063,5 +1034,61 @@ extern "C" ISocketServer* new_fstack_dpdk_socket_server() {
 #endif // ENABLE_FSTACK_DPDK
 #endif // __linux__
 
+////////////////////////////////////////////////////////////////////////////////
+
+/* Implementations in socket.h */
+
+EndPoint::EndPoint(const char* s) {
+    estring_view ep(s);
+    auto pos = ep.find_last_of(':');
+    if (pos == estring::npos)
+        return;
+    // Detect IPv6 or IPv4
+    estring ip_str = ep[pos - 1] == ']' ? ep.substr(1, pos - 2) : ep.substr(0, pos);
+    auto ip = IPAddr(ip_str.c_str());
+    if (ip.undefined())
+        return;
+    auto port_str = ep.substr(pos + 1);
+    if (!port_str.all_digits())
+        return;
+    addr = ip;
+    port = std::stoul(port_str);
 }
+
+LogBuffer& operator<<(LogBuffer& log, const IPAddr addr) {
+    if (addr.is_ipv4())
+        return log.printf(addr.a, '.', addr.b, '.', addr.c, '.', addr.d);
+    else {
+        if (log.size < INET6_ADDRSTRLEN)
+            return log;
+        inet_ntop(AF_INET6, &addr.addr, log.ptr, INET6_ADDRSTRLEN);
+        log.consume(strlen(log.ptr));
+        return log;
+    }
+}
+
+LogBuffer& operator<<(LogBuffer& log, const EndPoint ep) {
+    if (ep.is_ipv4())
+        return log << ep.addr << ':' << ep.port;
+    else
+        return log << '[' << ep.addr << "]:" << ep.port;
+}
+
+}
+}
+
+LogBuffer& operator<<(LogBuffer& log, const in_addr& iaddr) {
+    return log << photon::net::IPAddr(iaddr);
+}
+LogBuffer& operator<<(LogBuffer& log, const in6_addr& iaddr) {
+    return log << photon::net::IPAddr(iaddr);
+}
+LogBuffer& operator<<(LogBuffer& log, const sockaddr_in& addr) {
+    return log << photon::net::sockaddr_storage(addr).to_endpoint();
+}
+LogBuffer& operator<<(LogBuffer& log, const sockaddr_in6& addr) {
+    return log << photon::net::sockaddr_storage(addr).to_endpoint();
+}
+LogBuffer& operator<<(LogBuffer& log, const sockaddr& addr) {
+    return log << photon::net::sockaddr_storage(addr).to_endpoint();
 }

--- a/net/security-context/test/CMakeLists.txt
+++ b/net/security-context/test/CMakeLists.txt
@@ -1,14 +1,12 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-tls test.cpp)
-target_link_libraries(test-tls PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-tls PRIVATE photon_shared)
 add_test(NAME test-tls COMMAND $<TARGET_FILE:test-tls>)
 
 if (ENABLE_SASL AND (NOT (APPLE AND (${ARCH} STREQUAL arm64))))
     add_executable(test-sasl test-sasl.cpp)
-    target_link_libraries(test-sasl PRIVATE photon_shared ${testing_libs})
+    target_link_libraries(test-sasl PRIVATE photon_shared)
     add_test(NAME test-sasl COMMAND $<TARGET_FILE:test-sasl>)
 endif ()
 

--- a/net/socket.h
+++ b/net/socket.h
@@ -150,6 +150,7 @@ namespace net {
         uint16_t port = 0;
         EndPoint() = default;
         EndPoint(IPAddr ip, uint16_t port) : addr(ip), port(port) {}
+        explicit EndPoint(const char* s);
         bool is_ipv4() const {
             return addr.is_ipv4();
         };

--- a/net/test/CMakeLists.txt
+++ b/net/test/CMakeLists.txt
@@ -1,28 +1,26 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-socket test.cpp)
-target_link_libraries(test-socket PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-socket PRIVATE photon_shared)
 add_test(NAME test-socket COMMAND $<TARGET_FILE:test-socket>)
 
 add_executable(test-dg-socket test-udp.cpp)
-target_link_libraries(test-dg-socket PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-dg-socket PRIVATE photon_shared)
 add_test(NAME test-dg-socket COMMAND $<TARGET_FILE:test-dg-socket>)
 
 add_executable(test-sockpool test_sockpool.cpp)
-target_link_libraries(test-sockpool PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-sockpool PRIVATE photon_shared)
 add_test(NAME test-sockpool COMMAND $<TARGET_FILE:test-sockpool>)
 
 add_executable(test-curl test_curl.cpp)
-target_link_libraries(test-curl PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-curl PRIVATE photon_static)
 add_test(NAME test-curl COMMAND $<TARGET_FILE:test-curl>)
 
 add_executable(test-server test-server.cpp)
-target_link_libraries(test-server PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-server PRIVATE photon_shared)
 
 add_executable(test-client test-client.cpp)
-target_link_libraries(test-client PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-client PRIVATE photon_shared)
 
 add_executable(test-ipv6 test-ipv6.cpp)
-target_link_libraries(test-ipv6 PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-ipv6 PRIVATE photon_shared)

--- a/net/test/test-ipv6.cpp
+++ b/net/test/test-ipv6.cpp
@@ -7,14 +7,28 @@
 #include <photon/net/utils.h>
 #include <photon/common/alog.h>
 
-TEST(ipv6, addr) {
-    EXPECT_NO_THROW(photon::net::IPAddr a("::1"));
-    EXPECT_NO_THROW(photon::net::IPAddr a("1.2.3.4"));
-    EXPECT_NO_THROW(photon::net::IPAddr a("fdbd:dc01:ff:312:9641:f71:10c4:2378"));
-    EXPECT_NO_THROW(photon::net::IPAddr a("fdbd:dc01:ff:312:9641:f71::2378"));
-    EXPECT_NO_THROW(photon::net::IPAddr a("fdbd:dc01:ff:312:9641::2378"));
+TEST(ipv6, endpoint) {
+    auto c = photon::net::EndPoint("127.0.0.1");
+    EXPECT_TRUE(c.undefined());
+    c = photon::net::EndPoint("127.0.0.1:8888");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::EndPoint("[::1]:8888");
+    EXPECT_FALSE(c.undefined());
+}
 
-    auto c = photon::net::IPAddr("zfdbd:dq01:8:165::158");
+TEST(ipv6, addr) {
+    auto c = photon::net::IPAddr("::1");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::IPAddr("::1");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::IPAddr("fdbd:dc01:ff:312:9641:f71:10c4:2378");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::IPAddr("fdbd:dc01:ff:312:9641:f71::2378");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::IPAddr("fdbd:dc01:ff:312:9641::2378");
+    EXPECT_FALSE(c.undefined());
+
+    c = photon::net::IPAddr("zfdbd:dq01:8:165::158");
     EXPECT_TRUE(c.undefined());
     c = photon::net::IPAddr("fdbd::ff:312:9641:f71::2378");
     EXPECT_TRUE(c.undefined());

--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -256,8 +256,8 @@ bool Base64Decode(std::string_view in, std::string &out) {
 
 class DefaultResolver : public Resolver {
 public:
-    DefaultResolver(uint64_t cache_ttl, uint64_t resolve_timeout, bool ipv6)
-        : dnscache_(cache_ttl), resolve_timeout_(resolve_timeout), ipv6_(ipv6) {}
+    DefaultResolver(uint64_t cache_ttl, uint64_t resolve_timeout)
+        : dnscache_(cache_ttl), resolve_timeout_(resolve_timeout) {}
     ~DefaultResolver() { dnscache_.clear(); }
 
     IPAddr resolve(const char *host) override {
@@ -279,9 +279,10 @@ public:
                 LOG_WARN("Domain resolution for ` failed", host);
                 return new IPAddr;  // undefined addr
             }
-            for (auto& each : addrs) {
-                if ((each.is_ipv4() ^ !ipv6_) == 0)
-                    return new IPAddr(each);
+            // TODO: support ipv6
+            for (auto& ip : addrs) {
+                if (ip.is_ipv4())
+                    return new IPAddr(ip);
             }
             return new IPAddr;      // undefined addr
         };
@@ -298,11 +299,10 @@ public:
 private:
     ObjectCache<std::string, IPAddr *> dnscache_;
     uint64_t resolve_timeout_;
-    bool ipv6_;
 };
 
-Resolver* new_default_resolver(uint64_t cache_ttl, uint64_t resolve_timeout, bool ipv6) {
-    return new DefaultResolver(cache_ttl, resolve_timeout, ipv6);
+Resolver* new_default_resolver(uint64_t cache_ttl, uint64_t resolve_timeout) {
+    return new DefaultResolver(cache_ttl, resolve_timeout);
 }
 
 }  // namespace net

--- a/net/utils.h
+++ b/net/utils.h
@@ -165,10 +165,9 @@ public:
  *
  * @param cache_ttl cache's lifetime in microseconds.
  * @param resolve_timeout timeout in microseconds for domain resolution.
- * @param ipv6 specify v4 or v6 domain name
  * @return Resolver*
  */
-Resolver* new_default_resolver(uint64_t cache_ttl = 3600UL * 1000000, uint64_t resolve_timeout = -1, bool ipv6 = false);
+Resolver* new_default_resolver(uint64_t cache_ttl = 3600UL * 1000000, uint64_t resolve_timeout = -1);
 
 }  // namespace net
 }

--- a/rpc/rpc.h
+++ b/rpc/rpc.h
@@ -234,8 +234,7 @@ namespace rpc
     };
 
     extern "C" Stub* new_rpc_stub(IStream* stream, bool ownership = false);
-    extern "C" StubPool* new_stub_pool(uint64_t expiration, uint64_t connect_timeout, uint64_t rpc_timeout,
-                                       bool ipv6 = false);
+    extern "C" StubPool* new_stub_pool(uint64_t expiration, uint64_t connect_timeout, uint64_t rpc_timeout);
     extern "C" StubPool* new_uds_stub_pool(const char* path, uint64_t expiration,
                                 uint64_t connect_timeout,
                                 uint64_t rpc_timeout);

--- a/rpc/test/CMakeLists.txt
+++ b/rpc/test/CMakeLists.txt
@@ -1,15 +1,13 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-rpc test.cpp)
-target_link_libraries(test-rpc PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-rpc PRIVATE photon_shared)
 add_test(NAME test-rpc COMMAND $<TARGET_FILE:test-rpc>)
 
 add_executable(test-ooo test-ooo.cpp)
-target_link_libraries(test-ooo PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-ooo PRIVATE photon_shared)
 add_test(NAME test-ooo COMMAND $<TARGET_FILE:test-ooo>)
 
 add_executable(test-rpc-message test-rpc-message.cpp)
-target_link_libraries(test-rpc-message PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-rpc-message PRIVATE photon_shared)
 add_test(NAME test-rpc-message COMMAND $<TARGET_FILE:test-rpc-message>)

--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -1,35 +1,33 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(perf_usleepdefer_semaphore perf_usleepdefer_semaphore.cpp)
-target_link_libraries(perf_usleepdefer_semaphore PRIVATE photon_shared ${testing_libs})
+target_link_libraries(perf_usleepdefer_semaphore PRIVATE photon_shared)
 add_test(NAME perf_usleepdefer_semaphore COMMAND $<TARGET_FILE:perf_usleepdefer_semaphore>)
 
 add_executable(test-thread test.cpp x.cpp)
-target_link_libraries(test-thread PRIVATE photon_static ${testing_libs})
+target_link_libraries(test-thread PRIVATE photon_static)
 add_test(NAME test-thread COMMAND $<TARGET_FILE:test-thread>)
 
 add_executable(test-std-compat test-std-compat.cpp)
-target_link_libraries(test-std-compat PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-std-compat PRIVATE photon_shared)
 add_test(NAME test-std-compat COMMAND $<TARGET_FILE:test-std-compat>)
 
 add_executable(test-specific-key test-specific-key.cpp)
-target_link_libraries(test-specific-key PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-specific-key PRIVATE photon_shared)
 add_test(NAME test-specific-key COMMAND $<TARGET_FILE:test-specific-key>)
 
 add_executable(test-thread-local test-thread-local.cpp)
-target_link_libraries(test-thread-local PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-thread-local PRIVATE photon_shared)
 add_test(NAME test-thread-local COMMAND $<TARGET_FILE:test-thread-local>)
 
 add_executable(test-tls-order-native test-tls-order-native.cpp)
-target_link_libraries(test-tls-order-native PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-tls-order-native PRIVATE photon_shared)
 add_test(NAME test-tls-order-native COMMAND $<TARGET_FILE:test-tls-order-native>)
 
 add_executable(test-tls-order-photon test-tls-order-photon.cpp)
-target_link_libraries(test-tls-order-photon PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-tls-order-photon PRIVATE photon_shared)
 add_test(NAME test-tls-order-photon COMMAND $<TARGET_FILE:test-tls-order-photon>)
 
 add_executable(test-lib-data test-lib-data.cpp)
-target_link_libraries(test-lib-data PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-lib-data PRIVATE photon_shared)
 add_test(NAME test-lib-data COMMAND $<TARGET_FILE:test-lib-data>)

--- a/tools/libphoton.mri
+++ b/tools/libphoton.mri
@@ -1,0 +1,4 @@
+create libphoton.a
+addlib libphoton.a
+save
+end


### PR DESCRIPTION
1. RPC client now supports both v4 and v6. Don't need to create two clients any more.
2. HTTP client removes v6 temporarily. There are still a lot work to be done for HTTP to truly support IPv6 (url parse, domain resolve, single client that supports both sockets), leave this work to the future...
3. Backup errno when KernelSocketStream destruct
4. Endpoint adds a string constructor
5. CMake can build openssl and curl from source now