### PR TITLE
fs: support xattr for extfs and subfs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ if (PHOTON_ENABLE_FSTACK_DPDK)
     target_include_directories(photon_obj PUBLIC ${FSTACK_INCLUDE_DIRS})
 endif()
 if (PHOTON_ENABLE_EXTFS)
-    target_include_directories(photon_obj PUBLIC ${LIBE2FS_INCLUDE_DIRS})
+    target_include_directories(photon_obj PUBLIC ${E2FS_INCLUDE_DIRS})
 endif()
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
     # This option is enabled by default after -std=c++17

--- a/fs/extfs/extfs.h
+++ b/fs/extfs/extfs.h
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #pragma once
-#include <ext2fs/ext2fs.h>
 #include <photon/fs/filesystem.h>
 
 namespace photon {
 namespace fs {
 
-io_manager new_io_manager(photon::fs::IFile *file);
 photon::fs::IFileSystem *new_extfs(photon::fs::IFile *file, bool buffer = true);
 
 // make extfs on an prezeroed IFile,

--- a/fs/extfs/extfs_io.cpp
+++ b/fs/extfs/extfs_io.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "extfs.h"
+#include <ext2fs/ext2fs.h>
 #include <sys/stat.h>
 #include <photon/common/alog.h>
 #include <photon/common/callback.h>

--- a/fs/extfs/mkfs.cpp
+++ b/fs/extfs/mkfs.cpp
@@ -116,6 +116,7 @@ int do_mkfs(io_manager manager, size_t size, char *uuid) {
         return ret;
     }
     // reserve inodes
+    ext2fs_inode_alloc_stats2(fs, EXT2_BAD_INO, +1, 0);
     for (ext2_ino_t i = EXT2_ROOT_INO + 1; i < EXT2_FIRST_INODE(fs->super); i++)
         ext2fs_inode_alloc_stats2(fs, i, +1, 0);
     ext2fs_mark_ib_dirty(fs);
@@ -134,6 +135,8 @@ int do_mkfs(io_manager manager, size_t size, char *uuid) {
 
 namespace photon {
 namespace fs {
+
+extern io_manager new_io_manager(photon::fs::IFile *file);
 
 int make_extfs(photon::fs::IFile *file, char *uuid) {
     struct stat st;

--- a/fs/subfs.cpp
+++ b/fs/subfs.cpp
@@ -31,10 +31,11 @@ namespace photon {
 namespace fs
 {
     // Sub tree of a file system
-    class SubFileSystem : public IFileSystem
+    class SubFileSystem : public IFileSystem, public IFileSystemXAttr
     {
     public:
         IFileSystem* underlayfs = nullptr;
+        IFileSystemXAttr* underlay_xattrfs = nullptr;
         char base_path[PATH_MAX];
         uint base_path_len = 0;
         bool ownership = false;
@@ -43,6 +44,7 @@ namespace fs
         {
             ownership = _ownership;
             underlayfs = _underlayfs;
+            underlay_xattrfs = dynamic_cast<IFileSystemXAttr *>(_underlayfs);
             if (!_base_path || !_base_path[0])         // use default relative path
             {
                 base_path[0] = '\0';
@@ -228,48 +230,63 @@ namespace fs
             PathCat __(this, path);
             return underlayfs->mknod(path, mode, dev);
         }
-        /*
+
         virtual ssize_t getxattr(const char *path, const char *name, void *value, size_t size)
         {
+            if (!underlay_xattrfs)
+                LOG_ERROR_RETURN(ENOTSUP, -1, "xattr is not supported by underlay fs");
             PathCat __(this, path);
-            return underlayfs->getxattr(path, name, value, size);
+            return underlay_xattrfs->getxattr(path, name, value, size);
         }
         virtual ssize_t lgetxattr(const char *path, const char *name, void *value, size_t size)
         {
+            if (!underlay_xattrfs)
+                LOG_ERROR_RETURN(ENOTSUP, -1, "xattr is not supported by underlay fs");
             PathCat __(this, path);
-            return underlayfs->lgetxattr(path, name, value, size);
+            return underlay_xattrfs->lgetxattr(path, name, value, size);
         }
         virtual ssize_t listxattr(const char *path, char *list, size_t size)
         {
+            if (!underlay_xattrfs)
+                LOG_ERROR_RETURN(ENOTSUP, -1, "xattr is not supported by underlay fs");
             PathCat __(this, path);
-            return underlayfs->listxattr(path, list, size);
+            return underlay_xattrfs->listxattr(path, list, size);
         }
         virtual ssize_t llistxattr(const char *path, char *list, size_t size)
         {
+            if (!underlay_xattrfs)
+                LOG_ERROR_RETURN(ENOTSUP, -1, "xattr is not supported by underlay fs");
             PathCat __(this, path);
-            return underlayfs->llistxattr(path, list, size);
+            return underlay_xattrfs->llistxattr(path, list, size);
         }
         virtual int setxattr(const char *path, const char *name, const void *value, size_t size, int flags)
         {
+            if (!underlay_xattrfs)
+                LOG_ERROR_RETURN(ENOTSUP, -1, "xattr is not supported by underlay fs");
             PathCat __(this, path);
-            return underlayfs->setxattr(path, name, value, size, flags);
+            return underlay_xattrfs->setxattr(path, name, value, size, flags);
         }
         virtual int lsetxattr(const char *path, const char *name, const void *value, size_t size, int flags)
         {
+            if (!underlay_xattrfs)
+                LOG_ERROR_RETURN(ENOTSUP, -1, "xattr is not supported by underlay fs");
             PathCat __(this, path);
-            return underlayfs->lsetxattr(path, name, value, size, flags);
+            return underlay_xattrfs->lsetxattr(path, name, value, size, flags);
         }
         virtual int removexattr(const char *path, const char *name)
         {
+            if (!underlay_xattrfs)
+                LOG_ERROR_RETURN(ENOTSUP, -1, "xattr is not supported by underlay fs");
             PathCat __(this, path);
-            return underlayfs->removexattr(path, name);
+            return underlay_xattrfs->removexattr(path, name);
         }
         virtual int lremovexattr(const char *path, const char *name)
         {
+            if (!underlay_xattrfs)
+                LOG_ERROR_RETURN(ENOTSUP, -1, "xattr is not supported by underlay fs");
             PathCat __(this, path);
-            return underlayfs->lremovexattr(path, name);
+            return underlay_xattrfs->lremovexattr(path, name);
         }
-        */
     };
     class SubFile : public ForwardFile_Ownership
     {


### PR DESCRIPTION
Extfs and subfs implement IFileSystemXAttr interface to support xattr.
Add xattr test case for extfs.