### PR TITLE
iouring: remove RLIMIT_MEMLOCK check for new kernel

### DIFF
--- a/.github/workflows/ci.linux.x86.yml
+++ b/.github/workflows/ci.linux.x86.yml
@@ -86,7 +86,6 @@ jobs:
 
     container:
       image: dokken/centos-stream-8:sha-40294ce
-      # In order to run io_uring, the docker daemon should add --default-ulimit memlock=-1:-1
       options: --cpus 4
 
     steps:
@@ -116,6 +115,5 @@ jobs:
       - name: Test
         run: |
           cd build
-          ulimit -l unlimited
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest --timeout 3600 -V

--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -76,10 +76,14 @@ public:
     }
 
     int init() {
-        rlimit resource_limit{.rlim_cur = RLIM_INFINITY, .rlim_max = RLIM_INFINITY};
-        if (setrlimit(RLIMIT_MEMLOCK, &resource_limit) != 0) {
-            LOG_ERROR_RETURN(0, -1, "iouring: failed to set resource limit. Use command `ulimit -l unlimited`, or change to root");
+        int compare_result;
+        if (kernel_version_compare("5.11", compare_result) == 0 && compare_result <= 0) {
+            rlimit resource_limit{.rlim_cur = RLIM_INFINITY, .rlim_max = RLIM_INFINITY};
+            if (setrlimit(RLIMIT_MEMLOCK, &resource_limit) != 0)
+                LOG_ERROR_RETURN(0, -1, "iouring: failed to set resource limit. "
+                                        "Use command `ulimit -l unlimited`, or change to root");
         }
+
         check_register_file_support();
         check_cooperative_task_support();
         set_submit_wait_function();


### PR DESCRIPTION
> io_uring accounts memory it needs under the rlimit memlocked option, which
> can be quite low on some setups (64K). The default is usually enough for
> most use cases, but bigger rings or things like registered buffers deplete
> it quickly. This affects 5.11 and earlier, new kernels are less dependent
> on RLIMIT_MEMLOCK as it is only used for registering buffers.