### PR TITLE
marking inode 1 inuse for extfs/mkfs

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -2,9 +2,9 @@ name: Linux ARM
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   centos8-gcc921-epoll-release:

--- a/.github/workflows/ci.linux.x86.yml
+++ b/.github/workflows/ci.linux.x86.yml
@@ -2,9 +2,9 @@ name: Linux x86
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   centos8-gcc921-epoll-release:

--- a/.github/workflows/ci.linux.x86.yml
+++ b/.github/workflows/ci.linux.x86.yml
@@ -108,17 +108,14 @@ jobs:
         run: |
           dnf install -y git gcc-c++ cmake
           dnf install -y gcc-toolset-9-gcc-c++
-          dnf install -y openssl-devel libcurl-devel
-          dnf install -y epel-release
-          dnf install -y fuse-devel libgsasl-devel e2fsprogs-devel
+          dnf install -y autoconf automake libtool
 
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-9/enable
           cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel \
-            -D PHOTON_BUILD_DEPENDENCIES=ON -D PHOTON_BUILD_TESTING=ON \
-            -D PHOTON_ENABLE_SASL=ON -D PHOTON_ENABLE_FUSE=ON \
-            -D PHOTON_ENABLE_EXTFS=ON \
+            -D PHOTON_BUILD_DEPENDENCIES=ON \
+            -D PHOTON_BUILD_TESTING=ON \
             -D PHOTON_ENABLE_URING=ON
           cmake --build build -j -- VERBOSE=1
 

--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -2,9 +2,9 @@ name: macOS ARM
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   macOS-clang-debug:

--- a/.github/workflows/ci.macos.yml
+++ b/.github/workflows/ci.macos.yml
@@ -2,9 +2,9 @@ name: macOS
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   macOS-12-Monterey-debug:

--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -1,4 +1,5 @@
 # Note: Be aware of the differences between CMake project and Makefile project.
+# Makefile project is not able to get BINARY_DIR at configuration.
 
 set(actually_built)
 
@@ -53,9 +54,12 @@ function(build_from_src [dep])
                 CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_POSITION_INDEPENDENT_CODE=ON
                 INSTALL_COMMAND ""
         )
+        if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+            set(POSTFIX "_debug")
+        endif ()
         ExternalProject_Get_Property(gflags BINARY_DIR)
         set(GFLAGS_INCLUDE_DIRS ${BINARY_DIR}/include PARENT_SCOPE)
-        set(GFLAGS_LIBRARIES ${BINARY_DIR}/lib/libgflags.a ${BINARY_DIR}/lib/libgflags_nothreads.a PARENT_SCOPE)
+        set(GFLAGS_LIBRARIES ${BINARY_DIR}/lib/libgflags${POSTFIX}.a ${BINARY_DIR}/lib/libgflags_nothreads${POSTFIX}.a PARENT_SCOPE)
 
     elseif (dep STREQUAL "googletest")
         ExternalProject_Add(
@@ -70,6 +74,48 @@ function(build_from_src [dep])
         set(GOOGLETEST_INCLUDE_DIRS ${SOURCE_DIR}/googletest/include ${SOURCE_DIR}/googlemock/include PARENT_SCOPE)
         set(GOOGLETEST_LIBRARIES ${BINARY_DIR}/lib/libgmock.a ${BINARY_DIR}/lib/libgmock_main.a
                 ${BINARY_DIR}/lib/libgtest.a ${BINARY_DIR}/lib/libgtest_main.a PARENT_SCOPE)
+
+    elseif (dep STREQUAL "openssl")
+        set(BINARY_DIR ${PROJECT_BINARY_DIR}/openssl-build)
+        ExternalProject_Add(
+                openssl
+                URL ${PHOTON_OPENSSL_SOURCE}
+                URL_MD5 bad68bb6bd9908da75e2c8dedc536b29
+                BUILD_IN_SOURCE ON
+                CONFIGURE_COMMAND ./config -fPIC no-unit-test no-shared --openssldir=${BINARY_DIR} --prefix=${BINARY_DIR}
+                BUILD_COMMAND make depend -j ${NumCPU} && make -j ${NumCPU}
+                INSTALL_COMMAND make install
+        )
+        ExternalProject_Get_Property(openssl SOURCE_DIR)
+        set(OPENSSL_ROOT_DIR ${SOURCE_DIR} PARENT_SCOPE)
+        set(OPENSSL_INCLUDE_DIRS ${BINARY_DIR}/include PARENT_SCOPE)
+        set(OPENSSL_LIBRARIES ${BINARY_DIR}/lib/libssl.a ${BINARY_DIR}/lib/libcrypto.a PARENT_SCOPE)
+
+    elseif (dep STREQUAL "curl")
+        if (${OPENSSL_ROOT_DIR} STREQUAL "")
+            message(FATAL_ERROR "OPENSSL_ROOT_DIR not exist")
+        endif ()
+        set(BINARY_DIR ${PROJECT_BINARY_DIR}/curl-build)
+        ExternalProject_Add(
+                curl
+                URL ${PHOTON_CURL_SOURCE}
+                URL_MD5 a66270f11e3fbfad709600bbd1686704
+                BUILD_IN_SOURCE ON
+                CONFIGURE_COMMAND export CC=${CMAKE_C_COMPILER} && export CXX=${CMAKE_CXX_COMPILER} &&
+                    export LD=${CMAKE_LINKER} && export CFLAGS=-fPIC &&
+                    autoreconf -i && ./configure --with-ssl=${OPENSSL_ROOT_DIR}
+                    --without-libssh2 --enable-static --enable-shared=no --enable-optimize
+                    --disable-manual --without-libidn
+                    --disable-ftp --disable-file --disable-ldap --disable-ldaps
+                    --disable-rtsp --disable-dict --disable-telnet --disable-tftp
+                    --disable-pop3 --disable-imap --disable-smb --disable-smtp
+                    --disable-gopher --without-nghttp2 --enable-http
+                    --with-pic=PIC --prefix=${BINARY_DIR}
+                BUILD_COMMAND make -j ${NumCPU}
+                INSTALL_COMMAND make install
+        )
+        set(CURL_INCLUDE_DIRS ${BINARY_DIR}/include PARENT_SCOPE)
+        set(CURL_LIBRARIES ${BINARY_DIR}/lib/libcurl.a PARENT_SCOPE)
     endif ()
 
     list(APPEND actually_built ${dep})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ option(PHOTON_ENABLE_EXTFS "enable extfs" OFF)
 option(PHOTON_BUILD_DEPENDENCIES "" OFF)
 set(PHOTON_AIO_SOURCE "https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz" CACHE STRING "")
 set(PHOTON_ZLIB_SOURCE "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz" CACHE STRING "")
-set(PHOTON_OPENSSL_SOURCE "" CACHE STRING "")
-set(PHOTON_CURL_SOURCE "" CACHE STRING "")
+set(PHOTON_OPENSSL_SOURCE "https://github.com/openssl/openssl/archive/refs/heads/OpenSSL_1_0_2-stable.tar.gz" CACHE STRING "")
+set(PHOTON_CURL_SOURCE "https://github.com/curl/curl/archive/refs/tags/curl-7_42_1.tar.gz" CACHE STRING "")
 set(PHOTON_URING_SOURCE "https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz" CACHE STRING "")
 set(PHOTON_FUSE_SOURCE "" CACHE STRING "")
 set(PHOTON_GSASL_SOURCE "" CACHE STRING "")
@@ -96,7 +96,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/output)
 ################################################################################
 
 # There are two ways to handle dependencies:
-#   1. Find locally installed packages. (Static lib is suggested)
+#   1. Find locally installed packages.
 #   2. Build it from source. (Only when PHOTON_BUILD_DEPENDENCIES is set, and PHOTON_XXX_SOURCE is not empty)
 #
 # The naming conventions MUST obey:
@@ -196,21 +196,22 @@ endif ()
 
 # An object library compiles source files but does not archive or link their object files.
 add_library(photon_obj OBJECT ${PHOTON_SRC})
-target_include_directories(photon_obj PUBLIC include ${OPENSSL_INCLUDE_DIRS} ${AIO_INCLUDE_DIRS}
-        ${ZLIB_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS})
+target_include_directories(photon_obj PRIVATE include ${OPENSSL_INCLUDE_DIRS} ${AIO_INCLUDE_DIRS}
+        ${ZLIB_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS}
+)
 target_compile_definitions(photon_obj PRIVATE _FILE_OFFSET_BITS=64 FUSE_USE_VERSION=29)
 if (PHOTON_ENABLE_URING)
-    target_include_directories(photon_obj PUBLIC ${URING_INCLUDE_DIRS})
+    target_include_directories(photon_obj PRIVATE ${URING_INCLUDE_DIRS})
     target_compile_definitions(photon_obj PRIVATE PHOTON_URING=on)
 endif()
 if (PHOTON_ENABLE_MIMIC_VDSO)
     target_compile_definitions(photon_obj PRIVATE ENABLE_MIMIC_VDSO=on)
 endif()
 if (PHOTON_ENABLE_FSTACK_DPDK)
-    target_include_directories(photon_obj PUBLIC ${FSTACK_INCLUDE_DIRS})
+    target_include_directories(photon_obj PRIVATE ${FSTACK_INCLUDE_DIRS})
 endif()
 if (PHOTON_ENABLE_EXTFS)
-    target_include_directories(photon_obj PUBLIC ${LIBE2FS_INCLUDE_DIRS})
+    target_include_directories(photon_obj PRIVATE ${LIBE2FS_INCLUDE_DIRS})
 endif()
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
     # This option is enabled by default after -std=c++17
@@ -226,9 +227,9 @@ endif ()
 set(static_deps
         easy_weak
         fstack_weak
-        ${ZLIB_LIBRARIES}
-        ${OPENSSL_LIBRARIES}
         ${CURL_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        ${ZLIB_LIBRARIES}
 )
 set(shared_deps
         -lpthread
@@ -256,8 +257,8 @@ if (PHOTON_ENABLE_EXTFS)
     list(APPEND static_deps ${E2FS_LIBRARIES})
 endif ()
 
-# It's OK to have some `shared_deps` duplicated in `static_deps`.
-# Even though .a is suggested, we may still probably find .so in local installed dir.
+# Find out dynamic libs and append to `shared_deps`.
+# Because if not built from source, we won't know the local packages are static or shared.
 # This is for the max compatability.
 if (NOT APPLE)
     set(suffix "\.so$")
@@ -271,9 +272,6 @@ foreach (dep ${static_deps})
             break()
         endif ()
     endforeach ()
-    if (dep MATCHES "\.a$")
-        list(APPEND static_deps_archive ${dep})
-    endif ()
 endforeach ()
 
 set(version_scripts)
@@ -284,6 +282,7 @@ list(APPEND version_scripts "-Wl,--version-script=${PROJECT_SOURCE_DIR}/tools/li
 # Link photon shared lib
 add_library(photon_shared SHARED $<TARGET_OBJECTS:photon_obj>)
 set_target_properties(photon_shared PROPERTIES OUTPUT_NAME photon)
+target_include_directories(photon_shared PUBLIC include ${CURL_INCLUDE_DIRS})
 if (NOT APPLE)
     target_link_libraries(photon_shared
             PRIVATE ${version_scripts} -Wl,--whole-archive ${static_deps} -Wl,--no-whole-archive
@@ -299,32 +298,39 @@ endif ()
 # Link photon static lib
 add_library(photon_static STATIC $<TARGET_OBJECTS:photon_obj>)
 set_target_properties(photon_static PROPERTIES OUTPUT_NAME photon_sole)
+target_include_directories(photon_static PUBLIC include ${CURL_INCLUDE_DIRS})
 target_link_libraries(photon_static
         PUBLIC ${shared_deps}
         PRIVATE ${static_deps}
 )
 
-# Merge static libs into libphoton.a
-# Do NOT use this target directly.
+# Merge static libs into libphoton.a for manual distribution.
+# Do NOT link to this target directly.
 if (NOT APPLE)
-    set(merge_command ar -crT libphoton.a)
+    add_custom_target(_photon_static_archive ALL
+            COMMAND rm -rf libphoton.a
+            COMMAND ar -qcT libphoton.a $<TARGET_FILE:photon_static> $<TARGET_FILE:easy_weak> $<TARGET_FILE:fstack_weak>
+            COMMAND ar -M < ${PROJECT_SOURCE_DIR}/tools/libphoton.mri
+            DEPENDS photon_static
+            WORKING_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+            VERBATIM
+    )
 else ()
-    set(merge_command libtool -static -o libphoton.a)
+    add_custom_target(_photon_static_archive ALL
+            COMMAND rm -rf libphoton.a
+            COMMAND libtool -static -o libphoton.a $<TARGET_FILE:photon_static> $<TARGET_FILE:easy_weak> $<TARGET_FILE:fstack_weak>
+            DEPENDS photon_static
+            WORKING_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+            VERBATIM
+    )
 endif ()
-add_custom_target(_photon_static_archive ALL
-        COMMAND rm -rf libphoton.a
-        COMMAND ${merge_command} $<TARGET_FILE:photon_static> $<TARGET_FILE:easy_weak> $<TARGET_FILE:fstack_weak>
-        DEPENDS photon_static
-        WORKING_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
-        VERBATIM
-)
 
 # Build test cases
 if (PHOTON_BUILD_TESTING)
     include(CTest)
 
-    set(testing_libs ${GFLAGS_LIBRARIES} ${GOOGLETEST_LIBRARIES})
-    include_directories(${GFLAGS_INCLUDE_DIRS} ${GOOGLETEST_INCLUDE_DIRS})
+    include_directories(photon_static ${GFLAGS_INCLUDE_DIRS} ${GOOGLETEST_INCLUDE_DIRS})
+    link_libraries(${GFLAGS_LIBRARIES} ${GOOGLETEST_LIBRARIES})
 
     add_subdirectory(examples)
     add_subdirectory(common/checksum/test)

--- a/common/checksum/test/CMakeLists.txt
+++ b/common/checksum/test/CMakeLists.txt
@@ -1,8 +1,6 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 SET(TEST_WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}/)
 ADD_DEFINITIONS(-w -DDATA_DIR=${TEST_WORKING_DIR})
 
 add_executable(test-checksum test_checksum.cpp)
-target_link_libraries(test-checksum PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-checksum PRIVATE photon_shared)
 add_test(NAME test-checksum COMMAND $<TARGET_FILE:test-checksum>)

--- a/common/estring.h
+++ b/common/estring.h
@@ -321,12 +321,8 @@ protected:
     }
 
 public:
-    constexpr rstring_view() = default; // note: don't give _offset or _length
-                                        // an initial value and do not
-                                        // assigned them in default ctor()
-                                        // it would caused verb_init() error
-    rstring_view(uint64_t offset, uint64_t length)
-    {
+    constexpr rstring_view() = default;
+    constexpr rstring_view(uint64_t offset, uint64_t length) {
         assert(offset <= std::numeric_limits<OffsetType>::max());
         assert(length <= std::numeric_limits<LengthType>::max());
         _offset = (OffsetType)offset;

--- a/common/identity-pool.cpp
+++ b/common/identity-pool.cpp
@@ -49,8 +49,8 @@ void IdentityPoolBase::put(void* obj)
             m_mtx.lock();
         }
         --m_refcnt;
+        m_cvar.notify_all();
     }
-    m_cvar.notify_all();
     assert(m_size <= m_capacity);
 }
 

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -1,32 +1,30 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 SET(TEST_WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}/)
 ADD_DEFINITIONS(-w -DDATA_DIR=${TEST_WORKING_DIR})
 
 add_executable(test-objcache test_objcache.cpp)
-target_link_libraries(test-objcache PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-objcache PRIVATE photon_shared)
 add_test(NAME test-objcache COMMAND $<TARGET_FILE:test-objcache>)
 
 add_executable(test-common test.cpp)
-target_link_libraries(test-common PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-common PRIVATE photon_shared)
 add_test(NAME test-common COMMAND $<TARGET_FILE:test-common>)
 
 add_executable(test-scalepool test_scalepool.cpp)
-target_link_libraries(test-scalepool PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-scalepool PRIVATE photon_shared)
 add_test(NAME test-scalepool COMMAND $<TARGET_FILE:test-scalepool>)
 
 add_executable(test-throttle test_throttle.cpp)
-target_link_libraries(test-throttle PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-throttle PRIVATE photon_shared)
 add_test(NAME test-throttle COMMAND $<TARGET_FILE:test-throttle>)
 
 add_executable(test-constexprstr test_constexprstr.cpp)
-target_link_libraries(test-constexprstr PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-constexprstr PRIVATE photon_shared)
 add_test(NAME test-constexprstr COMMAND $<TARGET_FILE:test-constexprstr>)
 
 #add_executable(test-lockfree test_lockfree.cpp)
-#target_link_libraries(test-lockfree PRIVATE photon_shared ${testing_libs})
+#target_link_libraries(test-lockfree PRIVATE photon_shared)
 #add_test(NAME test-lockfree COMMAND $<TARGET_FILE:test-lockfree>)
 
 add_executable(test-alog test_alog.cpp x.cpp)
-target_link_libraries(test-alog PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-alog PRIVATE photon_shared)
 add_test(NAME test-alog COMMAND $<TARGET_FILE:test-alog>)

--- a/doc/docs/introduction/how-to-build.md
+++ b/doc/docs/introduction/how-to-build.md
@@ -85,8 +85,7 @@ cmake --build build -j
 
 ```bash
 cd PhotonLibOS
-# Use `brew info openssl` to find openssl path
-cmake -B build -D OPENSSL_ROOT_DIR=/path/to/openssl/
+cmake -B build
 cmake --build build -j
 ```
 
@@ -178,3 +177,10 @@ ctest
 | PHOTON_ENABLE_FSTACK_DPDK |   OFF   |          Enable F-Stack and DPDK. Requires both.          |
 |    PHOTON_ENABLE_EXTFS    |   OFF   |             Enable extfs. Requires `libe2fs`              |
 
+#### Example
+
+If there is any shared lib you don't want Photon to link to on local host, build its static from source.
+
+```bash
+cmake -B build -D PHOTON_BUILD_DEPENDENCIES=ON -D PHOTON_GFLAGS_SOURCE=https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz
+```

--- a/doc/docs/introduction/how-to-build.md
+++ b/doc/docs/introduction/how-to-build.md
@@ -179,8 +179,18 @@ ctest
 
 #### Example
 
-If there is any shared lib you don't want Photon to link to on local host, build its static from source.
+Build all the dependencies from source, so you can distribute Photon binary anywhere, as long as libc and libc++ versions suffice.
 
 ```bash
-cmake -B build -D PHOTON_BUILD_DEPENDENCIES=ON -D PHOTON_GFLAGS_SOURCE=https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz
+cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+-D PHOTON_BUILD_TESTING=ON \
+-D PHOTON_BUILD_DEPENDENCIES=ON \
+-D PHOTON_ENABLE_URING=ON \
+-D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_ZLIB_SOURCE=https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz \
+-D PHOTON_URING_SOURCE=https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz \
+-D PHOTON_CURL_SOURCE=https://github.com/curl/curl/archive/refs/tags/curl-7_42_1.tar.gz \
+-D PHOTON_OPENSSL_SOURCE=https://github.com/openssl/openssl/archive/refs/heads/OpenSSL_1_0_2-stable.tar.gz \
+-D PHOTON_GFLAGS_SOURCE=https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz \
+-D PHOTON_GOOGLETEST_SOURCE=https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz
 ```

--- a/doc/docs/introduction/how-to-integrate.md
+++ b/doc/docs/introduction/how-to-integrate.md
@@ -7,7 +7,7 @@ toc_max_heading_level: 4
 
 We recommend using CMake's `FetchContent` to integrate Photon into your existing C++ project.
 
-It will download source code from the remote repo and track along with the dependencies (for example, liburing).
+It will download source code from the remote repo and track along with the third-party dependencies.
 
 ### Modify your `CMakeLists.txt`
 
@@ -30,15 +30,12 @@ FetchContent_Declare(
     GIT_TAG main
 )
 FetchContent_MakeAvailable(photon)
-
-set(PHOTON_INCLUDE_DIR ${photon_SOURCE_DIR}/include/)
 ```
 
 ### Case 1: Statically linking your app with Photon
 
 ```cmake
 add_executable(my_app ${SOURCES})
-target_include_directories(my_app PRIVATE ${PHOTON_INCLUDE_DIR})
 target_link_libraries(my_app photon_static)
 ```
 
@@ -46,7 +43,6 @@ target_link_libraries(my_app photon_static)
 
 ```cmake
 add_executable(my_app ${SOURCES})
-target_include_directories(my_app PRIVATE ${PHOTON_INCLUDE_DIR})
 target_link_libraries(my_app photon_shared)
 ```
 
@@ -54,17 +50,19 @@ target_link_libraries(my_app photon_shared)
 
 ```cmake
 add_library(my_lib STATIC ${SOURCES})
-target_include_directories(my_lib PRIVATE ${PHOTON_INCLUDE_DIR})
-target_link_libraries(my_lib photon_static)
+target_link_libraries(my_lib PRIVATE photon_static)
 ```
 
 ### Case 4: Add Photon into your shared lib
 
 ```cmake
 add_library(my_lib SHARED ${SOURCES})
-target_include_directories(my_lib PRIVATE ${PHOTON_INCLUDE_DIR})
-target_link_libraries(my_lib -Wl,--whole-archive photon_static -Wl,--no-whole-archive)
+target_link_libraries(my_lib PRIVATE -Wl,--whole-archive libphoton.a -Wl,--no-whole-archive)
 ```
+
+:::note
+The `photon_static` and `photon_shared` targets have already configured include directories for you.
+:::
 
 :::note
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(rpc-example-client PRIVATE photon_static ${testing_libs})
 add_executable(rpc-example-server rpc/server.cpp rpc/server_main.cpp)
 target_link_libraries(rpc-example-server PRIVATE photon_static ${testing_libs})
 
+add_executable(sync-primitive sync-primitive/sync-primitive.cpp)
+target_link_libraries(sync-primitive PRIVATE photon_static ${testing_libs})
+
 if (ENABLE_FSTACK_DPDK)
     add_executable(fstack-dpdk-demo fstack-dpdk/fstack-dpdk-demo.cpp)
     target_link_libraries(fstack-dpdk-demo PRIVATE fstack_dpdk photon_static ${testing_libs})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,9 +13,6 @@ target_link_libraries(rpc-example-server PRIVATE photon_static)
 add_executable(sync-primitive sync-primitive/sync-primitive.cpp)
 target_link_libraries(sync-primitive PRIVATE photon_static)
 
-add_executable(sync-primitive sync-primitive/sync-primitive.cpp)
-target_link_libraries(sync-primitive PRIVATE photon_static ${testing_libs})
-
 if (ENABLE_FSTACK_DPDK)
     add_executable(fstack-dpdk-demo fstack-dpdk/fstack-dpdk-demo.cpp)
     target_link_libraries(fstack-dpdk-demo PRIVATE fstack_dpdk photon_static)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,22 +1,22 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-
 add_executable(simple-example simple/simple.cpp)
 target_link_libraries(simple-example PRIVATE photon_static)
 
 add_executable(net-perf perf/net-perf.cpp)
-target_link_libraries(net-perf PRIVATE photon_static ${testing_libs})
+target_link_libraries(net-perf PRIVATE photon_static)
 
 add_executable(rpc-example-client rpc/client.cpp rpc/client_main.cpp)
-target_link_libraries(rpc-example-client PRIVATE photon_static ${testing_libs})
+target_link_libraries(rpc-example-client PRIVATE photon_static)
 
 add_executable(rpc-example-server rpc/server.cpp rpc/server_main.cpp)
-target_link_libraries(rpc-example-server PRIVATE photon_static ${testing_libs})
+target_link_libraries(rpc-example-server PRIVATE photon_static)
+
+add_executable(sync-primitive sync-primitive/sync-primitive.cpp)
+target_link_libraries(sync-primitive PRIVATE photon_static)
 
 add_executable(sync-primitive sync-primitive/sync-primitive.cpp)
 target_link_libraries(sync-primitive PRIVATE photon_static ${testing_libs})
 
 if (ENABLE_FSTACK_DPDK)
     add_executable(fstack-dpdk-demo fstack-dpdk/fstack-dpdk-demo.cpp)
-    target_link_libraries(fstack-dpdk-demo PRIVATE fstack_dpdk photon_static ${testing_libs})
+    target_link_libraries(fstack-dpdk-demo PRIVATE fstack_dpdk photon_static)
 endif ()

--- a/examples/sync-primitive/sync-primitive.cpp
+++ b/examples/sync-primitive/sync-primitive.cpp
@@ -1,0 +1,144 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is an example of synchronization primitives, also comparing the performance of
+// std::condition_variable and photon::semaphore. Note that std::binary_semaphore was not added
+// until C++20. Before that, cv is the only alternative.
+//
+// Test results:
+// std:     QPS 1231796, latency 8303 ns
+// Photon:  QPS 1102088, latency 10051 ns
+
+#include <mutex>
+#include <condition_variable>
+#include <chrono>
+
+#include <photon/photon.h>
+#include <photon/common/alog.h>
+#include <photon/common/lockfree_queue.h>
+#include <photon/thread/workerpool.h>
+#include <photon/thread/thread11.h>
+
+// Comment/uncomment this macro to trigger std or photon
+#define PHOTON
+
+struct Message {
+    photon::semaphore sem;
+    std::mutex mu;
+    std::condition_variable cv;
+    bool done = false;
+    std::chrono::time_point<std::chrono::steady_clock> start;
+};
+
+static const int num_producers = 16, num_consumers = 16;
+static LockfreeMPMCRingQueue<Message*, 1024 * 1024> ring;
+static std::atomic<uint64_t> qps{0}, latency{0};
+
+__attribute__ ((noinline))
+static void do_fill(char* buf, size_t size) {
+    memset(buf, 0, size);
+}
+
+// A function that costs approximately 1 us
+static void func_1us() {
+    for (int i = 0; i < 5; ++i) {
+        constexpr size_t size = 32 * 1024;
+        char buf[size];
+        do_fill(buf, size);
+    }
+}
+
+int main() {
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+    photon::WorkPool wp(num_producers, photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE, 128 * 1024);
+
+    // Setup some producer vCPUs/threads, continuously adding messages into the lock-free ring queue.
+    // Use semaphore.wait() for cv.wait() to wait for the messages been processed by the consumers.
+#ifdef PHOTON
+    for (int i = 0; i < num_producers; ++i) {
+        wp.async_call(new auto([] {
+            while (true) {
+                func_1us();
+                Message message;
+                ring.push(&message);
+                message.sem.wait(1);
+                auto end = std::chrono::steady_clock::now();
+                auto duration_us = std::chrono::duration_cast<std::chrono::nanoseconds>(end - message.start).count();
+                latency.fetch_add(duration_us, std::memory_order::memory_order_relaxed);
+                qps.fetch_add(1, std::memory_order::memory_order_relaxed);
+            }
+        }));
+    }
+#else
+    for (int i = 0; i < num_producers; ++i) {
+        new std::thread([] {
+            while (true) {
+                func_1us();
+                Message message;
+                ring.push(&message);
+                {
+                    std::unique_lock l(message.mu);
+                    message.cv.wait(l, [&] { return message.done; });
+                }
+                auto end = std::chrono::steady_clock::now();
+                auto duration_us = std::chrono::duration_cast<std::chrono::nanoseconds>(end - message.start).count();
+                latency.fetch_add(duration_us, std::memory_order::memory_order_relaxed);
+                qps.fetch_add(1, std::memory_order::memory_order_relaxed);
+            }
+        });
+    }
+#endif
+
+    // Setup some consumer std::threads, busy polling.
+    // Continuously process messages from the ring queue, and then notify the consumer.
+    for (int i = 0; i < num_consumers; ++i) {
+        new std::thread([&] {
+            while (true) {
+                func_1us();
+                Message* m;
+                bool ok = ring.pop_weak(m);
+                if (!ok)
+                    continue;
+                m->start = std::chrono::steady_clock::now();
+#ifdef PHOTON
+                m->sem.signal(1);
+#else
+                {
+                    std::unique_lock l(m->mu);
+                    m->done = true;
+                    m->cv.notify_one();
+                }
+#endif
+            }
+        });
+    }
+
+    // Show QPS and latency
+    photon::thread_create11([&] {
+        photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+        while (true) {
+            photon::thread_sleep(1);
+            auto prev_qps = qps.exchange(0, std::memory_order_seq_cst);
+            auto prev_lat = latency.exchange(0, std::memory_order_seq_cst);
+            if (prev_qps != 0)
+                prev_lat = prev_lat / prev_qps;
+            LOG_INFO("QPS `, latency ` ns", prev_qps, prev_lat);
+        }
+    });
+
+    photon::thread_sleep(-1);
+}
+

--- a/fs/extfs/mkfs.cpp
+++ b/fs/extfs/mkfs.cpp
@@ -116,6 +116,7 @@ int do_mkfs(io_manager manager, size_t size, char *uuid) {
         return ret;
     }
     // reserve inodes
+    ext2fs_inode_alloc_stats2(fs, EXT2_BAD_INO, +1, 0);
     for (ext2_ino_t i = EXT2_ROOT_INO + 1; i < EXT2_FIRST_INODE(fs->super); i++)
         ext2fs_inode_alloc_stats2(fs, i, +1, 0);
     ext2fs_mark_ib_dirty(fs);

--- a/fs/extfs/test/CMakeLists.txt
+++ b/fs/extfs/test/CMakeLists.txt
@@ -1,8 +1,6 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-extfs test.cpp)
-target_link_libraries(test-extfs PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-extfs PRIVATE photon_shared)
 
 add_test(NAME test-extfs COMMAND $<TARGET_FILE:test-extfs>)

--- a/fs/test/CMakeLists.txt
+++ b/fs/test/CMakeLists.txt
@@ -1,19 +1,17 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-fs test.cpp)
-target_link_libraries(test-fs PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-fs PRIVATE photon_shared)
 add_test(NAME test-fs COMMAND $<TARGET_FILE:test-fs>)
 
 # add_executable(test-exportfs test_exportfs.cpp)
-# target_link_libraries(test-exportfs PRIVATE photon_static ${testing_libs})
+# target_link_libraries(test-exportfs PRIVATE photon_static)
 # add_test(NAME test-exportfs COMMAND $<TARGET_FILE:test-exportfs>)
 
 add_executable(test-filecopy test_filecopy.cpp)
-target_link_libraries(test-filecopy PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-filecopy PRIVATE photon_shared)
 add_test(NAME test-filecopy COMMAND $<TARGET_FILE:test-filecopy>)
 
 add_executable(test-throttled test_throttledfile.cpp)
-target_link_libraries(test-throttled PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-throttled PRIVATE photon_shared)
 add_test(NAME test-throttled COMMAND $<TARGET_FILE:test-throttled>)

--- a/io/test/CMakeLists.txt
+++ b/io/test/CMakeLists.txt
@@ -1,21 +1,19 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(signalfdtest signalfdtest.cpp)
-target_link_libraries(signalfdtest PRIVATE photon_shared ${testing_libs})
+target_link_libraries(signalfdtest PRIVATE photon_shared)
 add_test(NAME signalfdtest COMMAND $<TARGET_FILE:signalfdtest>)
 
 add_executable(signalfdboom signalfdboom.cpp)
-target_link_libraries(signalfdboom PRIVATE photon_shared ${testing_libs})
+target_link_libraries(signalfdboom PRIVATE photon_shared)
 add_test(NAME signalfdboom COMMAND $<TARGET_FILE:signalfdboom>)
 
 if (NOT APPLE)
 add_executable(test-syncio test-syncio.cpp)
-target_link_libraries(test-syncio PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-syncio PRIVATE photon_shared)
 add_test(NAME test-syncio COMMAND $<TARGET_FILE:test-syncio>)
 
 add_executable(test-iouring test-iouring.cpp)
-target_link_libraries(test-iouring PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-iouring PRIVATE photon_shared)
 add_test(NAME test-iouring COMMAND $<TARGET_FILE:test-iouring>)
 endif ()

--- a/net/http/client.h
+++ b/net/http/client.h
@@ -133,7 +133,7 @@ protected:
 };
 
 //A Client without cookie_jar would ignore all response-header "Set-Cookies"
-Client* new_http_client(ICookieJar *cookie_jar = nullptr, bool ipv6 = false);
+Client* new_http_client(ICookieJar *cookie_jar = nullptr);
 
 ICookieJar* new_simple_cookie_jar();
 

--- a/net/http/headers.cpp
+++ b/net/http/headers.cpp
@@ -64,11 +64,6 @@ HeadersBase::iterator HeadersBase::find(std::string_view key) const {
     return {this, (uint16_t)(it - kv_begin())};
 }
 
-void buf_append(char*& ptr, std::string_view sv) {
-    memcpy(ptr, sv.data(), sv.size());
-    ptr += sv.size();
-}
-
 void buf_append(char*& ptr, uint64_t x) {
     auto begin = ptr;
     do {

--- a/net/http/headers.h
+++ b/net/http/headers.h
@@ -29,8 +29,12 @@ namespace photon {
 namespace net {
 namespace http {
 
-void buf_append(char*& ptr, std::string_view sv);
 void buf_append(char*& ptr, uint64_t x);
+
+inline void buf_append(char*& ptr, std::string_view sv) {
+    memcpy(ptr, sv.data(), sv.size());
+    ptr += sv.size();
+}
 
 class HeadersBase {
 public:

--- a/net/http/message.h
+++ b/net/http/message.h
@@ -57,7 +57,7 @@ public:
     void reset(void* buf, uint16_t buf_capacity, bool buf_ownership = false,
                 ISocketStream* s = nullptr, bool stream_ownership = false) {
         reset(s, stream_ownership);
-        if (m_buf_ownership && m_buf) {
+        if (m_buf_ownership) {
             free(m_buf);
         }
         m_buf = (char*)buf;

--- a/net/http/status.cpp
+++ b/net/http/status.cpp
@@ -17,7 +17,103 @@ limitations under the License.
 #include "photon/common/string_view.h"
 #include "message.h"
 
+struct SV : public std::string_view {
+	template<size_t N>
+	constexpr SV(const char(&s)[N]) : SV(s, N) { }
+	constexpr SV(const char* s, size_t n) : std::string_view(s, n) { }
+};
+
+constexpr static SV code_str[] = {
+	/*100*/ "Continue",
+	/*101*/ "Switching Protocols",
+	/*102*/ "Processing",
+	/*103*/ "Early Hints",
+
+	/*200*/ "OK",
+	/*201*/ "Created",
+	/*202*/ "Accepted",
+	/*203*/ "Non-Authoritative Information",
+	/*204*/ "No Content",
+	/*205*/ "Reset Content",
+	/*206*/ "Partial Content",
+	/*207*/ "Multi-Status",
+	/*208*/ "Already Reported",
+//	/*226*/ "IM Used",
+
+	/*300*/ "Multiple Choices",
+	/*301*/ "Moved Permanently",
+	/*302*/ "Found",
+	/*303*/ "See Other",
+	/*304*/ "Not Modified",
+	/*305*/ "Use Proxy",
+	/*306*/ {0, 0},
+	/*307*/ "Temporary Redirect",
+	/*308*/ "Permanent Redirect",
+
+	/*400*/ "Bad Request",
+	/*401*/ "Unauthorized",
+	/*402*/ "Payment Required",
+	/*403*/ "Forbidden",
+	/*404*/ "Not Found",
+	/*405*/ "Method Not Allowed",
+	/*406*/ "Not Acceptable",
+	/*407*/ "Proxy Authentication Required",
+	/*408*/ "Request Timeout",
+	/*409*/ "Conflict",
+	/*410*/ "Gone",
+	/*411*/ "Length Required",
+	/*412*/ "Precondition Failed",
+	/*413*/ "Content Too Large",
+	/*414*/ "URI Too Long",
+	/*415*/ "Unsupported Media Type",
+	/*416*/ "Range Not Satisfiable",
+	/*417*/ "Expectation Failed",
+	/*418*/ "I'm a teapot",
+	/*419*/ {0, 0},
+	/*420*/ {0, 0},
+	/*421*/ "Misdirected Request",
+	/*422*/ "Unprocessable Content",
+	/*423*/ "Locked",
+	/*424*/ "Failed Dependency",
+	/*425*/ "Too Early",
+	/*426*/ "Upgrade Required",
+	/*427*/ {0, 0},
+	/*428*/ "Precondition Required",
+	/*429*/ "Too Many Requests",
+	/*430*/ {0, 0},
+	/*431*/ "Request Header Fields Too Large",
+//	/*451*/ "Unavailable For Legal Reasons",
+
+	/*500*/ "Internal Server Error",
+	/*501*/ "Not Implemented",
+	/*502*/ "Bad Gateway",
+	/*503*/ "Service Unavailable",
+	/*504*/ "Gateway Timeout",
+	/*505*/ "HTTP Version Not Supported",
+	/*506*/ "Variant Also Negotiates",
+	/*507*/ "Insufficient Storage",
+	/*508*/ "Loop Detected",
+	/*509*/ {0, 0},
+	/*510*/ "Not Extended",
+	/*511*/ "Network Authentication Required",
+};
+
+const static uint8_t LEN1xx = 4;
+const static uint8_t LEN2xx = 9 + LEN1xx;
+const static uint8_t LEN3xx = 9 + LEN2xx;
+const static uint8_t LEN4xx = 32 + LEN3xx;
+const static uint8_t LEN5xx = 12 + LEN4xx;
+uint8_t entries[] = {0, LEN1xx, LEN2xx, LEN3xx, LEN4xx, LEN5xx};
+
 std::string_view photon::net::http::obsolete_reason(int code) {
+	uint8_t major = code / 100 - 1;
+	uint8_t minor = code % 100;
+	if (unlikely(major > 4)) return {};
+	uint8_t max = entries[major+1] - entries[major];
+	if (unlikely(minor >= max)) return {};
+	return code_str[entries[major] + minor];
+
+/*
 	switch (code){
 
 	case 100: return "Continue";
@@ -87,6 +183,7 @@ std::string_view photon::net::http::obsolete_reason(int code) {
 	case 510: return "Not Extended";
 	case 511: return "Network Authentication Required";
 
-	default: return "";
+	default: return { };
 	}
+*/
 }

--- a/net/http/test/CMakeLists.txt
+++ b/net/http/test/CMakeLists.txt
@@ -1,28 +1,26 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(client_perf client_perf.cpp)
-target_link_libraries(client_perf PRIVATE photon_shared ${testing_libs})
+target_link_libraries(client_perf PRIVATE photon_static)
 
 add_executable(server_perf server_perf.cpp)
-target_link_libraries(server_perf PRIVATE photon_shared ${testing_libs})
+target_link_libraries(server_perf PRIVATE photon_shared)
 
 add_executable(pure_libcurl pure_libcurl.cpp)
-target_link_libraries(pure_libcurl PRIVATE photon_shared ${testing_libs})
+target_link_libraries(pure_libcurl PRIVATE photon_static)
 
 add_executable(client_function_test client_function_test.cpp)
-target_link_libraries(client_function_test PRIVATE photon_shared ${testing_libs})
+target_link_libraries(client_function_test PRIVATE photon_shared)
 add_test(NAME client_function_test COMMAND $<TARGET_FILE:client_function_test>)
 
 add_executable(server_function_test server_function_test.cpp)
-target_link_libraries(server_function_test PRIVATE photon_shared ${testing_libs})
+target_link_libraries(server_function_test PRIVATE photon_shared)
 add_test(NAME server_function_test COMMAND $<TARGET_FILE:server_function_test>)
 
 add_executable(cookie_jar_test cookie_jar_test.cpp)
-target_link_libraries(cookie_jar_test PRIVATE photon_shared ${testing_libs})
+target_link_libraries(cookie_jar_test PRIVATE photon_shared)
 add_test(NAME cookie_jar_test COMMAND $<TARGET_FILE:cookie_jar_test>)
 
 add_executable(headers_test headers_test.cpp)
-target_link_libraries(headers_test PRIVATE photon_shared ${testing_libs})
+target_link_libraries(headers_test PRIVATE photon_shared)
 add_test(NAME headers_test COMMAND $<TARGET_FILE:headers_test>)

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -84,11 +84,12 @@ TEST(http_client, get) {
     auto op2 = client->new_operation(Verb::GET, target);
     DEFER(delete op2);
     op2->req.headers.content_length(0);
-    client->call(op2);
+    int ret = client->call(op2);
+    GTEST_ASSERT_EQ(0, ret);
 
     char resp_body_buf[1024];
     EXPECT_EQ(sizeof(socket_buf), op2->resp.resource_size());
-    auto ret = op2->resp.read(resp_body_buf, sizeof(socket_buf));
+    ret = op2->resp.read(resp_body_buf, sizeof(socket_buf));
     EXPECT_EQ(sizeof(socket_buf), ret);
     resp_body_buf[sizeof(socket_buf) - 1] = '\0';
     LOG_DEBUG(resp_body_buf);

--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 #include <photon/thread/thread11.h>
 #include <photon/thread/list.h>
 #include <photon/thread/timer.h>
+#include <photon/common/estring.h>
 #include <photon/common/utility.h>
 #include <photon/common/event-loop.h>
 #include <photon/net/basic_socket.h>
@@ -58,22 +59,6 @@ limitations under the License.
 #ifndef AF_SMC
 #define AF_SMC 43
 #endif
-
-LogBuffer& operator<<(LogBuffer& log, const in_addr& iaddr) {
-    return log << photon::net::IPAddr(iaddr);
-}
-LogBuffer& operator<<(LogBuffer& log, const in6_addr& iaddr) {
-    return log << photon::net::IPAddr(iaddr);
-}
-LogBuffer& operator<<(LogBuffer& log, const sockaddr_in& addr) {
-    return log << photon::net::sockaddr_storage(addr).to_endpoint();
-}
-LogBuffer& operator<<(LogBuffer& log, const sockaddr_in6& addr) {
-    return log << photon::net::sockaddr_storage(addr).to_endpoint();
-}
-LogBuffer& operator<<(LogBuffer& log, const sockaddr& addr) {
-    return log << photon::net::sockaddr_storage(addr).to_endpoint();
-}
 
 namespace photon {
 namespace net {
@@ -240,7 +225,12 @@ protected:
     ISocketStream* do_connect(const sockaddr* remote, socklen_t len_remote,
                               const sockaddr* local = nullptr, socklen_t len_local = 0) {
         auto stream = create_stream();
-        std::unique_ptr<KernelSocketStream> ptr(stream);
+        auto deleter = [&](KernelSocketStream*) {
+            auto errno_backup = errno;
+            delete stream;
+            errno = errno_backup;
+        };
+        std::unique_ptr<KernelSocketStream, decltype(deleter)> ptr(stream, deleter);
         if (!ptr || ptr->fd < 0) {
             LOG_ERROR_RETURN(0, nullptr, "Failed to create socket fd");
         }
@@ -983,25 +973,6 @@ protected:
 
 /* ET Socket - End */
 
-LogBuffer& operator<<(LogBuffer& log, const IPAddr addr) {
-    if (addr.is_ipv4())
-        return log.printf(addr.a, '.', addr.b, '.', addr.c, '.', addr.d);
-    else {
-        if (log.size < INET6_ADDRSTRLEN)
-            return log;
-        inet_ntop(AF_INET6, &addr.addr, log.ptr, INET6_ADDRSTRLEN);
-        log.consume(strlen(log.ptr));
-        return log;
-    }
-}
-
-LogBuffer& operator<<(LogBuffer& log, const EndPoint ep) {
-    if (ep.is_ipv4())
-        return log << ep.addr << ':' << ep.port;
-    else
-        return log << '[' << ep.addr << "]:" << ep.port;
-}
-
 extern "C" ISocketClient* new_tcp_socket_client() {
     return new KernelSocketClient(AF_INET, true);
 }
@@ -1063,5 +1034,61 @@ extern "C" ISocketServer* new_fstack_dpdk_socket_server() {
 #endif // ENABLE_FSTACK_DPDK
 #endif // __linux__
 
+////////////////////////////////////////////////////////////////////////////////
+
+/* Implementations in socket.h */
+
+EndPoint::EndPoint(const char* s) {
+    estring_view ep(s);
+    auto pos = ep.find_last_of(':');
+    if (pos == estring::npos)
+        return;
+    // Detect IPv6 or IPv4
+    estring ip_str = ep[pos - 1] == ']' ? ep.substr(1, pos - 2) : ep.substr(0, pos);
+    auto ip = IPAddr(ip_str.c_str());
+    if (ip.undefined())
+        return;
+    auto port_str = ep.substr(pos + 1);
+    if (!port_str.all_digits())
+        return;
+    addr = ip;
+    port = std::stoul(port_str);
 }
+
+LogBuffer& operator<<(LogBuffer& log, const IPAddr addr) {
+    if (addr.is_ipv4())
+        return log.printf(addr.a, '.', addr.b, '.', addr.c, '.', addr.d);
+    else {
+        if (log.size < INET6_ADDRSTRLEN)
+            return log;
+        inet_ntop(AF_INET6, &addr.addr, log.ptr, INET6_ADDRSTRLEN);
+        log.consume(strlen(log.ptr));
+        return log;
+    }
+}
+
+LogBuffer& operator<<(LogBuffer& log, const EndPoint ep) {
+    if (ep.is_ipv4())
+        return log << ep.addr << ':' << ep.port;
+    else
+        return log << '[' << ep.addr << "]:" << ep.port;
+}
+
+}
+}
+
+LogBuffer& operator<<(LogBuffer& log, const in_addr& iaddr) {
+    return log << photon::net::IPAddr(iaddr);
+}
+LogBuffer& operator<<(LogBuffer& log, const in6_addr& iaddr) {
+    return log << photon::net::IPAddr(iaddr);
+}
+LogBuffer& operator<<(LogBuffer& log, const sockaddr_in& addr) {
+    return log << photon::net::sockaddr_storage(addr).to_endpoint();
+}
+LogBuffer& operator<<(LogBuffer& log, const sockaddr_in6& addr) {
+    return log << photon::net::sockaddr_storage(addr).to_endpoint();
+}
+LogBuffer& operator<<(LogBuffer& log, const sockaddr& addr) {
+    return log << photon::net::sockaddr_storage(addr).to_endpoint();
 }

--- a/net/security-context/test/CMakeLists.txt
+++ b/net/security-context/test/CMakeLists.txt
@@ -1,14 +1,12 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-tls test.cpp)
-target_link_libraries(test-tls PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-tls PRIVATE photon_shared)
 add_test(NAME test-tls COMMAND $<TARGET_FILE:test-tls>)
 
 if (ENABLE_SASL AND (NOT (APPLE AND (${ARCH} STREQUAL arm64))))
     add_executable(test-sasl test-sasl.cpp)
-    target_link_libraries(test-sasl PRIVATE photon_shared ${testing_libs})
+    target_link_libraries(test-sasl PRIVATE photon_shared)
     add_test(NAME test-sasl COMMAND $<TARGET_FILE:test-sasl>)
 endif ()
 

--- a/net/socket.h
+++ b/net/socket.h
@@ -217,6 +217,10 @@ namespace net {
         virtual ssize_t recv(void *buf, size_t count, int flags = 0) = 0;
         virtual ssize_t recv(const struct iovec *iov, int iovcnt, int flags = 0) = 0;
 
+        // recv at `least` bytes to buffer (`buf`, `count`)
+        ssize_t recv_at_least(void* buf, size_t count, size_t least, int flags = 0);
+        ssize_t recv_at_least_mutable(struct iovec *iov, int iovcnt, size_t least, int flags = 0);
+
         // read count bytes and drop them
         // return true/false for success/failure
         bool skip_read(size_t count);

--- a/net/socket.h
+++ b/net/socket.h
@@ -150,6 +150,7 @@ namespace net {
         uint16_t port = 0;
         EndPoint() = default;
         EndPoint(IPAddr ip, uint16_t port) : addr(ip), port(port) {}
+        explicit EndPoint(const char* s);
         bool is_ipv4() const {
             return addr.is_ipv4();
         };

--- a/net/test/CMakeLists.txt
+++ b/net/test/CMakeLists.txt
@@ -1,28 +1,26 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-socket test.cpp)
-target_link_libraries(test-socket PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-socket PRIVATE photon_shared)
 add_test(NAME test-socket COMMAND $<TARGET_FILE:test-socket>)
 
 add_executable(test-dg-socket test-udp.cpp)
-target_link_libraries(test-dg-socket PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-dg-socket PRIVATE photon_shared)
 add_test(NAME test-dg-socket COMMAND $<TARGET_FILE:test-dg-socket>)
 
 add_executable(test-sockpool test_sockpool.cpp)
-target_link_libraries(test-sockpool PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-sockpool PRIVATE photon_shared)
 add_test(NAME test-sockpool COMMAND $<TARGET_FILE:test-sockpool>)
 
 add_executable(test-curl test_curl.cpp)
-target_link_libraries(test-curl PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-curl PRIVATE photon_static)
 add_test(NAME test-curl COMMAND $<TARGET_FILE:test-curl>)
 
 add_executable(test-server test-server.cpp)
-target_link_libraries(test-server PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-server PRIVATE photon_shared)
 
 add_executable(test-client test-client.cpp)
-target_link_libraries(test-client PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-client PRIVATE photon_shared)
 
 add_executable(test-ipv6 test-ipv6.cpp)
-target_link_libraries(test-ipv6 PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-ipv6 PRIVATE photon_shared)

--- a/net/test/test-ipv6.cpp
+++ b/net/test/test-ipv6.cpp
@@ -7,14 +7,28 @@
 #include <photon/net/utils.h>
 #include <photon/common/alog.h>
 
-TEST(ipv6, addr) {
-    EXPECT_NO_THROW(photon::net::IPAddr a("::1"));
-    EXPECT_NO_THROW(photon::net::IPAddr a("1.2.3.4"));
-    EXPECT_NO_THROW(photon::net::IPAddr a("fdbd:dc01:ff:312:9641:f71:10c4:2378"));
-    EXPECT_NO_THROW(photon::net::IPAddr a("fdbd:dc01:ff:312:9641:f71::2378"));
-    EXPECT_NO_THROW(photon::net::IPAddr a("fdbd:dc01:ff:312:9641::2378"));
+TEST(ipv6, endpoint) {
+    auto c = photon::net::EndPoint("127.0.0.1");
+    EXPECT_TRUE(c.undefined());
+    c = photon::net::EndPoint("127.0.0.1:8888");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::EndPoint("[::1]:8888");
+    EXPECT_FALSE(c.undefined());
+}
 
-    auto c = photon::net::IPAddr("zfdbd:dq01:8:165::158");
+TEST(ipv6, addr) {
+    auto c = photon::net::IPAddr("::1");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::IPAddr("::1");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::IPAddr("fdbd:dc01:ff:312:9641:f71:10c4:2378");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::IPAddr("fdbd:dc01:ff:312:9641:f71::2378");
+    EXPECT_FALSE(c.undefined());
+    c = photon::net::IPAddr("fdbd:dc01:ff:312:9641::2378");
+    EXPECT_FALSE(c.undefined());
+
+    c = photon::net::IPAddr("zfdbd:dq01:8:165::158");
     EXPECT_TRUE(c.undefined());
     c = photon::net::IPAddr("fdbd::ff:312:9641:f71::2378");
     EXPECT_TRUE(c.undefined());

--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -279,9 +279,9 @@ public:
                 LOG_WARN("Domain resolution for ` failed", host);
                 return new IPAddr;  // undefined addr
             }
-            for (auto& each : addrs) {
-                if ((each.is_ipv4() ^ !ipv6_) == 0)
-                    return new IPAddr(each);
+            for (auto& ip : addrs) {
+                if (ip.is_ipv4())
+                    return new IPAddr(ip);
             }
             return new IPAddr;      // undefined addr
         };

--- a/net/utils.h
+++ b/net/utils.h
@@ -153,7 +153,7 @@ bool zerocopy_available();
  */
 class Resolver : public Object {
 public:
-    // When failed, IPAddr(0) should be returned.
+    // When failed, return an Undefined IPAddr
     // Normally dns servers return multiple ips in random order, choosing the first one should suffice.
     virtual IPAddr resolve(const char* host) = 0;
     virtual void resolve(const char* host, Delegate<void, IPAddr> func) = 0;
@@ -165,9 +165,10 @@ public:
  *
  * @param cache_ttl cache's lifetime in microseconds.
  * @param resolve_timeout timeout in microseconds for domain resolution.
+ * @param ipv6 specify v4 or v6 domain name
  * @return Resolver*
  */
-Resolver* new_default_resolver(uint64_t cache_ttl = 3600UL * 1000000, uint64_t resolve_timeout = -1);
+Resolver* new_default_resolver(uint64_t cache_ttl = 3600UL * 1000000, uint64_t resolve_timeout = -1, bool ipv6 = false);
 
 }  // namespace net
 }

--- a/rpc/rpc.h
+++ b/rpc/rpc.h
@@ -234,8 +234,7 @@ namespace rpc
     };
 
     extern "C" Stub* new_rpc_stub(IStream* stream, bool ownership = false);
-    extern "C" StubPool* new_stub_pool(uint64_t expiration, uint64_t connect_timeout, uint64_t rpc_timeout,
-                                       bool ipv6 = false);
+    extern "C" StubPool* new_stub_pool(uint64_t expiration, uint64_t connect_timeout, uint64_t rpc_timeout);
     extern "C" StubPool* new_uds_stub_pool(const char* path, uint64_t expiration,
                                 uint64_t connect_timeout,
                                 uint64_t rpc_timeout);

--- a/rpc/test/CMakeLists.txt
+++ b/rpc/test/CMakeLists.txt
@@ -1,15 +1,13 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(test-rpc test.cpp)
-target_link_libraries(test-rpc PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-rpc PRIVATE photon_shared)
 add_test(NAME test-rpc COMMAND $<TARGET_FILE:test-rpc>)
 
 add_executable(test-ooo test-ooo.cpp)
-target_link_libraries(test-ooo PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-ooo PRIVATE photon_shared)
 add_test(NAME test-ooo COMMAND $<TARGET_FILE:test-ooo>)
 
 add_executable(test-rpc-message test-rpc-message.cpp)
-target_link_libraries(test-rpc-message PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-rpc-message PRIVATE photon_shared)
 add_test(NAME test-rpc-message COMMAND $<TARGET_FILE:test-rpc-message>)

--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -1,35 +1,33 @@
-include_directories(${CMAKE_SOURCE_DIR}/include)
-link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_definitions(-w)
 
 add_executable(perf_usleepdefer_semaphore perf_usleepdefer_semaphore.cpp)
-target_link_libraries(perf_usleepdefer_semaphore PRIVATE photon_shared ${testing_libs})
+target_link_libraries(perf_usleepdefer_semaphore PRIVATE photon_shared)
 add_test(NAME perf_usleepdefer_semaphore COMMAND $<TARGET_FILE:perf_usleepdefer_semaphore>)
 
 add_executable(test-thread test.cpp x.cpp)
-target_link_libraries(test-thread PRIVATE photon_static ${testing_libs})
+target_link_libraries(test-thread PRIVATE photon_static)
 add_test(NAME test-thread COMMAND $<TARGET_FILE:test-thread>)
 
 add_executable(test-std-compat test-std-compat.cpp)
-target_link_libraries(test-std-compat PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-std-compat PRIVATE photon_shared)
 add_test(NAME test-std-compat COMMAND $<TARGET_FILE:test-std-compat>)
 
 add_executable(test-specific-key test-specific-key.cpp)
-target_link_libraries(test-specific-key PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-specific-key PRIVATE photon_shared)
 add_test(NAME test-specific-key COMMAND $<TARGET_FILE:test-specific-key>)
 
 add_executable(test-thread-local test-thread-local.cpp)
-target_link_libraries(test-thread-local PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-thread-local PRIVATE photon_shared)
 add_test(NAME test-thread-local COMMAND $<TARGET_FILE:test-thread-local>)
 
 add_executable(test-tls-order-native test-tls-order-native.cpp)
-target_link_libraries(test-tls-order-native PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-tls-order-native PRIVATE photon_shared)
 add_test(NAME test-tls-order-native COMMAND $<TARGET_FILE:test-tls-order-native>)
 
 add_executable(test-tls-order-photon test-tls-order-photon.cpp)
-target_link_libraries(test-tls-order-photon PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-tls-order-photon PRIVATE photon_shared)
 add_test(NAME test-tls-order-photon COMMAND $<TARGET_FILE:test-tls-order-photon>)
 
 add_executable(test-lib-data test-lib-data.cpp)
-target_link_libraries(test-lib-data PRIVATE photon_shared ${testing_libs})
+target_link_libraries(test-lib-data PRIVATE photon_shared)
 add_test(NAME test-lib-data COMMAND $<TARGET_FILE:test-lib-data>)

--- a/thread/thread-pool.cpp
+++ b/thread/thread-pool.cpp
@@ -29,9 +29,37 @@ namespace photon
             pCtrl->joining = false;
             pCtrl->start = start;
             pCtrl->arg = arg;
+            pCtrl->cvar.notify_one();
         }
-        pCtrl->cvar.notify_one();
         return pCtrl;
+    }
+    bool ThreadPoolBase::wait_for_work(TPControl &ctrl)
+    {
+        SCOPED_LOCK(ctrl.m_mtx);
+        while (!ctrl.start)                     // wait for `create()` to give me
+            ctrl.cvar.wait(ctrl.m_mtx);           // thread_entry and argument
+
+        if (ctrl.start == &stub)
+            return false;
+
+        ((partial_thread*) CURRENT)->tls = nullptr;
+        return true;
+    }
+    bool ThreadPoolBase::after_work_done(TPControl &ctrl)
+    {
+        SCOPED_LOCK(ctrl.m_mtx);
+        auto ret = !ctrl.joining;
+        if (ctrl.joining) {
+            assert(ctrl.joinable);
+            ctrl.cvar.notify_all();
+        } else if (ctrl.joinable) {
+            ctrl.joining = true;
+            ctrl.cvar.wait(ctrl.m_mtx);
+        }
+        ctrl.joinable = false;
+        ctrl.joining = false;
+        ctrl.start = nullptr;
+        return ret;
     }
     void* ThreadPoolBase::stub(void* arg)
     {
@@ -39,52 +67,43 @@ namespace photon
         auto th = *(thread**)arg;
         *(TPControl**)arg = &ctrl;              // tell ctor where my `ctrl` is
         thread_yield_to(th);
-        while(true)
+        while(wait_for_work(ctrl))
         {
-            {
-                SCOPED_LOCK(ctrl.m_mtx);
-                while (!ctrl.start)                     // wait for `create()` to give me
-                    ctrl.cvar.wait(ctrl.m_mtx);           // thread_entry and argument
-
-                if (ctrl.start == &stub)
-                    break;
-                ((partial_thread*) CURRENT)->tls = nullptr;
-            }
             ctrl.start(ctrl.arg);
             deallocate_tls();
-            {
-                SCOPED_LOCK(ctrl.m_mtx);
-                if (ctrl.joining) {
-                    assert(ctrl.joinable);
-                    ctrl.cvar.notify_all();
-                } else if (ctrl.joinable) {
-                    ctrl.joining = true;
-                    ctrl.cvar.wait(ctrl.m_mtx);
-                }
-                ctrl.joinable = false;
-                ctrl.joining = false;
-                ctrl.start = nullptr;
+            auto should_put = after_work_done(ctrl);
+            if (should_put) {
+                // if has no other joiner waiting
+                // collect it into pool
+                ctrl.pool->put(&ctrl);
             }
-            ctrl.pool->put(&ctrl);
         }
         return nullptr;
     }
-    void ThreadPoolBase::join(TPControl* pCtrl)
+    bool ThreadPoolBase::do_thread_join(TPControl* pCtrl)
     {
         SCOPED_LOCK(pCtrl->m_mtx);
         if (!pCtrl->joinable)
-            LOG_ERROR_RETURN(EINVAL, , "thread is not joinable");
+            LOG_ERROR_RETURN(EINVAL, false, "thread is not joinable");
         if (!pCtrl->start)
-            LOG_ERROR_RETURN(EINVAL, , "thread is not running");
+            LOG_ERROR_RETURN(EINVAL, false, "thread is not running");
         if (pCtrl->start == &stub)
-            LOG_ERROR_RETURN(EINVAL, , "thread is dying");
+            LOG_ERROR_RETURN(EINVAL, false, "thread is dying");
 
+        auto ret = !pCtrl->joining;
         if (pCtrl->joining) {
             pCtrl->cvar.notify_one();
         } else {
             pCtrl->joining = true;
             pCtrl->cvar.wait(pCtrl->m_mtx);
         }
+        return ret;
+    }
+    void ThreadPoolBase::join(TPControl* pCtrl)
+    {
+        auto should_put = do_thread_join(pCtrl);
+        if (should_put)
+            pCtrl->pool->put(pCtrl);
     }
     int ThreadPoolBase::ctor(ThreadPoolBase* pool, TPControl** out)
     {

--- a/thread/thread-pool.h
+++ b/thread/thread-pool.h
@@ -67,6 +67,9 @@ namespace photon
         static void* stub(void* arg);
         static int ctor(ThreadPoolBase*, TPControl**);
         static int dtor(ThreadPoolBase*, TPControl*);
+        static bool wait_for_work(TPControl &ctrl);
+        static bool after_work_done(TPControl &ctrl);
+        static bool do_thread_join(TPControl* pCtrl);
         void init(uint64_t stack_size)
         {
             set_ctor({this, &ctor});

--- a/tools/libphoton.mri
+++ b/tools/libphoton.mri
@@ -1,0 +1,4 @@
+create libphoton.a
+addlib libphoton.a
+save
+end


### PR DESCRIPTION
Fix the issue of being unable to write data to ext filesystem created by user-space tools in lower version linux.