### PR TITLE
Semaphore now able to be interrupted

### DIFF
--- a/thread/test/test.cpp
+++ b/thread/test/test.cpp
@@ -1933,7 +1933,7 @@ TEST(interrupt, semaphore) {
         // any errno except 0 is able to stop waiting
         photon::thread_interrupt(th, reason);
     });
-    auto ret = sem.wait(1); // nobody
+    auto ret = sem.wait_interruptible(1); // nobody
     ERRNO err;
     EXPECT_EQ(-1, ret);
     EXPECT_EQ(reason, err.no);

--- a/thread/test/test.cpp
+++ b/thread/test/test.cpp
@@ -1953,9 +1953,12 @@ TEST(condition_variable, pred) {
         cond.notify_one();
 
     });
-    auto ret = cond.wait_pred_no_lock([&flag](){ return flag == 2;});
+    auto ret = cond.wait_no_lock([&flag](){ return flag == 2;});
     EXPECT_EQ(0, ret);
     EXPECT_EQ(2, flag);
+    ret = cond.wait_no_lock([&flag](){ return flag == 3; }, 1000);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ETIMEDOUT, errno);
     flag = 0;
     photon::mutex mtx;
     SCOPED_LOCK(mtx);
@@ -1974,9 +1977,12 @@ TEST(condition_variable, pred) {
             cond.notify_one();
         }
     });
-    ret = cond.wait_pred(mtx, [&flag](){ return flag == 2;});
+    ret = cond.wait(mtx, [&flag](){ return flag == 2;});
     EXPECT_EQ(0, ret);
     EXPECT_EQ(2, flag);
+    ret = cond.wait(mtx, [&flag](){ return flag == 3; }, 1000);
+    EXPECT_EQ(-1, ret);
+    EXPECT_EQ(ETIMEDOUT, errno);
 }
 
 int main(int argc, char** arg)

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1672,7 +1672,7 @@ R"(
     {
         return cvar_do_wait((thread_list*)&q, m, timeout, spinlock_lock, spinlock_unlock);
     }
-    int semaphore::wait(uint64_t count, Timeout timeout)
+    int semaphore::wait_interruptible(uint64_t count, Timeout timeout)
     {
         if (count == 0) return 0;
         splock.lock();

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1494,7 +1494,7 @@ R"(
             *perrno = ETIMEDOUT;
             return -1;
         }
-        return (*perrno == ECANCELED) ? 0 : -1;
+        return (*perrno == -1) ? 0 : -1;
     }
     int waitq::wait(Timeout timeout)
     {
@@ -1591,7 +1591,7 @@ R"(
         ScopedLockHead h(m);
         m->owner.store(h);
         if (h)
-            prelocked_thread_interrupt(h, ECANCELED);
+            prelocked_thread_interrupt(h, -1);
     }
     static void mutex_unlock(void* m_)
     {
@@ -1680,11 +1680,14 @@ R"(
         int ret = 0;
         while (!try_substract(count)) {
             ret = waitq::wait_defer(timeout, spinlock_unlock, &splock);
+            ERRNO err;
             splock.lock();
-            if (ret < 0 && errno == ETIMEDOUT) {
+            if (ret < 0) {
                 CURRENT->semaphore_count = 0;
-                try_resume();       // when timeout, we need to try
-                splock.unlock();    // to resume next thread(s) in q
+                // when timeout, we need to try to resume next thread(s) in q
+                if (err.no == ETIMEDOUT) try_resume();
+                splock.unlock();
+                errno = err.no;
                 return ret;
             }
         }
@@ -1704,7 +1707,7 @@ R"(
             if (qfcount > cnt) break;
             cnt -= qfcount;
             qfcount = 0;
-            prelocked_thread_interrupt(th, ECANCELED);
+            prelocked_thread_interrupt(th, -1);
         }
     }
     bool semaphore::try_substract(uint64_t count)

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -398,15 +398,14 @@ namespace photon
     {
     public:
         explicit semaphore(uint64_t count = 0) : m_count(count) { }
-        int wait(uint64_t count, Timeout timeout = {});
-        int wait_uninterruptible(uint64_t count, Timeout timeout = {}) {
+        int wait(uint64_t count, Timeout timeout = {}) {
             int ret = 0;
             do {
-                ret = wait(count, timeout);
-            } while (!timeout.expired() &&
-                     (ret == 0 || (ret < 0 && errno == ESHUTDOWN)));
+                ret = wait_interruptible(count, timeout);
+            } while (ret < 0 && (errno != ESHUTDOWN && errno != ETIMEDOUT));
             return ret;
         }
+        int wait_interruptible(uint64_t count, Timeout timeout = {});
         int signal(uint64_t count)
         {
             if (count == 0) return 0;

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -363,19 +363,18 @@ namespace photon
             return waitq::wait(timeout);
         }
         template <typename LOCK, typename PRED,
-                  typename = typename std::enable_if<std::is_same<
-                      decltype(std::declval<PRED>()()), bool>::value>::type>
+                  typename = decltype(std::declval<PRED>()())>
         int wait(LOCK&& lock, PRED&& pred, Timeout timeout = {}) {
             return do_wait_pred(
                 [&] { return wait(std::forward<LOCK>(lock), timeout); },
                 std::forward<PRED>(pred), timeout);
         }
         template <typename PRED,
-                  typename = typename std::enable_if<std::is_same<
-                      decltype(std::declval<PRED>()()), bool>::value>::type>
+                  typename = decltype(std::declval<PRED>()())>
         int wait_no_lock(PRED&& pred, Timeout timeout = {}) {
-            return do_wait_pred([&] { return wait_no_lock(timeout); },
-                                std::forward<PRED>(pred), timeout);
+            return do_wait_pred(
+                [&] { return wait_no_lock(timeout); },
+                std::forward<PRED>(pred), timeout);
         }
         thread* signal()     { return resume_one(); }
         thread* notify_one() { return resume_one(); }


### PR DESCRIPTION
This pull request improves the synchronization components based on `waitq` by adding support for interruption using `thread_interrupt`. The semaphore component, which was previously unable to be interrupted, is now included in this enhancement.

Interruption of a running photon thread can be beneficial in specific situations, such as during the graceful shutdown of a process. This update enables more efficient and controlled termination of threads, resulting in improved system reliability and performance.

Additionally, the internal photon thread interruption errno used by `waitq` has been changed to -1 by default. As a result, users can now utilize all generic error numbers to interrupt synchronization components.