### PR TITLE
[Discuss] Add register_fd for epoll

### DIFF
--- a/io/fd-events.h
+++ b/io/fd-events.h
@@ -58,6 +58,15 @@ public:
         return wait_for_fd(fd, EVENT_ERROR, timeout);
     }
 
+    // only works in epoll
+    virtual int register_fd(int fd) {
+        return 0;
+    }
+
+    virtual int unregister_fd(int fd) {
+        return 0;
+    }
+
     /**
      * @brief Wait for events, and fire them by photon::thread_interrupt()
      * @param timeout The *maximum* amount of time to sleep. May wake up


### PR DESCRIPTION
This PR mainly modifies the use of epoll, including 4 parts:

1. Always set `EPOLLONESHOT` in `epoll_ctl` when `ONESHOT` is set in photon. As is disscussed in https://github.com/alibaba/PhotonLibOS/issues/398. This change is meant to help address part2 issue.

2. https://github.com/alibaba/PhotonLibOS/pull/388 shows a performance issue when using epoll in a multi-thread program. This PR tries to fix it by allowing user to avoid frequent `EPOLL_CTL_ADD`:
    1. Offer user a new API to register a fd
    2. When `rm_interest` is going to delete the fd from epfd, just do nothing instead if the fd is registered (no more events of fd will be reported by epfd, because `EPOLLONESHOT` is set)
    3. Further `add_interest` will always use `EPOLL_CTL_MOD` rather than `EPOLL_CTL_ADD`
    4. Unregister the fd will `EPOLL_CTL_DEL` it

3. `entry` in `_inflight_events` will not be modified until the whole `add_interest/rm_interest` succeeds, preventing dirty data of `entry` in some failure cases

4. Combine several `rm_interest` in `wait_for_events`, concerned that:
    1. Reduce overhead of multiple calls of `epoll_ctl`
    2. Consider such unexpected case if no combination: fd is registered as part1 says. `EVENT_READ` and `EVENT_WRITE` is reported at the same time by `epoll_wait`. When `rm_interest` `EVENT_READ`, it finds that there is still `EVENT_WRITE` in `entry`'s interests, so `EPOLL_CTL_MOD` is used. After that, when `rm_interest` `EVENT_WRITE`, nothing will be done because no interest is in `entry`. Now it is expected that no events of this fd will be reported, but actually `EVENT_WRITE` is still there.

I don't know if it is necessary to `rm_interest` event individually (i.e. NO combination). If it is, I need to find another way to address issue 4.2

Finally, the new APIs `register_fd` and `unregister_fd` is not that good-designed, as it works only for epoll. Better APIs may be needed. So this PR is not formal and the main goal is looking for more discussion and suggestion. 