### PR TITLE
Fix endpoint undefined situation

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -1043,8 +1043,6 @@ EndPoint::EndPoint(const char* _ep) {
     // Detect IPv6 or IPv4
     estring ip_str = ep[pos - 1] == ']' ? ep.substr(1, pos - 2) : ep.substr(0, pos);
     auto ip = IPAddr(ip_str.c_str());
-    if (ip.undefined())
-        return;
     auto port_str = ep.substr(pos + 1);
     if (!port_str.all_digits())
         return;

--- a/net/test/test-ipv6.cpp
+++ b/net/test/test-ipv6.cpp
@@ -14,6 +14,13 @@ TEST(ipv6, endpoint) {
     EXPECT_FALSE(c.undefined());
     c = photon::net::EndPoint("[::1]:8888");
     EXPECT_FALSE(c.undefined());
+    c = photon::net::EndPoint("0.0.0.0:8888");
+    EXPECT_TRUE(c.undefined());
+    EXPECT_EQ(8888, c.port);
+    c = photon::net::EndPoint("::", 8888);
+    EXPECT_TRUE(!c.undefined());
+    EXPECT_TRUE(!c.is_ipv4());
+    EXPECT_EQ(8888, c.port);
 }
 
 TEST(ipv6, addr) {


### PR DESCRIPTION
The `undefined` has caused many troubles. Shall we use the rest 16bits padding of Endpoint as a new flag to indicate it's undefined?  @lihuiba @Coldwings 

Extra alignment are no longer needed as well.