### PR TITLE
ALog Prologue now keeps only last part of source path (filename), using us timestamps

### DIFF
--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -228,11 +228,6 @@ struct tm* alog_update_time(time_t now)
     return &alog_time;
 }
 
-static struct tm* alog_update_time()
-{
-    return alog_update_time(time(0) - timezone);
-}
-
 class LogOutputFile final : public BaseLogOutput {
 public:
     uint64_t log_file_size_limit = 0;
@@ -494,19 +489,26 @@ static inline ALogInteger DEC_W2P0(uint64_t x)
     return DEC(x).width(2).padding('0');
 }
 
+namespace photon {
+uint64_t alog_update_now(uint64_t *sec, uint64_t *usec);
+}
+
 LogBuffer& operator << (LogBuffer& log, const Prologue& pro)
 {
 #ifdef LOG_BENCHMARK
     auto t = &alog_time;
 #else
-    auto t = alog_update_time();
+    uint64_t sec, usec;
+    photon::alog_update_now(&sec, &usec);
+    auto t = alog_update_time(sec - timezone);
 #endif
     log.printf(t->tm_year, '/');
     log.printf(DEC_W2P0(t->tm_mon),  '/');
     log.printf(DEC_W2P0(t->tm_mday), ' ');
     log.printf(DEC_W2P0(t->tm_hour), ':');
     log.printf(DEC_W2P0(t->tm_min),  ':');
-    log.printf(DEC_W2P0(t->tm_sec));
+    log.printf(DEC_W2P0(t->tm_sec), '.');
+    log.printf(DEC(usec).width(6).padding('0'));
 
     static const char levels[] = "|DEBUG|th=|INFO |th=|WARN |th=|ERROR|th=|FATAL|th=|TEMP |th=|AUDIT|th=";
     log.reserved = pro.level;

--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -490,7 +490,7 @@ static inline ALogInteger DEC_W2P0(uint64_t x)
 }
 
 namespace photon {
-uint64_t alog_update_now(uint64_t *sec, uint64_t *usec);
+struct timeval alog_update_now();
 }
 
 LogBuffer& operator << (LogBuffer& log, const Prologue& pro)
@@ -498,9 +498,8 @@ LogBuffer& operator << (LogBuffer& log, const Prologue& pro)
 #ifdef LOG_BENCHMARK
     auto t = &alog_time;
 #else
-    uint64_t sec, usec;
-    photon::alog_update_now(&sec, &usec);
-    auto t = alog_update_time(sec - timezone);
+    auto ts = photon::alog_update_now();
+    auto t = alog_update_time(ts.tv_sec - timezone);
 #endif
     log.printf(t->tm_year, '/');
     log.printf(DEC_W2P0(t->tm_mon),  '/');
@@ -508,7 +507,7 @@ LogBuffer& operator << (LogBuffer& log, const Prologue& pro)
     log.printf(DEC_W2P0(t->tm_hour), ':');
     log.printf(DEC_W2P0(t->tm_min),  ':');
     log.printf(DEC_W2P0(t->tm_sec), '.');
-    log.printf(DEC(usec).width(6).padding('0'));
+    log.printf(DEC(ts.tv_usec).width(6).padding('0'));
 
     static const char levels[] = "|DEBUG|th=|INFO |th=|WARN |th=|ERROR|th=|FATAL|th=|TEMP |th=|AUDIT|th=";
     log.reserved = pro.level;

--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -514,9 +514,9 @@ LogBuffer& operator << (LogBuffer& log, const Prologue& pro)
     log.printf(ALogString(&levels[pro.level * 10], 10));
     log.printf(photon::CURRENT, '|');
     if (pro.level != ALOG_AUDIT) {
-        log.printf(ALogString((char*)pro.addr_file, pro.len_file), ':');
+        log.printf(ALogString(pro.addr_file, pro.len_file), ':');
         log.printf(pro.line, '|');
-        log.printf(ALogString((char*)pro.addr_func, pro.len_func), ':');
+        log.printf(ALogString(pro.addr_func, pro.len_func), ':');
     }
     return log;
 }

--- a/common/alog.h
+++ b/common/alog.h
@@ -343,7 +343,7 @@ protected:
 
 struct Prologue
 {
-    uint64_t addr_func, addr_file;
+    const char *addr_func, *addr_file;
     int len_func, len_file;
     int line, level;
 };
@@ -448,8 +448,8 @@ struct LogBuilder {
     auto _partial_file =                                                       \
         ConstString::TSpliter<'/', ' ',                                        \
                               decltype(_prologue_file_r)>::Current::reverse(); \
-    const static Prologue prolog{(uint64_t)_prologue_func,                     \
-                                 (uint64_t)_partial_file.chars,                \
+    const static Prologue prolog{_prologue_func,                               \
+                                 _partial_file.chars,                          \
                                  sizeof(__func__) - 1,                         \
                                  (int)_partial_file.len,                       \
                                  __LINE__,                                     \
@@ -460,8 +460,8 @@ struct LogBuilder {
     auto _partial_file =                                                       \
         ConstString::TSpliter<'/', ' ',                                        \
                               decltype(_prologue_file_r)>::Current::reverse(); \
-    const static Prologue prolog{(uint64_t) __func__,                          \
-                                 (uint64_t)_partial_file.chars,                \
+    const static Prologue prolog{__func__,                                     \
+                                 _partial_file.chars,                          \
                                  sizeof(__func__) - 1,                         \
                                  (int)_partial_file.len,                       \
                                  __LINE__,                                     \

--- a/common/alog.h
+++ b/common/alog.h
@@ -537,13 +537,13 @@ inline NamedValue<T> make_named_value(const char (&name)[N], T&& value)
     return NamedValue<T> {ALogStringL(name), std::forward<T>(value)};
 }
 
-#define VALUE(x) make_named_value(#x, x)
-
-template <size_t N>
-inline LogBuffer& operator<<(LogBuffer& log,
-                             const NamedValue<char (&)[N]>& v) {
-    return log.printf('[', v.name, '=', (const char*)v.value, ']');
+template <ssize_t N, ssize_t M>
+inline NamedValue<ALogString> make_named_value(const char (&name)[N],
+                                               char (&value)[M]) {
+    return {ALogStringL(name), ALogString(value, strlen(value))};
 }
+
+#define VALUE(x) make_named_value(#x, x)
 
 template<typename T>
 inline LogBuffer& operator << (LogBuffer& log, const NamedValue<T>& v)

--- a/common/alog.h
+++ b/common/alog.h
@@ -525,6 +525,12 @@ inline NamedValue<T> make_named_value(const char (&name)[N], T&& value)
 
 #define VALUE(x) make_named_value(#x, x)
 
+template <size_t N>
+inline LogBuffer& operator<<(LogBuffer& log,
+                             const NamedValue<char (&)[N]>& v) {
+    return log.printf('[', v.name, '=', (const char*)v.value, ']');
+}
+
 template<typename T>
 inline LogBuffer& operator << (LogBuffer& log, const NamedValue<T>& v)
 {

--- a/common/alog.h
+++ b/common/alog.h
@@ -530,7 +530,7 @@ inline NamedValue<T> make_named_value(const char (&name)[N], T&& value)
 template <ssize_t N, ssize_t M>
 inline NamedValue<ALogString> make_named_value(const char (&name)[N],
                                                char (&value)[M]) {
-    return {ALogStringL(name), ALogString(value, strlen(value))};
+    return {ALogStringL(name), alog_forwarding(value)};
 }
 
 #define VALUE(x) make_named_value(#x, x)

--- a/common/alog.h
+++ b/common/alog.h
@@ -442,16 +442,30 @@ struct LogBuilder {
 };
 
 #if __GNUC__ >= 9
-#define DEFINE_PROLOGUE(level, prolog)                                          \
-    static constexpr const char* _prologue_func = __func__;                     \
-    const static Prologue prolog{                                               \
-        (uint64_t) _prologue_func,  (uint64_t)__FILE__, sizeof(__func__) - 1,   \
-        sizeof(__FILE__) - 1, __LINE__, level};
+#define DEFINE_PROLOGUE(level, prolog)                                         \
+    static constexpr const char* _prologue_func = __func__;                    \
+    auto _prologue_file_r = TSTRING(__FILE__).reverse();                       \
+    auto _partial_file =                                                       \
+        ConstString::TSpliter<'/', ' ',                                        \
+                              decltype(_prologue_file_r)>::Current::reverse(); \
+    const static Prologue prolog{(uint64_t)_prologue_func,                     \
+                                 (uint64_t)_partial_file.chars,                \
+                                 sizeof(__func__) - 1,                         \
+                                 (int)_partial_file.len,                       \
+                                 __LINE__,                                     \
+                                 level};
 #else
-#define DEFINE_PROLOGUE(level, prolog)                                  \
-    const static Prologue prolog{                                       \
-        (uint64_t) __func__,  (uint64_t)__FILE__, sizeof(__func__) - 1, \
-        sizeof(__FILE__) - 1, __LINE__, level};
+#define DEFINE_PROLOGUE(level, prolog)                                         \
+    auto _prologue_file_r = TSTRING(__FILE__).reverse();                       \
+    auto _partial_file =                                                       \
+        ConstString::TSpliter<'/', ' ',                                        \
+                              decltype(_prologue_file_r)>::Current::reverse(); \
+    const static Prologue prolog{(uint64_t) __func__,                          \
+                                 (uint64_t)_partial_file.chars,                \
+                                 sizeof(__func__) - 1,                         \
+                                 (int)_partial_file.len,                       \
+                                 __LINE__,                                     \
+                                 level};
 #endif
 
 #define _IS_LITERAL_STRING(x) \

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1090,6 +1090,12 @@ R"(
         }
         return photon::now;
     }
+    void alog_update_now(uint64_t *sec, uint64_t *usec) {
+        last_tsc = _rdtsc();
+        auto ts = update_now();
+        *sec = ts / 1000000;
+        *usec = ts % 1000000;
+    }
     int timestamp_updater_init() {
         if (!ts_updater) {
             std::thread([&]{


### PR DESCRIPTION
This pull request introduces a change to the ALog Prologue module. The modification made is to keep only the last part of the source path, specifically the filename, while utilizing microsecond timestamps.

Microsecond timestamps shares photon thread timestamp `photon::now`.