### PR TITLE
Fix prologue file field length

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -353,7 +353,7 @@ struct Prologue
         : addr_func(addr_func_),
           addr_file(addr_file_.chars),
           len_func(N - 1),
-          len_file(addr_file_.len - 1),
+          len_file(addr_file_.len),
           line(line_),
           level(level_) {}
 };


### PR DESCRIPTION
Fix issue in the alog prologue where the filename portion was mistakenly truncated, losing the last character.