### PR TITLE
retval<T> to return a value and an error number at the same time

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -26,6 +26,7 @@ limitations under the License.
 
 #include <photon/common/utility.h>
 #include <photon/common/conststr.h>
+#include <photon/common/retval.h>
 
 class ILogOutput {
 protected:
@@ -508,6 +509,18 @@ struct ERRNO
 
 LogBuffer& operator << (LogBuffer& log, ERRNO e);
 
+inline LogBuffer& operator << (LogBuffer& log, const photon::retval_base& rvb) {
+    auto x = rvb._errno;
+    assert(0<x && x<INT_MAX);
+    return x ? log << ERRNO((int)x) : log;
+}
+
+template<typename T> inline
+LogBuffer& operator << (LogBuffer& log, const photon::retval<T>& v) {
+    return v.succeeded() ? (log << v.get()) :
+        (log << (const photon::retval_base&)v);
+}
+
 template<typename T>
 struct NamedValue
 {
@@ -551,6 +564,13 @@ inline LogBuffer& operator<<(LogBuffer& log, const NamedValue<T>& v) {
     LOG_ERROR(__VA_ARGS__, ' ', eno);               \
     if (new_errno) eno.set(new_errno);              \
     return retv;                                    \
+}
+
+#define LOG_ERROR_RETVAL(error, ...) {  \
+    retval_base e{error};               \
+    assert(e.failed());                 \
+    LOG_ERROR(__VA_ARGS__, ' ', e);     \
+    return e;                           \
 }
 
 // Acts like a LogBuilder

--- a/common/alog.h
+++ b/common/alog.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <ctime>
 #include <utility>
 #include <type_traits>
+#include <limits.h>
 
 #include <photon/common/utility.h>
 #include <photon/common/conststr.h>

--- a/common/alog.h
+++ b/common/alog.h
@@ -513,13 +513,17 @@ LogBuffer& operator << (LogBuffer& log, ERRNO e);
 inline LogBuffer& operator << (LogBuffer& log, const photon::retval_base& rvb) {
     auto x = rvb._errno;
     assert(0<x && x<INT_MAX);
-    return x ? log << ERRNO((int)x) : log;
+    return x ? (log << ERRNO((int)x)) : log;
 }
 
 template<typename T> inline
 LogBuffer& operator << (LogBuffer& log, const photon::retval<T>& v) {
-    return v.succeeded() ? (log << v.get()) :
-        (log << (const photon::retval_base&)v);
+    return v.succeeded() ? (log << v.get()) : (log << v.base());
+}
+
+template<> inline
+LogBuffer& operator << <void> (LogBuffer& log, const photon::retval<void>& v) {
+    return log << v.base();
 }
 
 template<typename T>

--- a/common/alog.h
+++ b/common/alog.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include <ctime>
 #include <utility>
 #include <type_traits>
-#include <limits.h>
 
 #include <photon/common/utility.h>
 #include <photon/common/conststr.h>
@@ -512,7 +511,6 @@ LogBuffer& operator << (LogBuffer& log, ERRNO e);
 
 inline LogBuffer& operator << (LogBuffer& log, const photon::retval_base& rvb) {
     auto x = rvb._errno;
-    assert(0<x && x<INT_MAX);
     return x ? (log << ERRNO((int)x)) : log;
 }
 

--- a/common/retval.h
+++ b/common/retval.h
@@ -32,15 +32,6 @@ struct retval_base {
 template<typename T> inline
 T failure_value() { return 0; }
 
-#define DEFINE_FAILURE_VALUE(type, val) \
-    template<> inline type failure_value<type>() { return val; }
-
-DEFINE_FAILURE_VALUE(int8_t,  -1)
-DEFINE_FAILURE_VALUE(int16_t, -1)
-DEFINE_FAILURE_VALUE(int32_t, -1)
-DEFINE_FAILURE_VALUE(int64_t, -1)
-
-
 template<typename T>
 struct retval : public retval_base {
     T _val;
@@ -92,3 +83,12 @@ struct retval<void> : public retval_base {
 };
 
 }
+
+#define DEFINE_FAILURE_VALUE(type, val) namespace photon {  \
+    template<> inline type failure_value<type>() { return val; } }
+
+DEFINE_FAILURE_VALUE(int8_t,  -1)
+DEFINE_FAILURE_VALUE(int16_t, -1)
+DEFINE_FAILURE_VALUE(int32_t, -1)
+DEFINE_FAILURE_VALUE(int64_t, -1)
+

--- a/common/retval.h
+++ b/common/retval.h
@@ -68,7 +68,7 @@ struct retval : public retval_base {
 
 template<>
 struct retval<void> : public retval_base {
-    retval(int _errno) : retval_base{(uint64_t)_errno} { }
+    retval(int _errno = 0) : retval_base{(uint64_t)_errno} { }
     retval(const retval_base& rvb) : retval_base(rvb) { }
     void get() const { }
     retval_base base() const {

--- a/common/retval.h
+++ b/common/retval.h
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+#include <inttypes.h>
+#include <assert.h>
+
+namespace photon {
+
+struct retval_base {
+    // use uint64_t to make sure the result is returned
+    // via another register, so that it is accessed easily
+    uint64_t _errno = 0;
+    bool failed() const { return _errno; }
+    bool succeeded() const { return !failed(); }
+    int get_errno() const { assert(_errno > 0); return (int)_errno; }
+};
+
+template<typename T> inline
+T failure_value() { return 0; }
+
+#define DEFINE_FAILURE_VALUE(type, val) \
+    template<> inline type failure_value<type>() { return val; }
+
+DEFINE_FAILURE_VALUE(int16_t, -1)
+DEFINE_FAILURE_VALUE(int32_t, -1)
+DEFINE_FAILURE_VALUE(int64_t, -1)
+
+
+template<typename T>
+struct retval : public retval_base {
+    T _val;
+    retval(T x) : _val(x) { }
+    retval(int _errno, T val) : retval_base{(uint64_t)_errno}, _val(val) {
+        assert(failed());
+    }
+    retval(const retval_base& rvb) : retval_base(rvb) {
+        assert(failed());
+        _val = failure_value<T>();
+    }
+    operator T() const {
+        return get();
+    }
+    T get() const {
+        return _val;
+    }
+    bool operator==(const retval& rhs) const {
+        return _errno ? (_errno == rhs._errno) : (_val == rhs._val);
+    }
+    bool operator!=(const retval& rhs) const {
+        return !(*this == rhs);
+    }
+    bool operator==(T rhs) const {
+        return _val == rhs;
+    }
+    bool operator!=(T rhs) const {
+        return _val != rhs;
+    }
+};
+
+
+}

--- a/common/retval.h
+++ b/common/retval.h
@@ -35,6 +35,7 @@ T failure_value() { return 0; }
 #define DEFINE_FAILURE_VALUE(type, val) \
     template<> inline type failure_value<type>() { return val; }
 
+DEFINE_FAILURE_VALUE(int8_t,  -1)
 DEFINE_FAILURE_VALUE(int16_t, -1)
 DEFINE_FAILURE_VALUE(int32_t, -1)
 DEFINE_FAILURE_VALUE(int64_t, -1)
@@ -57,6 +58,9 @@ struct retval : public retval_base {
     T get() const {
         return _val;
     }
+    retval_base base() const {
+        return *this;
+    }
     bool operator==(const retval& rhs) const {
         return _errno ? (_errno == rhs._errno) : (_val == rhs._val);
     }
@@ -71,5 +75,20 @@ struct retval : public retval_base {
     }
 };
 
+template<>
+struct retval<void> : public retval_base {
+    retval(int _errno) : retval_base{(uint64_t)_errno} { }
+    retval(const retval_base& rvb) : retval_base(rvb) { }
+    void get() const { }
+    retval_base base() const {
+        return *this;
+    }
+    bool operator==(const retval& rhs) const {
+        return _errno == rhs._errno;
+    }
+    bool operator!=(const retval& rhs) const {
+        return !(*this == rhs);
+    }
+};
 
 }

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -904,6 +904,14 @@ photon::retval<int> foo(int i) {
     }
 }
 
+retval<void> ret_failed() {
+    return {EBADF};
+}
+
+retval<void> ret_succeeded() {
+    return {0};
+}
+
 TEST(retval, basic) {
     const static retval<int> rvs[] =
         {{32}, {EINVAL, -2345}, {EADDRINUSE, -1234}, {EALREADY, -5234}};
@@ -917,6 +925,12 @@ TEST(retval, basic) {
         LOG_DEBUG("got ", ret);
         EXPECT_EQ(ret, rvs[i]);
     }
+    auto A = ret_failed();
+    EXPECT_TRUE(A.failed());
+    LOG_DEBUG(A);
+    auto B = ret_succeeded();
+    EXPECT_TRUE(B.succeeded());
+    LOG_DEBUG(B);
 }
 
 template <class T>

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -909,7 +909,7 @@ retval<void> ret_failed() {
 }
 
 retval<void> ret_succeeded() {
-    return {0};
+    return {/* 0 */};
 }
 
 TEST(retval, basic) {

--- a/include/photon/common/retval.h
+++ b/include/photon/common/retval.h
@@ -1,0 +1,1 @@
+../../../common/retval.h


### PR DESCRIPTION
so as to avoid some bugs:

* unintentionally change the global errno by some function calls (e.g. printf or LOG_XXXX) in the error handling path,  causing misunderstanding about the error

* return an error but forget to set errno, causing incorrect handling of the error

In addition, ```retval<T>``` makes the error number returned in register, more efficient than the global thread-local ```errno``` variable.

