### PR TITLE
FIX httpfs preadv return wrong length of partial-read http body. 

### DIFF
--- a/fs/httpfs/httpfs.cpp
+++ b/fs/httpfs/httpfs.cpp
@@ -229,8 +229,7 @@ public:
                              VALUE(url), VALUE(offset), VALUE(ret));
         }
         authorized = true;
-        headers.try_get("content-length", ret);
-        return ret;
+        return writer.written;
     }
 
     int fstat(struct stat* buf) override {

--- a/net/curl.h
+++ b/net/curl.h
@@ -145,9 +145,11 @@ public:
 struct IOVWriter : public IOVector {
     using IOVector::IOVector;
     size_t drop = 0;
+    size_t written = 0;
     size_t write(const void* buf, size_t size) {
         auto actual_count = memcpy_from(
             buf, size);  // copy from (buf, size) to iovec[] in *this,
+        written += actual_count;
         extract_front(actual_count);  // and extract the portion just copied
         if (actual_count < size)      // means full
         {


### PR DESCRIPTION
FIX:`preadv` in `httpfs` may return wrong read byte count if tcp connection disconnected when receiving body of response by libcurl.

`preadv` return value now only get by checking `IOVWriter` written bytes.

