### PR TITLE
support reset photon at fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ file(GLOB PHOTON_SRC
         fs/xfile.cpp
         fs/httpfs/*.cpp
         io/signal.cpp
+        io/reset_handle.cpp
         net/*.cpp
         net/http/*.cpp
         net/security-context/tls-stream.cpp

--- a/io/fstack-dpdk.cpp
+++ b/io/fstack-dpdk.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include "../thread/thread11.h"
 #include "../common/alog.h"
 #include "../net/basic_socket.h"
+#include "reset_handle.h"
 
 #ifndef EVFILT_EXCEPT
 #define EVFILT_EXCEPT (-15)
@@ -37,7 +38,7 @@ namespace photon {
 constexpr static EventsMap<EVUnderlay<EVFILT_READ, EVFILT_WRITE, EVFILT_EXCEPT>>
     evmap;
 
-class FstackDpdkEngine : public MasterEventEngine, public CascadingEventEngine {
+class FstackDpdkEngine : public MasterEventEngine, public CascadingEventEngine, public ResetHandle {
 public:
     struct InFlightEvent {
         uint32_t interests = 0;
@@ -74,6 +75,10 @@ public:
             LOG_ERRNO_RETURN(0, -1, "failed to setup self-wakeup EVFILT_USER event by kevent()");
         }
         return 0;
+    }
+
+    int reset() override {
+        assert(false);
     }
 
     ~FstackDpdkEngine() override {

--- a/io/reset_handle.cpp
+++ b/io/reset_handle.cpp
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "reset_handle.h"
+#include <photon/common/alog.h>
+#include <photon/thread/std-compat.h>
+#include <pthread.h>
+
+namespace photon {
+
+static thread_local ResetHandle *list = nullptr;
+
+ResetHandle::ResetHandle() {
+    LOG_DEBUG("push ", VALUE(this));
+    if (list == nullptr) {
+        list = this;
+    } else {
+        list->insert_tail(this);
+    }
+}
+
+ResetHandle::~ResetHandle() {
+    LOG_DEBUG("erase ", VALUE(this));
+    auto nx = this->remove_from_list();
+    if (this == list)
+        list = nx;
+}
+
+void reset_all_handle() {
+    if (list == nullptr)
+        return;
+    LOG_INFO("reset all handle called");
+    for (auto handler : *list) {
+        LOG_DEBUG("reset ", VALUE(handler));
+        handler->reset();
+    }
+}
+
+} // namespace photon

--- a/io/reset_handle.h
+++ b/io/reset_handle.h
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+#include <photon/thread/list.h>
+
+namespace photon {
+
+class ResetHandle : public intrusive_list_node<ResetHandle> {
+public:
+    ResetHandle();
+    virtual ~ResetHandle();
+
+    virtual int reset() = 0;
+};
+
+void reset_all_handle();
+
+} // namespace photon

--- a/io/signal.cpp
+++ b/io/signal.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 #include "fd-events.h"
 #include "../common/event-loop.h"
 #include "../common/alog.h"
+#include "reset_handle.h"
 
 namespace photon
 {
@@ -227,14 +228,35 @@ namespace photon
 #endif
     }
 
-    // should be invoked in child process after forked, to clear signal mask
-    static void fork_hook_child(void)
-    {
-        LOG_DEBUG("Fork hook");
-        sigset_t sigset0;       // can NOT use photon::clear_signal_mask(),
-        sigemptyset(&sigset0);  // as memory may be shared with parent, when vfork()ed
-        sigprocmask(SIG_SETMASK, &sigset0, nullptr);
-    }
+    class SignalResetHandle : public ResetHandle {
+        int reset() override {
+            if (sgfd < 0)
+                return 0;
+            LOG_INFO("reset signalfd by reset handle");
+            sigset_t sigset0;       // can NOT use photon::clear_signal_mask(),
+            sigemptyset(&sigset0);  // as memory may be shared with parent, when vfork()ed
+            sigprocmask(SIG_SETMASK, &sigset0, nullptr);
+            // reset sgfd
+            memset(sighandlers, 0, sizeof(sighandlers));
+#ifdef __APPLE__
+            sgfd = kqueue();        // kqueue fd is not inherited from the parent process
+#else
+            close(sgfd);
+            sigfillset(&sigset);
+            sgfd = signalfd(-1, &sigset, SFD_CLOEXEC | SFD_NONBLOCK);
+#endif
+            if (sgfd == -1) {
+                LOG_ERROR("failed to create signalfd() or kqueue()");
+                exit(1);
+            }
+            // interrupt event loop by ETIMEDOUT to replace sgfd
+            if (eloop)
+                thread_interrupt(eloop->loop_thread(), ETIMEDOUT);
+
+            return 0;
+        }
+    };
+    static SignalResetHandle *reset_handler = nullptr;
 
     int sync_signal_init()
     {
@@ -262,9 +284,11 @@ namespace photon
             LOG_ERROR_RETURN(EFAULT, -1, "failed to thread_create() for signal handling");
         }
         eloop->async_run();
-        LOG_INFO("signalfd initialized");
         thread_yield(); // give a chance let eloop to execute do_wait
-        pthread_atfork(nullptr, nullptr, &fork_hook_child);
+        if (reset_handler == nullptr) {
+            reset_handler = new SignalResetHandle();
+        }
+        LOG_INFO("signalfd initialized");
         return clear_signal_mask();
     }
 
@@ -298,6 +322,7 @@ namespace photon
             }
         }
 #endif
+        safe_delete(reset_handler);
         LOG_INFO("signalfd finished");
         return clear_signal_mask();
     }

--- a/io/test/CMakeLists.txt
+++ b/io/test/CMakeLists.txt
@@ -8,6 +8,13 @@ add_executable(signalfdboom signalfdboom.cpp)
 target_link_libraries(signalfdboom PRIVATE photon_shared)
 add_test(NAME signalfdboom COMMAND $<TARGET_FILE:signalfdboom>)
 
+add_executable(test-fork test-fork.cpp)
+target_link_libraries(test-fork PRIVATE photon_shared)
+if (PHOTON_ENABLE_URING)
+    target_compile_definitions(test-fork PRIVATE PHOTON_URING=on)
+endif()
+add_test(NAME test-fork COMMAND $<TARGET_FILE:test-fork>)
+
 if (NOT APPLE)
 add_executable(test-syncio test-syncio.cpp)
 target_link_libraries(test-syncio PRIVATE photon_shared)

--- a/io/test/test-fork.cpp
+++ b/io/test/test-fork.cpp
@@ -1,0 +1,325 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <unistd.h>
+#include <sys/wait.h>
+#include <gtest/gtest.h>
+#include <thread>
+#include <fcntl.h>
+
+#include <photon/common/alog.h>
+#include <photon/photon.h>
+#include <photon/thread/thread.h>
+#include <photon/io/fd-events.h>
+#include <photon/io/signal.h>
+#include <photon/net/curl.h>
+#include <photon/fs/localfs.h>
+
+bool exit_flag = false;
+bool exit_normal = false;
+
+void sigint_handler(int signal = SIGINT) {
+    LOG_INFO("signal ` received, pid `", signal, getpid());
+    exit_flag = true;
+}
+
+inline int check_process_exit_stat(int &statVal, int &pid) {
+    if (WIFEXITED(statVal)) { // child exit normally
+        LOG_INFO("process with pid ` finished with code `.", pid, WEXITSTATUS(statVal));
+        return WEXITSTATUS(statVal);
+    } else {
+        if (WIFSIGNALED(statVal)) { // child terminated due to uncaptured signal
+            LOG_INFO("process with pid ` terminated due to uncaptured signal `.", pid,
+                     WTERMSIG(statVal));
+        } else if (WIFSTOPPED(statVal)) { // child terminated unexpectedly
+            LOG_INFO("process with pid ` terminated unexpectedly with signal `.", pid,
+                     WSTOPSIG(statVal));
+        } else {
+            LOG_INFO("process with pid ` terminated abnormally.", pid);
+        }
+        return -1;
+    }
+}
+
+void wait_process_end(pid_t pid) {
+    if (pid > 0) {
+        int statVal;
+        if (waitpid(pid, &statVal, 0) > 0) {
+            check_process_exit_stat(statVal, pid);
+        } else {
+            /// EINTR
+            if (EINTR == errno) {
+                LOG_INFO("process with pid ` waitpid is interrupted.", pid);
+            } else {
+                LOG_INFO("process with pid ` waitpid exception, strerror: `.", pid,
+                         strerror(errno));
+            }
+        }
+    }
+}
+
+void wait_process_end_no_hang(pid_t pid) {
+    if (pid > 0) {
+        int statVal;
+        int retry = 100;
+    again:
+        if (waitpid(pid, &statVal, WNOHANG) <= 0) {
+            if (retry--) {
+                photon::thread_usleep(50 * 1000);
+                goto again;
+            } else {
+                if (kill(pid, SIGKILL) == 0) {
+                    LOG_WARN("force kill child process with pid `", pid);
+                } else {
+                    LOG_ERROR("force kill child process with pid ` error, errno:`:`", pid, errno,
+                              strerror(errno));
+                }
+                wait_process_end(pid);
+            }
+        } else {
+            if (check_process_exit_stat(statVal, pid) == 0) {
+                exit_normal = true;
+            }
+        }
+    }
+}
+
+int fork_child_process() {
+    pid_t pid = fork();
+    if (pid < 0) {
+        LOG_ERRNO_RETURN(0, -1, "fork error");
+        return -1;
+    }
+
+    if (pid == 0) {
+        photon::block_all_signal();
+        photon::sync_signal(SIGTERM, &sigint_handler);
+
+        LOG_INFO("child hello, pid `", getpid());
+        while (!exit_flag) {
+            photon::thread_usleep(200 * 1000);
+        }
+        photon::fini();
+        LOG_INFO("child exited, pid `", getpid());
+        exit(0);
+    } else {
+        LOG_INFO("parent hello, pid `", getpid());
+        return pid;
+    }
+}
+
+int fork_parent_process(uint64_t event_engine) {
+    pid_t m_pid = fork();
+    if (m_pid < 0) {
+        LOG_ERRNO_RETURN(0, -1, "fork error");
+        return -1;
+    }
+
+    if (m_pid > 0) {
+        LOG_INFO("main hello, pid `", getpid());
+        return m_pid;
+    }
+    photon::fini();
+    photon::init(event_engine, photon::INIT_IO_LIBCURL);
+
+    photon::block_all_signal();
+    photon::sync_signal(SIGINT, &sigint_handler);
+
+    LOG_INFO("parent hello, pid `", getpid());
+    photon::thread_sleep(1);
+    auto pid = fork_child_process();
+    photon::thread_sleep(1);
+
+    int statVal;
+    if (waitpid(pid, &statVal, WNOHANG) == 0) {
+        if (kill(pid, SIGTERM) == 0) {
+            LOG_INFO("kill child process with pid `", pid);
+        } else {
+            ERRNO eno;
+            LOG_ERROR("kill child process with pid ` error, `", pid, eno);
+        }
+        wait_process_end_no_hang(pid);
+    } else {
+        check_process_exit_stat(statVal, pid);
+        LOG_ERROR("child process exit unexpected");
+    }
+
+    LOG_INFO("child process exit status `", exit_normal);
+    EXPECT_EQ(true, exit_normal);
+
+    while (!exit_flag) {
+        photon::thread_usleep(200 * 1000);
+    }
+    LOG_INFO("parent exited, pid `", getpid());
+    photon::fini();
+    exit(exit_normal ? 0 : -1);
+}
+
+TEST(ForkTest, Fork) {
+    photon::init(photon::INIT_EVENT_NONE, photon::INIT_IO_NONE);
+    DEFER(photon::fini());
+    exit_flag = false;
+    exit_normal = false;
+#if defined(__linux__)
+    auto pid = fork_parent_process(photon::INIT_EVENT_EPOLL | photon::INIT_EVENT_SIGNAL);
+#else  // macOS, FreeBSD ...
+    auto pid = fork_parent_process(photon::INIT_EVENT_DEFAULT);
+#endif
+    photon::thread_sleep(5);
+
+    int statVal;
+    if (waitpid(pid, &statVal, WNOHANG) == 0) {
+        if (kill(pid, SIGINT) == 0) {
+            LOG_INFO("kill parent process with pid `", pid);
+        } else {
+            ERRNO eno;
+            LOG_ERROR("kill parent process with pid ` error, `", pid, eno);
+        }
+        wait_process_end_no_hang(pid);
+    } else {
+        check_process_exit_stat(statVal, pid);
+        LOG_ERROR("parent process exit unexpected");
+    }
+
+    LOG_INFO("parent process exit status `", exit_normal);
+    EXPECT_EQ(true, exit_normal);
+}
+
+TEST(ForkTest, ForkInThread) {
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_LIBCURL);
+    DEFER(photon::fini());
+
+    int ret = -1;
+    std::thread th([&]() {
+        pid_t pid = fork();
+        ASSERT_GE(pid, 0);
+
+        if (pid == 0) {
+            LOG_INFO("child hello, pid `", getpid());
+            exit(0);
+        } else {
+            LOG_INFO("parent hello, pid `", getpid());
+            int statVal;
+            waitpid(pid, &statVal, 0);
+            ret = check_process_exit_stat(statVal, pid);
+        }
+    });
+    th.join();
+    EXPECT_EQ(0, ret);
+}
+
+TEST(ForkTest, PopenInThread) {
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_LIBCURL);
+    DEFER(photon::fini());
+
+    photon::semaphore sem(0);
+    auto cmd = "du -s \"/tmp\"";
+    ssize_t size = -1;
+    std::thread([&] {
+        auto f = popen(cmd, "r");
+        EXPECT_NE(nullptr, f);
+        DEFER(fclose(f));
+        fscanf(f, "%lu", &size);
+        sem.signal(1);
+        LOG_INFO("popen done");
+    }).detach();
+    sem.wait(1);
+    EXPECT_NE(-1, size);
+    LOG_INFO(VALUE(size));
+}
+
+#if defined(__linux__) && defined(PHOTON_URING)
+TEST(ForkTest, Iouring) {
+    photon::init(photon::INIT_EVENT_NONE, photon::INIT_IO_NONE);
+    DEFER(photon::fini());
+    exit_flag = false;
+    exit_normal = false;
+    auto pid = fork_parent_process(photon::INIT_EVENT_IOURING | photon::INIT_EVENT_SIGNAL);
+
+    photon::thread_sleep(5);
+
+    int statVal;
+    if (waitpid(pid, &statVal, WNOHANG) == 0) {
+        if (kill(pid, SIGINT) == 0) {
+            LOG_INFO("kill parent process with pid `", pid);
+        } else {
+            ERRNO eno;
+            LOG_ERROR("kill parent process with pid ` error, `", pid, eno);
+        }
+        wait_process_end_no_hang(pid);
+    } else {
+        check_process_exit_stat(statVal, pid);
+        LOG_ERROR("parent process exit unexpected");
+    }
+
+    LOG_INFO("parent process exit status `", exit_normal);
+    EXPECT_EQ(true, exit_normal);
+}
+#endif
+
+#if defined(__linux__)
+TEST(ForkTest, LIBAIO) {
+    photon::init(photon::INIT_EVENT_EPOLL, photon::INIT_IO_LIBAIO);
+    DEFER(photon::fini());
+
+    std::unique_ptr<photon::fs::IFileSystem> fs(
+        photon::fs::new_localfs_adaptor("/tmp/", photon::fs::ioengine_libaio));
+    std::unique_ptr<photon::fs::IFile> lf(
+        fs->open("test_local_fs_fork_parent", O_RDWR | O_CREAT, 0755));
+    void* buf = nullptr;
+    ::posix_memalign(&buf, 4096, 4096);
+    DEFER(free(buf));
+    int ret = lf->pwrite(buf, 4096, 0);
+    EXPECT_EQ(ret, 4096);
+
+    ret = -1;
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+
+    if (pid == 0) {
+        std::unique_ptr<photon::fs::IFileSystem> fs(
+            photon::fs::new_localfs_adaptor("/tmp/", photon::fs::ioengine_libaio));
+        std::unique_ptr<photon::fs::IFile> lf(
+            fs->open("test_local_fs_fork", O_RDWR | O_CREAT, 0755));
+        void* buf = nullptr;
+        ::posix_memalign(&buf, 4096, 4096);
+        DEFER(free(buf));
+        auto ret = lf->pwrite(buf, 4096, 0);
+        EXPECT_EQ(ret, 4096);
+        ret = lf->close();
+        photon::fini();
+        exit(ret);
+    } else {
+        int statVal;
+        waitpid(pid, &statVal, 0);
+        ret = check_process_exit_stat(statVal, pid);
+    }
+    EXPECT_EQ(0, ret);
+
+    ret = lf->pwrite(buf, 4096, 0);
+    EXPECT_EQ(ret, 4096);
+    ret = lf->close();
+    EXPECT_EQ(0, ret);
+}
+#endif
+
+int main(int argc, char **argv) {
+    set_log_output_level(0);
+
+    ::testing::InitGoogleTest(&argc, argv);
+    auto ret = RUN_ALL_TESTS();
+    if (ret) LOG_ERROR_RETURN(0, ret, VALUE(ret));
+}

--- a/photon.cpp
+++ b/photon.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #ifdef ENABLE_FSTACK_DPDK
 #include "io/fstack-dpdk.h"
 #endif
+#include "io/reset_handle.h"
 #include "net/curl.h"
 #include "net/socket.h"
 #include "fs/exportfs.h"
@@ -31,6 +32,7 @@ namespace photon {
 using namespace fs;
 using namespace net;
 
+static bool reset_handle_registed = false;
 static thread_local uint64_t g_event_engine = 0, g_io_engine = 0;
 
 #define INIT_IO(name, prefix)    if (INIT_IO_##name & io_engine) { if (prefix##_init() < 0) return -1; }
@@ -74,6 +76,11 @@ int init(uint64_t event_engine, uint64_t io_engine) {
 #endif
     g_event_engine = event_engine;
     g_io_engine = io_engine;
+    if (!reset_handle_registed) {
+        pthread_atfork(nullptr, nullptr, &reset_all_handle);
+        LOG_DEBUG("reset_all_handle registed ", VALUE(getpid()));
+        reset_handle_registed = true;
+    }
     return 0;
 }
 


### PR DESCRIPTION
In photon context, event engine based module need reset after fork, if exec will not be called after fork.
This is implicitly done by pthread_atfork hook.