### PR TITLE
Fix the va_args order of http header

### DIFF
--- a/fs/httpfs/httpfs.cpp
+++ b/fs/httpfs/httpfs.cpp
@@ -252,7 +252,9 @@ public:
     }
 
     void add_header(va_list args) {
-        common_header[va_arg(args, const char*)] = va_arg(args, const char*);
+        auto k = va_arg(args, const char*);
+        auto v = va_arg(args, const char*);
+        common_header[k] = v;
     }
 
     void add_url_param(va_list args) { url_param = va_arg(args, const char*); }

--- a/fs/httpfs/httpfs_v2.cpp
+++ b/fs/httpfs/httpfs_v2.cpp
@@ -222,7 +222,9 @@ public:
 
     //TODO: 这里是否需要考虑m_common_header被打爆的问题？
     void add_header(va_list args) {
-        m_common_header.insert(va_arg(args, const char*), va_arg(args, const char*));
+        auto k = va_arg(args, const char*);
+        auto v = va_arg(args, const char*);
+        m_common_header.insert(k, v);
     }
 
     void add_url_param(va_list args) { m_url_param = va_arg(args, const char*); }


### PR DESCRIPTION
The current HTTP header has a bug of wrong key value order.
This is the POC. It will print `v` first, and then `k`, which is obviously wrong.

```c++ 
#include <iostream>
#include <string>
#include <map>
#include <string>
#include <cstdarg>

std::map<std::string, std::string> common_header;

void add_header(va_list args) {
    common_header[va_arg(args, const char*)] = va_arg(args, const char*);
}

void f(int a, ...) {
    va_list args;
    va_start(args, a);
    add_header(args);
    va_end(args);
}

int main() {
    f(1, "k", "v");
    for (auto& i: common_header) {
        std::cout << i.first << std::endl;
        std::cout << i.second << std::endl;
    }
}
```