### PR TITLE
Should not run two kinds of stack allocator in same process

### DIFF
--- a/thread/test/test-pooled-stack-allocator.cpp
+++ b/thread/test/test-pooled-stack-allocator.cpp
@@ -36,20 +36,6 @@ uint64_t do_test(int mode) {
     return done - start;
 }
 
-TEST(Normal, NoPool) {
-    photon::init();
-    DEFER(photon::fini());
-    auto spend = do_test(0);
-    LOG_TEMP("Spent ` us", spend);
-}
-
-TEST(Normal, ThreadPool) {
-    photon::init();
-    DEFER(photon::fini());
-    auto spend = do_test(64);
-    LOG_TEMP("Spent ` us", spend);
-}
-
 TEST(PooledAllocator, PooledStack) {
     photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT,
                  {.use_pooled_stack_allocator = true});


### PR DESCRIPTION
Tests in Pooled stack allocator wants to show differences between default allocator and pooled allocator,
but may leads to stacks that allocated by default allocator put into PooledAllocator, and make the PooledAllocator confused about buffer size.

All thread stack allocators should configured before the allocation of any photon thread stack.

