### PR TITLE
FIX httpfs_v2 common header for file able to replace by ioctl

### DIFF
--- a/fs/httpfs/httpfs_v2.cpp
+++ b/fs/httpfs/httpfs_v2.cpp
@@ -103,7 +103,7 @@ public:
 class HttpFile_v2 : public fs::VirtualReadOnlyFile {
 public:
     std::string m_url;
-    net::http::CommonHeaders<> m_common_header;
+    std::unordered_map<std::string, std::string> m_common_header;
     HttpFs_v2* m_fs;
     struct stat m_stat;
     uint64_t m_stat_gettime = 0;
@@ -153,7 +153,8 @@ public:
         url.appends(m_url, "?", m_url_param);
         op.set_enable_proxy(m_fs->get_client()->has_proxy());
         op.req.reset(net::http::Verb::GET, url, op.enable_proxy);
-        op.req.headers.merge(m_common_header);
+        for (auto &kv : m_common_header)
+            op.req.headers.insert(kv.first, kv.second);
         op.req.headers.range(offset, offset + length - 1);
         op.req.headers.content_length(0);
         op.timeout = tmo.timeout();
@@ -228,9 +229,10 @@ public:
         return m_exists ? 0 : -1;
     }
 
-    //TODO: 这里是否需要考虑m_common_header被打爆的问题？
     void add_header(va_list args) {
-        m_common_header.insert(va_arg(args, const char*), va_arg(args, const char*));
+        auto k = va_arg(args, const char*);
+        auto v = va_arg(args, const char*);
+        m_common_header[k] = v;
     }
 
     void add_url_param(va_list args) { m_url_param = va_arg(args, const char*); }

--- a/fs/httpfs/httpfs_v2.cpp
+++ b/fs/httpfs/httpfs_v2.cpp
@@ -103,7 +103,7 @@ public:
 class HttpFile_v2 : public fs::VirtualReadOnlyFile {
 public:
     std::string m_url;
-    std::unordered_map<std::string, std::string> m_common_header;
+    unordered_map_string_key<std::string> m_common_header;
     HttpFs_v2* m_fs;
     struct stat m_stat;
     uint64_t m_stat_gettime = 0;


### PR DESCRIPTION
This pull request addresses an issue with the ioctl set header functionality in `httpfs_v2`. Currently, `httpfs_v2` treats ioctl headers differently than httpfs, by appending records instead of handling them as a key-value map.

The proposed changes aim to align the behavior of httpfs_v2 with httpfs, ensuring that ioctl headers are treated consistently across both implementations. This will improve compatibility and make it easier for developers to work with these file systems.
