### PR TITLE
Use acquire-release memory order for mutex::try_lock

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1572,7 +1572,7 @@ R"(
     {
         thread* ptr = nullptr;
         bool ret = owner.compare_exchange_strong(ptr, CURRENT,
-            std::memory_order_release, std::memory_order_relaxed);
+            std::memory_order_acq_rel, std::memory_order_relaxed);
         return (int)ret - 1;
     }
     inline void do_mutex_unlock(mutex* m)


### PR DESCRIPTION
Mutex locking needs to have memory-order acquire semantics. Imagine two threads incrementing a counter, protected by a mutex:

Preconditions:
* Mutex atomic `owner = nullptr`
* Non-atomic variable `X = 0`

Each thread:
1. `mutex::try_lock` successfully performs [`owner.compare_exchange_strong(self, memory_order_release)`](url). This only guarantees that any **preceding** reads and writes are not reordered after this one.
2. `X = X + 1`. This is not an atomic variable and therefore depends on the memory ordering of `owner` to synchronize reads and writes.
3. `mutex::unlock` calls `owner.store(nullptr)` which has `seq` ordering. This guarantees no preceding or subsequent reads or writes will be reordered.

But because the CAS uses `release` memory ordering, other threads can reorder 2 before 1 and 3.

This ordering is therefore possible:

| Thread 1      | Thread 2      |
|---------------|---------------|
| 2. `X=X+1`, X=1 |               |
|               | 2. `X=X+1`, X=1 |
|               | 1. lock       |
|               | 3. unlock     |
| 1. lock       |               |
| 3. unlock     |               |

Both threads read X as 0 and both set X to 1. The end state is that X=1, but it should be 2. 

Using `acquire` semantics for the `try_lock` guarantees that 2 can only happen after 1 and before 3. 