### PR TITLE
Remove some outdated libcurl option usage in curl wrapper header

### DIFF
--- a/net/curl.h
+++ b/net/curl.h
@@ -240,7 +240,6 @@ public:
             return;
         }
         setopt(CURLOPT_ERRORBUFFER, m_errmsg);
-        setopt(CURLOPT_DNS_USE_GLOBAL_CACHE, 0L);
         setopt(CURLOPT_NOSIGNAL, 1L);
         setopt(CURLOPT_TCP_NODELAY, 1L);
         m_errmsg[0] = '\0';
@@ -413,7 +412,6 @@ public:
         set_read_stream(rstream);
         set_write_stream(wstream);
         setopt(CURLOPT_UPLOAD, 1L);
-        setopt(CURLOPT_PUT, 1L);
         setopt(CURLOPT_URL, url);
         setopt(CURLOPT_HTTPHEADER, headers.list);
 #if LIBCURL_VERSION_MAJOR > 7 || LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 37


### PR DESCRIPTION
#435 mentioned some deprecated curl option in net/curl.h

`CURLOPT_DNS_USE_GLOBAL_CACHE` and `CURLOPT_PUT` are deprecated in libcurl 7.11 7.12 version, which is toooo old that photon may never considering support them.

`CURLOPT_PUT` is as same as `CURLOPT_UPLOAD`, and is already set in code.

`CURLOPT_DNS_USE_GLOBAL_CACHE` become deprecated, should set using `curl_share` API, but here in code disabled sharing global dns cache, which is default action in libcurl, so it can be simply removed.