### PR TITLE
Re-define an undefined endpoint

### DIFF
--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -87,7 +87,7 @@ function(build_from_src [dep])
                 BUILD_IN_SOURCE ON
                 CONFIGURE_COMMAND ./config -fPIC --prefix=${BINARY_DIR} --openssldir=${BINARY_DIR} shared
                 BUILD_COMMAND make -j 1  # https://github.com/openssl/openssl/issues/5762#issuecomment-376622684
-                INSTALL_COMMAND $(MAKE) install
+                INSTALL_COMMAND make install
                 LOG_CONFIGURE ON
                 LOG_BUILD ON
                 LOG_INSTALL ON

--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -1035,8 +1035,8 @@ extern "C" ISocketServer* new_fstack_dpdk_socket_server() {
 
 /* Implementations in socket.h */
 
-EndPoint::EndPoint(const char* s) {
-    estring_view ep(s);
+EndPoint::EndPoint(const char* _ep) {
+    estring_view ep(_ep);
     auto pos = ep.find_last_of(':');
     if (pos == estring::npos)
         return;

--- a/net/socket.h
+++ b/net/socket.h
@@ -150,7 +150,8 @@ namespace net {
         uint16_t port = 0;
         EndPoint() = default;
         EndPoint(IPAddr ip, uint16_t port) : addr(ip), port(port) {}
-        explicit EndPoint(const char* s);
+        explicit EndPoint(const char* ep);
+        EndPoint(const char* ip, uint16_t port) : addr(ip), port(port) {}
         bool is_ipv4() const {
             return addr.is_ipv4();
         };
@@ -161,7 +162,7 @@ namespace net {
             return !operator==(rhs);
         }
         bool undefined() const {
-            return addr.undefined() && port == 0;
+            return addr.undefined();
         }
     };
 


### PR DESCRIPTION
When errors happened, we often get an empty `Endpoint` with an empty `IPAddr`, but we'll usually not reset zero value to its `port`.

An empty IP is enough to indicate it's `undefined`, and makes it more convenient to use.

Another option is to change the condition from AND to OR.