### PR TITLE
epoll_wait allows to wait 0ms, instead of the previous 1ms

### DIFF
--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -203,10 +203,8 @@ ok:     entry.interests |= eint;
     int do_epoll_wait(uint64_t timeout) {
         assert(_events_remain == 0);
         uint8_t cool_down_ms = 1;
-        // since timeout may less than 1ms
-        // in such condition, timeout_ms should be at least 1
-        // or it may call epoll_wait without any idle
-        timeout = (timeout && timeout < 1024) ? 1 : timeout / 1024;
+        // The granularity of epoll_wait is milliseconds, but epoll_wait 0 finishes in microseconds
+        timeout /= 1000;
         while (_engine_fd > 0) {
             int ret = epoll_wait(_engine_fd, _events, LEN(_events), timeout);
             if (ret < 0) {


### PR DESCRIPTION
- Continuously calling epoll_wait 0 (when scheduler is idle) will not incurease CPU usage at all
- epoll_wait 0 only consumes 1 us, even better than io_uring's 5 us 