### PR TITLE
Realize true one-shot semantics for epoll with EPOLLONESHOT

### DIFF
--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -132,6 +132,7 @@ public:
         auto x = entry.interests & EVENT_RWE;
         auto events = evmap.translate_bitwisely(x);
         if (e.interests & ONE_SHOT) {
+            events |= EPOLLONESHOT;
             auto op = likely(eint & ONE_SHOT) ? EPOLL_CTL_MOD : EPOLL_CTL_ADD;
             auto ret = ctl(e.fd, op, events);
             return likely(ret >= 0) ? ret :

--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -129,7 +129,7 @@ public:
         auto eint = entry.interests;
         auto x = (eint | e.interests) & EVENT_RWE;
         auto events = evmap.translate_bitwisely(x);
-        if (e.interests & ONE_SHOT) {
+        if (likely(e.interests & ONE_SHOT)) {
             events |= EPOLLONESHOT;
             if (likely(eint & ONE_SHOT)) {
                 ret = ctl(e.fd, EPOLL_CTL_MOD, events);
@@ -163,7 +163,7 @@ public:
 
         int ret, op = 0;    // ^ is to flip intersected bits
         auto x = (entry.interests ^ intersection) & EVENT_RWE;
-        if (e.interests & ONE_SHOT) {
+        if (likely(e.interests & ONE_SHOT)) {
             if (!x) {
                 ret = 0; // no need to epoll_ctl()
             } else {

--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -133,7 +133,7 @@ public:
             events |= EPOLLONESHOT;
             if (likely(eint & ONE_SHOT)) {
                 ret = ctl(e.fd, EPOLL_CTL_MOD, events);
-                if (unlikely(ret < 0))
+                if (unlikely(ret < 0 && errno == ENOENT))
                     ret = ctl(e.fd, EPOLL_CTL_ADD, events);
             } else {
                 if (eint != 0) LOG_ERROR_RETURN(EINVAL, -1, "conflicted interest(s) regarding ONE_SHOT");

--- a/io/fd-events.h
+++ b/io/fd-events.h
@@ -24,6 +24,7 @@ namespace photon {
 const static uint32_t EVENT_READ = 1;
 const static uint32_t EVENT_WRITE = 2;
 const static uint32_t EVENT_ERROR = 4;
+const static uint32_t EVENT_RWE = EVENT_READ | EVENT_WRITE | EVENT_ERROR;
 const static uint32_t EDGE_TRIGGERED = 0x4000;
 const static uint32_t ONE_SHOT = 0x8000;
 
@@ -44,7 +45,7 @@ public:
      * @return 0 for success, which means event arrived in time
      *         -1 for failure, could be timeout or interrupted by another thread
      */
-    virtual int wait_for_fd(int fd, uint32_t interests, uint64_t timeout) = 0;
+    virtual int wait_for_fd(int fd, uint32_t interest, uint64_t timeout) = 0;
 
     int wait_for_fd_readable(int fd, uint64_t timeout = -1) {
         return wait_for_fd(fd, EVENT_READ, timeout);

--- a/net/test/test.cpp
+++ b/net/test/test.cpp
@@ -695,18 +695,20 @@ void* start_server(void*) {
 
 TEST(utils, gethostbyname) {
     net::IPAddr localhost("127.0.0.1");
-    net::IPAddr addr;
-    net::gethostbyname("localhost", &addr);
-    EXPECT_EQ(localhost.to_nl(), addr.to_nl());
     std::vector<net::IPAddr> addrs;
     net::gethostbyname("localhost", addrs);
     EXPECT_GT((int)addrs.size(), 0);
-    EXPECT_EQ(localhost.to_nl(), addrs[0].to_nl());
+
     net::IPAddr host = net::gethostbypeer("localhost");
-    EXPECT_EQ(localhost.to_nl(), host.to_nl());
-    for (auto &x : addrs) {
+    bool found_localhost = false, found_host = false;
+    for (auto& x: addrs) {
         LOG_INFO(VALUE(x));
+        EXPECT_TRUE(x.is_loopback());
+        found_localhost |= (x == localhost);
+        found_host |= (x == host);
     }
+    EXPECT_TRUE(found_localhost);
+    EXPECT_TRUE(found_host);
 }
 
 TEST(utils, resolver) {

--- a/net/utils.h
+++ b/net/utils.h
@@ -94,7 +94,7 @@ inline int gethostbyname(const char* name, IPAddr* buf, int bufsize = 1) {
     int i = 0;
     auto cb = [&](IPAddr addr) {
         if (i < bufsize) buf[i++] = addr;
-        return 0;
+        return (i < bufsize) ? 0 : -1;
     };
     return _gethostbyname(name, cb);
 }


### PR DESCRIPTION
So that all invocations to wait_for_fd_xxx() will benefit from it, especially the one in cascading engine.