### PR TITLE
zlib and uring source build didn't have -O3

### DIFF
--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -27,7 +27,7 @@ function(build_from_src [dep])
                 URL_MD5 9b8aa094c4e5765dabf4da391f00d15c
                 UPDATE_DISCONNECTED ON
                 BUILD_IN_SOURCE ON
-                CONFIGURE_COMMAND CFLAGS=-fPIC ./configure --prefix=${BINARY_DIR} --static
+                CONFIGURE_COMMAND sh -c "CFLAGS=\"-fPIC -O3\" ./configure --prefix=${BINARY_DIR} --static"
                 BUILD_COMMAND $(MAKE)
                 INSTALL_COMMAND $(MAKE) install
         )
@@ -43,7 +43,7 @@ function(build_from_src [dep])
                 UPDATE_DISCONNECTED ON
                 BUILD_IN_SOURCE ON
                 CONFIGURE_COMMAND ./configure --prefix=${BINARY_DIR}
-                BUILD_COMMAND V=1 CFLAGS=-fPIC $(MAKE) -C src
+                BUILD_COMMAND sh -c "V=1 CFLAGS=\"-fPIC -g -O3 -Wall -Wextra -fno-stack-protector\" $(MAKE) -C src"
                 INSTALL_COMMAND $(MAKE) install
         )
         set(URING_INCLUDE_DIRS ${BINARY_DIR}/include PARENT_SCOPE)


### PR DESCRIPTION
liburing's makefile surprisingly used `?=` instead of `+=`  ...  🤦

<img width="393" alt="image" src="https://github.com/alibaba/PhotonLibOS/assets/4076315/86736c6a-e1f4-4bcd-b40a-eaf333a75009">

https://github.com/axboe/liburing/blob/f1dfb94bdaf1de14281030e28dd64f4d23d615a3/src/Makefile#L13C8-L13C9