### PR TITLE
Fix: make_named_tuple maked ref to temporary alogstring

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -528,22 +528,16 @@ inline NamedValue<T> make_named_value(const char (&name)[N], T&& value)
 }
 
 template <ssize_t N, ssize_t M>
-inline NamedValue<ALogString> make_named_value(const char (&name)[N],
-                                               char (&value)[M]) {
-    return {ALogStringL(name), alog_forwarding(value)};
+inline NamedValue<const char*> make_named_value(const char (&name)[N],
+                                                char (&value)[M]) {
+    return {ALogStringL(name), value};
 }
 
 #define VALUE(x) make_named_value(#x, x)
 
-template<typename T>
-inline LogBuffer& operator << (LogBuffer& log, const NamedValue<T>& v)
-{
+template <typename T>
+inline LogBuffer& operator<<(LogBuffer& log, const NamedValue<T>& v) {
     return log.printf('[', v.name, '=', v.value, ']');
-}
-
-inline LogBuffer& operator << (LogBuffer& log, const NamedValue<ALogString>& v)
-{
-    return log.printf('[', v.name, '=', '"', v.value, '"', ']');
 }
 
 // output a log message, set errno, then return a value


### PR DESCRIPTION
To make named value with char array reference acts like printing string, last fix build a temporary ALogString for value.

Value field of `NamedValue<T>` is a `CopyOrRef<T>` type, makes small object copy and big-enough type a reference.
And ALogString takes 16 bytes as a big structure, will take reference type.

that makes `make_named_value` to a char array used a reference to on-stack temporary object, which is a UB for C++, and may cause segfault with optimization in GCC 11.4.

This pull request fix it by only cast to char pointer, and let type conversion goes in later stage in logging, or said formatting step.

Though, `const NamedValue<ALogString>&` output overloading is useless, so remove it.

