### PR TITLE
FIX: epoll-ng wait for fd with event 0

### DIFF
--- a/.github/workflows/ci.linux.x86-64.yml
+++ b/.github/workflows/ci.linux.x86-64.yml
@@ -62,6 +62,8 @@ jobs:
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest -E test-lockfree --timeout 3600 -V
+          export PHOTON_CI_EV_ENGINE=epoll_ng
+          ctest -E test-lockfree --timeout 3600 -V
 
   gcc921:
     needs: gcc850
@@ -102,6 +104,8 @@ jobs:
           cd build/output/
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
+          ctest -E test-lockfree --timeout 3600 -V
+          export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
 
   gcc1031:
@@ -144,6 +148,8 @@ jobs:
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest -E test-lockfree --timeout 3600 -V
+          export PHOTON_CI_EV_ENGINE=epoll_ng
+          ctest -E test-lockfree --timeout 3600 -V
 
   gcc1121:
     needs: gcc1031
@@ -185,6 +191,8 @@ jobs:
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest -E test-lockfree --timeout 3600 -V
+          export PHOTON_CI_EV_ENGINE=epoll_ng
+          ctest -E test-lockfree --timeout 3600 -V
 
   gcc1211:
     needs: gcc1121
@@ -225,6 +233,8 @@ jobs:
           cd build/output/
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
+          ctest -E test-lockfree --timeout 3600 -V
+          export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
 
 

--- a/io/epoll-ng.cpp
+++ b/io/epoll-ng.cpp
@@ -288,6 +288,7 @@ public:
     virtual int cancel_wait() override { return eventfd_write(evfd, 1); }
 
     int wait_for_fd(int fd, uint32_t interests, Timeout timeout) override {
+        if (interests == 0) return 0;
         Event waiter{fd, interests | ONE_SHOT, CURRENT};
         Event event{fd, interests | ONE_SHOT, &waiter};
         int ret = add_interest(event);

--- a/net/http/test/server_function_test.cpp
+++ b/net/http/test/server_function_test.cpp
@@ -243,7 +243,10 @@ int chunked_handler_pt(void*, net::ISocketStream* sock) {
 
 int test_director(void* src_, Request& src, Request& dst) {
     auto source_server = (ISocketServer*)src_;
-    dst.reset(src.verb(), to_url(source_server, "/filename_not_important"));
+    if (source_server)
+        dst.reset(src.verb(), to_url(source_server, "/filename_not_important"));
+    else
+        dst.reset(src.verb(), "http://localhost:0/filename_not_important");
     dst.headers.insert("proxy_server_test", "just4test");
     for (auto kv = src.headers.begin(); kv != src.headers.end(); kv++) {
         if (kv.first() != "Host") dst.headers.insert(kv.first(), kv.second(), 1);
@@ -433,7 +436,7 @@ TEST(http_server, proxy_handler_failure) {
     DEFER(delete tcpserver);
     auto proxy_server = new_http_server();
     DEFER(delete proxy_server);
-    auto proxy_handler = new_proxy_handler({tcpserver, &test_director},
+    auto proxy_handler = new_proxy_handler({nullptr, &test_director},
                                            {nullptr, &test_modifier}, client_proxy);
     proxy_server->add_handler(proxy_handler);
     tcpserver->set_handler(proxy_server->get_connection_handler());

--- a/photon.cpp
+++ b/photon.cpp
@@ -73,7 +73,8 @@ int __photon_init(uint64_t event_engine, uint64_t io_engine, const PhotonOptions
     const uint64_t ALL_ENGINES =
             INIT_EVENT_EPOLL   | INIT_EVENT_EPOLL_NG |
             INIT_EVENT_IOURING | INIT_EVENT_KQUEUE |
-            INIT_EVENT_SELECT  | INIT_EVENT_IOCP;
+            INIT_EVENT_SELECT  | INIT_EVENT_IOCP |
+            INIT_EVENT_EPOLL_NG;
     if (event_engine & ALL_ENGINES) {
         bool ok = false;
         for (auto x : recommended_order) {

--- a/test/ci-tools.cpp
+++ b/test/ci-tools.cpp
@@ -25,6 +25,8 @@ static void parse_env_eng() {
         _engine = photon::INIT_EVENT_IOURING;
     } else if (strcmp(_engine_name, "kqueue") == 0) {
         _engine = photon::INIT_EVENT_KQUEUE;
+    } else if (strcmp(_engine_name, "epoll_ng") == 0) {
+        _engine = photon::INIT_EVENT_EPOLL_NG;
     } else {
         printf("invalid event engine: %s\n", _engine_name);
         _engine_name = nullptr;
@@ -39,6 +41,7 @@ static estring_view get_engine_name(uint64_t eng) {
         case INIT_EVENT_KQUEUE:     return "kqueue";
         case INIT_EVENT_SELECT:     return "select";
         case INIT_EVENT_IOCP:       return "iocp";
+        case INIT_EVENT_EPOLL_NG:   return "epoll_ng";
     }
     return {};
 }
@@ -66,7 +69,8 @@ int init(uint64_t event_engine, uint64_t io_engine, const PhotonOptions& options
     LOG_INFO("enter CI overriden photon::init()");
     const uint64_t all_engines = INIT_EVENT_EPOLL  |
             INIT_EVENT_IOURING | INIT_EVENT_KQUEUE |
-            INIT_EVENT_SELECT  | INIT_EVENT_IOCP;
+            INIT_EVENT_SELECT  | INIT_EVENT_IOCP   |
+            INIT_EVENT_EPOLL_NG;
     auto arg_specified = event_engine & all_engines;
     LOG_INFO("argument specified: ` (`)", get_engine_names(arg_specified), arg_specified);
     LOG_INFO("environment specified: '`'", _engine_name);


### PR DESCRIPTION
`epoll-ng` `wait_for_fd` with event 0 (no event) should return immediately.