### PR TITLE
Add SNI support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,6 +4,9 @@ link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 add_executable(simple-example simple/simple.cpp)
 target_link_libraries(simple-example PRIVATE photon_static)
 
+add_executable(sni sni/sni.cpp)
+target_link_libraries(sni PRIVATE photon_static)
+
 add_executable(net-perf perf/net-perf.cpp)
 target_link_libraries(net-perf PRIVATE photon_static ${testing_libs})
 

--- a/examples/sni/sni.cpp
+++ b/examples/sni/sni.cpp
@@ -1,0 +1,23 @@
+#include <photon/photon.h>
+#include <photon/common/alog.h>
+#include <photon/net/http/verb.h>
+#include <photon/net/http/client.h>
+#include <photon/net/security-context/tls-stream.h>
+
+using namespace photon::net;
+
+int main(int argc, char **argv) {
+    set_log_output_level(0);
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_DEFAULT);
+    DEFER({photon::fini();});
+
+    auto tls = new_tls_context();
+    auto client = http::new_http_client(nullptr, tls);
+
+    auto op = client->new_operation(http::Verb::GET, "https://debug.fly.dev");
+    op->retry = 0;
+    int res = op->call();
+
+    printf("result: %d\n", res);
+    exit(res);
+}

--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -73,6 +73,7 @@ ISocketStream* PooledDialer::dial(std::string_view host, uint16_t port, bool sec
     if (secure) {
         tlssock->timeout(timeout);
         sock = tlssock->connect(ep);
+        tls_socket_set_hostname(sock, strhost.c_str());
     } else {
         tcpsock->timeout(timeout);
         sock = tcpsock->connect(ep);

--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -411,7 +411,8 @@ ISocketStream* new_tls_stream(TLSContext* ctx, ISocketStream* base,
 
 void tls_socket_set_hostname(ISocketStream *stream, const char *hostname) {
     if (auto s = dynamic_cast<TLSSocketStream*>(stream)) {
-        s->set_hostname(hostname);
+        if (!s->set_hostname(hostname))
+            LOG_ERROR("Failed to set hostname on tls stream: ", VALUE(stream), VALUE(hostname));
     } else if (auto s = dynamic_cast<ForwardSocketStream*>(stream)) {
         auto underlay = static_cast<ISocketStream*>(s->get_underlay_object(0));
         tls_socket_set_hostname(underlay, hostname);

--- a/net/security-context/tls-stream.h
+++ b/net/security-context/tls-stream.h
@@ -16,6 +16,7 @@ limitations under the License.
 
 #pragma once
 
+#include <photon/net/socket.h>
 #include <photon/common/object.h>
 
 #include <cstdlib>
@@ -96,6 +97,8 @@ ISocketServer* new_tls_server(TLSContext* ctx, ISocketServer* base,
  */
 ISocketClient* new_tls_client(TLSContext* ctx, ISocketClient* base,
                               bool ownership = false);
+
+void tls_socket_set_hostname(ISocketStream* stream, const char* hostname);
 
 }  // namespace net
 }  // namespace photon


### PR DESCRIPTION
I needed SNI support in the TLS implementation for use in overlaybd, to connect to my container registry. - https://github.com/containerd/overlaybd/issues/317

This change works, you can test it with the example program: `./output/sni`. It should probably be rewritten as a test.

It would be nice to not have to call an extra function, but `tlssock->connect()` takes an endpoint, which only has the IP address and not the hostname. I initially tried to create a method, like `tlssock->set_hostname(...)`, but the class hierarchy made it difficult. I didn't want to move around any classes to not break the API. So I chose to create a separate method, `tls_socket_set_hostname`, which uses `dynamic_cast`.