### PR TITLE
Fix IPAddress packed layout and iovector flex array

### DIFF
--- a/common/iovector.h
+++ b/common/iovector.h
@@ -236,6 +236,10 @@ inline void delete_iovector(iovector* ptr);
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#if __GNUC_MINOR__ >= 13
+#pragma GCC diagnostic ignored "-Wzero-length-bounds"
+#pragma GCC diagnostic ignored "-Wstrict-flex-arrays"
+#endif
 
 class iovector
 {
@@ -861,7 +865,7 @@ protected:
 
     struct IOVAllocation_ : public IOAlloc
     {
-        void* bases[0];
+        void* bases[];
         void* do_allocate(int size, uint16_t& nbases, uint16_t capacity)
         {
             return do_allocate(size, size, nbases, capacity);

--- a/net/socket.h
+++ b/net/socket.h
@@ -47,7 +47,7 @@ namespace net {
         union {
             in6_addr addr = {};
             struct { uint16_t _1, _2, _3, _4, _5, _6; uint8_t a, b, c, d; };
-        };
+        } __attribute__((packed));
         // For compatibility, the default constructor is still 0.0.0.0 (IPv4)
         IPAddr() {
             map_v4(htonl(INADDR_ANY));


### PR DESCRIPTION
In issue #350 

Shows new version GCC performs more check for old GNU extensions, and treats union as non-POD member in struct layout.

Here some fixes for them, tested worked in GCC 13.2 and fits the requirements of C++ standard:

1. Use flex array instead of deprecated zero-sized array which causes warning.
2. Prevent inherent to a struct with flex-array.
3. Add attribute for union in `IPAddr`, make `IPAddr` struct able to be packed