### PR TITLE
Mute an UBSan check error for SCOPED_LOCK macro

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -72,8 +72,6 @@ inline int posix_memalign(void** memptr, size_t alignment, size_t size) {
    by target vcpu in resume_thread(), when its runq becomes empty;
 */
 
-#define SCOPED_MEMBER_LOCK(x) SCOPED_LOCK(&(x)->lock, ((bool)x) * 2)
-
 // Define assembly section header for clang and gcc
 #if defined(__APPLE__)
 #define DEF_ASM_FUNC(name) ".text\n" \
@@ -1199,7 +1197,8 @@ R"(
     __attribute__((always_inline)) inline
     Switch prepare_usleep(uint64_t useconds, thread_list* waitq, RunQ rq = {})
     {
-        SCOPED_MEMBER_LOCK(waitq);
+        spinlock* waitq_lock = waitq ? &waitq->lock : nullptr;
+        SCOPED_LOCK(waitq_lock, ((bool) waitq) * 2);
         SCOPED_LOCK(rq.current->lock);
         assert(!AtomicRunQ(rq).single());
         auto sw = AtomicRunQ(rq).remove_current(states::SLEEPING);


### PR DESCRIPTION
The previous SCOPED_MEMBER_LOCK will visit member address even if the object itself is nullptr.

This behavior will cause an runtime error in the UndefinedBehaviorSanitizer check (https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), although the compiler didn't regard it as a warning.

Removed SCOPED_MEMBER_LOCK, luckily this is the only usage in the whole project.
