### PR TITLE
fix dns resolver discard_cache

### DIFF
--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -304,8 +304,10 @@ public:
 
     void discard_cache(const char *host, IPAddr ip) override {
         auto ipaddr = dnscache_.borrow(host);
-        if (ip.undefined() || ipaddr->empty()) ipaddr.recycle(true);
-        else {
+        if (ip.undefined() || ipaddr->empty()) {
+            ipaddr->delete_all();
+            ipaddr.recycle(true);
+        } else {
             for (auto itr = ipaddr->rbegin(); itr != ipaddr->rend(); itr++) {
                 if ((*itr)->addr == ip) {
                     ipaddr->erase(*itr);


### PR DESCRIPTION
call ipaddr->delete_all() if ip.undefined() 