### PR TITLE
Fix HTTPFSv2 using proxy

### DIFF
--- a/fs/httpfs/httpfs_v2.cpp
+++ b/fs/httpfs/httpfs_v2.cpp
@@ -151,8 +151,8 @@ public:
     again:
         estring url;
         url.appends(m_url, "?", m_url_param);
-        op.req.reset(net::http::Verb::GET, url);
         op.set_enable_proxy(m_fs->get_client()->has_proxy());
+        op.req.reset(net::http::Verb::GET, url, op.enable_proxy);
         op.req.headers.merge(m_common_header);
         op.req.headers.range(offset, offset + length - 1);
         op.req.headers.content_length(0);


### PR DESCRIPTION
In httpfs V2, give it a client with proxy does not makes all file access going with proxy.

Every request will be reset during fetching requests. But`op.set_enable_proxy()` only marks it using or not using proxy.
Do or do not generate request follows proxy standard is only decided by the third argument in request reset  operation (which has default value `false`)

Fix it by setting correct argument of `reset` call.