### PR TITLE
Support ipv6 in http client

### DIFF
--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -91,7 +91,7 @@ ISocketStream* PooledDialer::dial(std::string_view host, uint16_t port, bool sec
     if (ipaddr.undefined()) LOG_DEBUG("No connectable resolve result");
     // When failed, remove resolved result from dns cache so that following retries can try
     // different ips.
-    resolver->discard_cache(strhost.c_str());
+    resolver->discard_cache(strhost.c_str(), ipaddr);
     return nullptr;
 }
 

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -513,6 +513,16 @@ TEST(http_client, partial_body) {
     EXPECT_EQ(true, buf == "http_clien");
 }
 
+TEST(DISABLED_http_client, ipv6) {  // make sure runing in a ipv6-ready environment
+    auto client = new_http_client();
+    DEFER(delete client);
+    // here is an ipv6-only website
+    auto op = client->new_operation(Verb::GET, "http://test6.ustc.edu.cn");
+    DEFER(delete op);
+    op->call();
+    EXPECT_EQ(200, op->resp.status_code());
+}
+
 TEST(url, url_escape_unescape) {
     EXPECT_EQ(
         url_escape("?a=x:b&b=cd&c= feg&d=2/1[+]@alibaba.com&e='!bad';"),

--- a/net/test/test.cpp
+++ b/net/test/test.cpp
@@ -714,9 +714,9 @@ TEST(utils, resolver) {
     DEFER(delete resolver);
     net::IPAddr localhost("127.0.0.1");
     net::IPAddr addr = resolver->resolve("localhost");
-    EXPECT_EQ(localhost.to_nl(), addr.to_nl());
+    if (addr.is_ipv4()) EXPECT_EQ(localhost.to_nl(), addr.to_nl());
     auto func = [&](net::IPAddr addr_){
-        EXPECT_EQ(localhost.to_nl(), addr_.to_nl());
+        if (addr_.is_ipv4()) EXPECT_EQ(localhost.to_nl(), addr_.to_nl());
     };
     resolver->resolve("localhost", func);
     resolver->discard_cache("non-exist-host.com");

--- a/net/utils.h
+++ b/net/utils.h
@@ -109,7 +109,8 @@ inline int gethostbyname(const char* name, IPAddr* buf, int bufsize = 1) {
  * @param ret `std::vector<IPAddr>` reference to get results
  * @return sum of resolved address number. -1 means error.
  */
-inline int gethostbyname(const char* name, std::vector<IPAddr>& ret) {
+template <typename Container>
+inline int gethostbyname(const char* name, Container& ret) {
     ret.clear();
     auto cb = [&](IPAddr addr) {
         ret.push_back(addr);
@@ -157,7 +158,7 @@ public:
     // Normally dns servers return multiple ips in random order, choosing the first one should suffice.
     virtual IPAddr resolve(const char* host) = 0;
     virtual void resolve(const char* host, Delegate<void, IPAddr> func) = 0;
-    virtual void discard_cache(const char* host) = 0;  // discard current cache of host:ip
+    virtual void discard_cache(const char* host, IPAddr ip = IPAddr()) = 0;  // discard current cache of ip
 };
 
 /**

--- a/net/utils.h
+++ b/net/utils.h
@@ -109,8 +109,7 @@ inline int gethostbyname(const char* name, IPAddr* buf, int bufsize = 1) {
  * @param ret `std::vector<IPAddr>` reference to get results
  * @return sum of resolved address number. -1 means error.
  */
-template <typename Container>
-inline int gethostbyname(const char* name, Container& ret) {
+inline int gethostbyname(const char* name, std::vector<IPAddr>& ret) {
     ret.clear();
     auto cb = [&](IPAddr addr) {
         ret.push_back(addr);
@@ -163,6 +162,7 @@ public:
 
 /**
  * @brief A non-blocking Resolver based on gethostbyname.
+ * Currently, it's not thread safe.
  *
  * @param cache_ttl cache's lifetime in microseconds.
  * @param resolve_timeout timeout in microseconds for domain resolution.

--- a/thread/list.h
+++ b/thread/list.h
@@ -221,6 +221,48 @@ public:
     {
         return {nullptr, nullptr};
     }
+
+    struct reverse_iterator
+    {
+        __intrusive_list_node* ptr;
+        __intrusive_list_node* end;
+        T* operator*()
+        {
+            return static_cast<T*>(ptr);
+        }
+        reverse_iterator& operator++()
+        {
+            ptr = ptr->__prev_ptr;
+            if (ptr == end)
+                ptr = nullptr;
+            return *this;
+        }
+        reverse_iterator operator++(int)
+        {
+            auto rst = *this;
+            ptr = ptr->__prev_ptr;
+            if (ptr == end)
+                ptr = nullptr;
+            return rst;
+        }
+        bool operator == (const reverse_iterator& rhs) const
+        {
+            return ptr == rhs.ptr;
+        }
+        bool operator != (const reverse_iterator& rhs) const
+        {
+            return !(*this == rhs);
+        }
+    };
+
+    reverse_iterator rbegin()
+    {
+        return {this->__prev_ptr, this->__prev_ptr};
+    }
+    reverse_iterator rend()
+    {
+        return {nullptr, nullptr};
+    }
 };
 
 
@@ -321,11 +363,20 @@ public:
         return node == nullptr;
     }
     typedef typename NodeType::iterator iterator;
+    typedef typename NodeType::reverse_iterator reverse_iterator;
     iterator begin()
     {
         return node ? node->begin() : end();
     }
     iterator end()
+    {
+        return {nullptr, nullptr};
+    }
+    reverse_iterator rbegin()
+    {
+        return node ? node->rbegin() : rend();
+    }
+    reverse_iterator rend()
     {
         return {nullptr, nullptr};
     }


### PR DESCRIPTION
1. Support ipv6 in http client.
- refactor KernelSocketClient by removing socket_family in KernelSocketClient.
- apply dns load balance in DefaultResolver.
- fix bug in DefaultResolver when timeout happen.

2. Add big writes/uid/gid/du support to FUSE
- In Fuse 2.x, without big writes, write io size is limited to 4k. Turing it on can enlarge write io size to 128K at maximum.
- Support du by adding st_blocks to xmp_getattr result.
- Add default uid/gid to xmp_getattr to avoid permission problems.