### PR TITLE
restore errno when release success in pooled socket

### DIFF
--- a/net/pooled_socket.cpp
+++ b/net/pooled_socket.cpp
@@ -230,9 +230,11 @@ public:
 
     bool release(const EndPoint& ep, ISocketStream* stream) {
         auto fd = stream->get_underlay_fd();
+        ERRNO err;
         if (!stream_alive(fd)) return false;
         auto node = new StreamListNode(ep, stream, fd, TTL_us);
         push_into_pool(node);
+        errno = err.no;
         return true;
     }
 


### PR DESCRIPTION
In release() of TCPSocketPool, the call to stream_alive() modifies errno even if it succeeds. So restore and reset errno if stream_alive() success.