### PR TITLE
openssl not use locking after 1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(PHOTON_CXX_STANDARD "14" CACHE STRING "C++ standard")
 option(PHOTON_BUILD_TESTING "enable build testing" OFF)
 option(PHOTON_ENABLE_URING "enable io_uring function" OFF)
 option(PHOTON_ENABLE_FUSE "enable fuse function" OFF)
+option(PHOTON_GLOBAL_INIT_OPENSSL "Turn this off if any of your third-party libs inits old-version OpenSSL as well,
+because Photon will register coroutine locks for crypto. But don't bother if you have latest OpenSSL >= 1.1.0" ON)
 option(PHOTON_ENABLE_SASL "enable sasl" OFF)
 option(PHOTON_ENABLE_MIMIC_VDSO "enable mimic vdso" OFF)
 option(PHOTON_ENABLE_FSTACK_DPDK "Use f-stack + DPDK as the event engine" OFF)
@@ -213,6 +215,9 @@ target_include_directories(photon_obj PRIVATE include ${OPENSSL_INCLUDE_DIRS} ${
         ${ZLIB_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS}
 )
 target_compile_definitions(photon_obj PRIVATE _FILE_OFFSET_BITS=64 FUSE_USE_VERSION=29)
+if (PHOTON_GLOBAL_INIT_OPENSSL)
+    target_compile_definitions(photon_obj PRIVATE PHOTON_GLOBAL_INIT_OPENSSL)
+endif ()
 if (PHOTON_ENABLE_URING)
     target_include_directories(photon_obj PRIVATE ${URING_INCLUDE_DIRS})
     target_compile_definitions(photon_obj PRIVATE PHOTON_URING=on)

--- a/fs/httpfs/httpfs_v2.cpp
+++ b/fs/httpfs/httpfs_v2.cpp
@@ -281,9 +281,9 @@ IFileSystem* new_httpfs_v2(bool default_https, uint64_t conn_timeout,
                          client, client_ownership);
 }
 
-IFile* new_httpfile_v2(const char* url, HttpFs_v2* httpfs, uint64_t conn_timeout,
+IFile* new_httpfile_v2(const char* url, IFileSystem* httpfs, uint64_t conn_timeout,
                     uint64_t stat_timeout) {
-    return new HttpFile_v2(url, httpfs, conn_timeout, stat_timeout);
+    return new HttpFile_v2(url, (HttpFs_v2*) httpfs, conn_timeout, stat_timeout);
 }
 }  // namespace fs
 }

--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -139,6 +139,7 @@ public:
         return (Object*) (uint64_t) fd;
     }
     int close() final {
+        if (fd < 0) return 0;
         get_vcpu()->master_event_engine->wait_for_fd(fd, 0, -1UL);
         auto ret = ::close(fd);
         fd = -1;


### PR DESCRIPTION
Going to backport to 0.7