### PR TITLE
Add extra options in `photon::init`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /.clang_complete
 /.ccls*
 /.cquery*
+/.cache
+/compile_commands.json
 
 # alimake
 /.dep_create/

--- a/io/aio-wrapper.cpp
+++ b/io/aio-wrapper.cpp
@@ -38,10 +38,10 @@ limitations under the License.
 
 namespace photon
 {
-    const uint64_t IODEPTH = 2048;
+    constexpr static int IODEPTH_MAX = 2048;
     struct libaio_ctx_t
     {
-        int evfd = -1, running = 0;
+        int evfd = -1, running = 0, iodepth = 32;
         io_context_t aio_ctx = {0};
         thread* polling_thread = nullptr;
         condition_variable cond;
@@ -152,8 +152,8 @@ namespace photon
     static void resume_libaio_requesters()
     {
 retry:
-        struct io_event events[IODEPTH];
-        int n = HAVE_N_TRY(my_io_getevents, (0, IODEPTH, events));
+        struct io_event events[IODEPTH_MAX];
+        int n = HAVE_N_TRY(my_io_getevents, (0, IODEPTH_MAX, events));
         for (int i=0; i<n; ++i)
         {
             auto piocb = (libaiocb*)events[i].obj;
@@ -166,7 +166,7 @@ retry:
                          VALUE(piocb->u.c.buf), VALUE(piocb->u.c.resfd));
             thread_interrupt((thread *)events[i].data, EOK);
         }
-        if (n == IODEPTH)
+        if (n == IODEPTH_MAX)
         {
             thread_yield();
             goto retry;
@@ -355,7 +355,7 @@ retry:
             }
             io_destroy(libaio_ctx->aio_ctx);
             libaio_ctx->aio_ctx = {0};
-            int ret = io_setup(IODEPTH, &libaio_ctx->aio_ctx);
+            int ret = io_setup(libaio_ctx->iodepth, &libaio_ctx->aio_ctx);
             if (ret < 0) {
                 LOG_ERROR("failed to create aio context by io_setup() ", ERRNO(), VALUE(ret));
                 exit(-1);
@@ -366,17 +366,18 @@ retry:
     };
     static thread_local AioResetHandle *reset_handler = nullptr;
 
-    int libaio_wrapper_init()
+    int libaio_wrapper_init(int iodepth)
     {
         if (libaio_ctx)
             return 0;
 
         std::unique_ptr<libaio_ctx_t> ctx(new libaio_ctx_t);
         ctx->evfd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+        libaio_ctx->iodepth = iodepth > IODEPTH_MAX ? IODEPTH_MAX : iodepth;
         if (ctx->evfd < 0)
             LOG_ERRNO_RETURN(0, -1, "failed to create eventfd");
 
-        int ret = io_setup(IODEPTH, &ctx->aio_ctx);
+        int ret = io_setup(ctx->iodepth, &ctx->aio_ctx);
         if (ret < 0)
         {
             LOG_ERROR("failed to create aio context by io_setup() ", ERRNO(), VALUE(ret));

--- a/io/aio-wrapper.cpp
+++ b/io/aio-wrapper.cpp
@@ -153,7 +153,7 @@ namespace photon
     {
 retry:
         struct io_event events[IODEPTH_MAX];
-        int n = HAVE_N_TRY(my_io_getevents, (0, IODEPTH_MAX, events));
+        int n = HAVE_N_TRY(my_io_getevents, (0, libaio_ctx->iodepth, events));
         for (int i=0; i<n; ++i)
         {
             auto piocb = (libaiocb*)events[i].obj;
@@ -166,7 +166,7 @@ retry:
                          VALUE(piocb->u.c.buf), VALUE(piocb->u.c.resfd));
             thread_interrupt((thread *)events[i].data, EOK);
         }
-        if (n == IODEPTH_MAX)
+        if (n == libaio_ctx->iodepth)
         {
             thread_yield();
             goto retry;

--- a/io/aio-wrapper.cpp
+++ b/io/aio-wrapper.cpp
@@ -376,7 +376,7 @@ retry:
 
         std::unique_ptr<libaio_ctx_t> ctx(new libaio_ctx_t);
         ctx->evfd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-        libaio_ctx->iodepth = iodepth > IODEPTH_MAX ? IODEPTH_MAX : iodepth;
+        ctx->iodepth = iodepth > IODEPTH_MAX ? IODEPTH_MAX : iodepth;
         if (ctx->evfd < 0)
             LOG_ERRNO_RETURN(0, -1, "failed to create eventfd");
 

--- a/io/aio-wrapper.cpp
+++ b/io/aio-wrapper.cpp
@@ -371,6 +371,9 @@ retry:
         if (libaio_ctx)
             return 0;
 
+        if (iodepth <= 0)
+            LOG_ERROR_RETURN(EINVAL, -1, "iodepth should be greater than 0");
+
         std::unique_ptr<libaio_ctx_t> ctx(new libaio_ctx_t);
         ctx->evfd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
         libaio_ctx->iodepth = iodepth > IODEPTH_MAX ? IODEPTH_MAX : iodepth;

--- a/io/aio-wrapper.h
+++ b/io/aio-wrapper.h
@@ -24,7 +24,7 @@ namespace photon
 {
     extern "C"
     {
-        int libaio_wrapper_init();
+        int libaio_wrapper_init(int iodepth = 32);
         int libaio_wrapper_fini();
 
         // `fd` must be opened with O_DIRECT, and the buffers must be aligned

--- a/photon.cpp
+++ b/photon.cpp
@@ -19,6 +19,9 @@ limitations under the License.
 #include "io/fd-events.h"
 #include "io/signal.h"
 #include "io/aio-wrapper.h"
+#include "thread/thread.h"
+#include "thread/thread-pool.h"
+#include "thread/stack-allocator.h"
 #ifdef ENABLE_FSTACK_DPDK
 #include "io/fstack-dpdk.h"
 #endif
@@ -35,7 +38,7 @@ using namespace net;
 static bool reset_handle_registed = false;
 static thread_local uint64_t g_event_engine = 0, g_io_engine = 0;
 
-#define INIT_IO(name, prefix)    if (INIT_IO_##name & io_engine) { if (prefix##_init() < 0) return -1; }
+#define INIT_IO(name, prefix, ...)    if (INIT_IO_##name & io_engine) { if (prefix##_init(__VA_ARGS__) < 0) return -1; }
 #define FINI_IO(name, prefix)    if (INIT_IO_##name & g_io_engine) { prefix##_fini(); }
 
 // Try to init master engine with the recommended order
@@ -45,7 +48,14 @@ static const int recommended_order[] = {INIT_EVENT_EPOLL, INIT_EVENT_IOURING, IN
 static const int recommended_order[] = {INIT_EVENT_KQUEUE, INIT_EVENT_SELECT};
 #endif
 
-int init(uint64_t event_engine, uint64_t io_engine) {
+int init(uint64_t event_engine, uint64_t io_engine, const PhotonOptions& options) {
+    if (options.use_pooled_stack_allocator) {
+        use_pooled_stack_allocator();
+    }
+    if (options.bypass_threadpool) {
+        set_bypass_threadpool(true);
+    }
+
     if (vcpu_init() < 0)
         return -1;
 
@@ -71,7 +81,7 @@ int init(uint64_t event_engine, uint64_t io_engine) {
     INIT_IO(EXPORTFS, exportfs)
     INIT_IO(LIBCURL, libcurl)
 #ifdef __linux__
-    INIT_IO(LIBAIO, libaio_wrapper)
+    INIT_IO(LIBAIO, libaio_wrapper, options.libaio_queue_depth)
     INIT_IO(SOCKET_EDGE_TRIGGER, et_poller)
 #endif
     g_event_engine = event_engine;

--- a/photon.h
+++ b/photon.h
@@ -48,17 +48,25 @@ const uint64_t INIT_IO_DEFAULT = INIT_IO_LIBCURL;
 
 #undef SHIFT
 
+struct PhotonOptions {
+    int libaio_queue_depth = 32;
+    bool use_pooled_stack_allocator = false;
+    bool bypass_threadpool = false;
+};
+
 /**
  * @brief Initialize the main photon thread and ancillary threads by flags.
  *        Ancillary threads will be running in background.
  * @return 0 for success
  */
 int init(uint64_t event_engine = INIT_EVENT_DEFAULT,
-         uint64_t io_engine = INIT_IO_DEFAULT);
+         uint64_t io_engine = INIT_IO_DEFAULT,
+         const PhotonOptions& options = {});
 
 /**
  * @brief Destroy/join ancillary threads, and finish the main thread.
  */
 int fini();
+
 
 }

--- a/thread/test/test-pooled-stack-allocator.cpp
+++ b/thread/test/test-pooled-stack-allocator.cpp
@@ -37,7 +37,6 @@ uint64_t do_test(int mode) {
 }
 
 TEST(Normal, NoPool) {
-    photon::set_photon_thread_stack_allocator();
     photon::init();
     DEFER(photon::fini());
     auto spend = do_test(0);
@@ -45,7 +44,6 @@ TEST(Normal, NoPool) {
 }
 
 TEST(Normal, ThreadPool) {
-    photon::set_photon_thread_stack_allocator();
     photon::init();
     DEFER(photon::fini());
     auto spend = do_test(64);
@@ -53,17 +51,17 @@ TEST(Normal, ThreadPool) {
 }
 
 TEST(PooledAllocator, PooledStack) {
-    photon::use_pooled_stack_allocator();
-    photon::init();
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT,
+                 {.use_pooled_stack_allocator = true});
     DEFER(photon::fini());
     auto spend = do_test(0);
     LOG_TEMP("Spent ` us", spend);
 }
 
 TEST(PooledAllocator, BypassThreadPool) {
-    photon::use_pooled_stack_allocator();
-    photon::set_bypass_threadpool();
-    photon::init();
+    photon::init(
+        photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT,
+        {.use_pooled_stack_allocator = true, .bypass_threadpool = true});
     DEFER(photon::fini());
     auto spend = do_test(64);
     LOG_TEMP("Spent ` us", spend);


### PR DESCRIPTION
This Pull Request proposes enhancements to the photon::init initialization procedure by introducing the ability to set crucial options directly within or prior to its invocation. To improve user convenience and configurability, the following three new options have been added:

1. Libaio Context Size Configuration: Allows users to specify the size of the libaio context.
2. Pooled Stack Allocator Enablement: Provides an option to utilize a pooled stack allocator for improved memory management.
3. Thread Pool Bypass: Introduces a mechanism to bypass the thread pool when necessary.

In line with this enhancement, the testing suite for the pooled-stack-allocator now utilizes the extended photon::init API, taking advantage of these newly introduced options as part of its setup process. This serves as a proof-of-concept for further extension, indicating that additional configuration parameters may be seamlessly integrated following the same approach.