### PR TITLE
CI with fully parallel jobs

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -13,7 +13,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Create Pull Request to the next higher release version
 

--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -15,13 +15,13 @@ jobs:
       options: --cpus 4
 
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -48,13 +48,13 @@ jobs:
       options: --cpus 4
 
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/ci.linux.x86-64.yml
+++ b/.github/workflows/ci.linux.x86-64.yml
@@ -7,9 +7,17 @@ on:
     branches: [ "main", "release/*" ]
 
 jobs:
-  gcc850:
-    runs-on: [self-hosted, compiler]
+  test850:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/coldwings/photon-ut-base:latest
+      options: --cpus 4 --privileged
     steps:
+      - uses: szenius/set-timezone@v1.2
+        with:
+          timezoneLinux: "Asia/Shanghai"
+          timezoneMacos: "Asia/Shanghai"
+          timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v3
       - name: Build850
         run: |
@@ -20,72 +28,18 @@ jobs:
                          -D PHOTON_ENABLE_SASL=ON         \
                          -D PHOTON_ENABLE_FUSE=ON         \
                          -D PHOTON_ENABLE_URING=ON        \
-                         -D PHOTON_ENABLE_EXTFS=ON        \
-                        #  -D PHOTON_BUILD_DEPENDENCIES=ON  \
-                        #  -D PHOTON_AIO_SOURCE=""          \
-                        #  -D PHOTON_ZLIB_SOURCE=""         \
-                        #  -D PHOTON_CURL_SOURCE=""         \
-                        #  -D PHOTON_OPENSSL_SOURCE=""      \
-                        #  -D PHOTON_GFLAGS_SOURCE=""       \
-                        #  -D PHOTON_GOOGLETEST_SOURCE=""   \
-                        #  -D PHOTON_URING_SOURCE=https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz
-
+                         -D PHOTON_ENABLE_EXTFS=ON
           cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
-          ln -f common/checksum/test/checksum.in build/output/
-          tar -c -h --use-compress-program=zstdmt -f output850.tzs build/output/
-      - name: Upload850
-        uses: actions/upload-artifact@v4
-        with:
-          name: output850
-          path: output850.tzs
-          retention-days: 5
-          compression-level: 0
-
-  test850:
-    needs: gcc850
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/coldwings/photon-ut-base:latest
-      options: --cpus 4 --privileged
-    steps:
-      - uses: szenius/set-timezone@v1.2
-        with:
-          timezoneLinux: "Asia/Shanghai"
-          timezoneMacos: "Asia/Shanghai"
-          timezoneWindows: "China Standard Time"
-      - uses: actions/download-artifact@v4
-        with:
-          name: output850
       - name: test
         run: |
-          tar -x --use-compress-program=zstdmt -f output850.tzs
           cd build/output/
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
-
-  gcc921:
-    needs: gcc850
-    runs-on: [self-hosted, compiler]
-    steps:
-      - name: Build921
-        run: |
-          source /opt/rh/gcc-toolset-9/enable
-          cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
-          ln -f common/checksum/test/checksum.in build/output/
-          tar -c --use-compress-program=zstdmt -f output921.tzs build/output/
-      - name: Upload921
-        uses: actions/upload-artifact@v4
-        with:
-          name: output921
-          path: output921.tzs
-          retention-days: 5
-          compression-level: 0
 
   test921:
-    needs: gcc921
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -96,39 +50,29 @@ jobs:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/download-artifact@v4
-        with:
-          name: output921
+      - uses: actions/checkout@v3
+      - name: Build850
+        run: |
+          source /opt/rh/gcc-toolset-9/enable
+          rm -fr build
+          cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel   \
+                         -D PHOTON_ENABLE_ECOSYSTEM=ON    \
+                         -D PHOTON_BUILD_TESTING=ON       \
+                         -D PHOTON_ENABLE_SASL=ON         \
+                         -D PHOTON_ENABLE_FUSE=ON         \
+                         -D PHOTON_ENABLE_URING=ON        \
+                         -D PHOTON_ENABLE_EXTFS=ON
+          cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
       - name: test
         run: |
-          tar -x --use-compress-program=zstdmt -f output921.tzs
           cd build/output/
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
-
-  gcc1031:
-    needs: gcc921
-    runs-on: [self-hosted, compiler]
-    steps:
-      - name: Build1031
-        run: |
-          source /opt/rh/gcc-toolset-10/enable
-          cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
-          ln -f common/checksum/test/checksum.in build/output/
-          tar -c --use-compress-program=zstdmt -f output1031.tzs build/output/
-      - name: Upload1031
-        uses: actions/upload-artifact@v4
-        with:
-          name: output1031
-          path: output1031.tzs
-          retention-days: 5
-          compression-level: 0
 
   test1031:
-    needs: gcc1031
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -139,39 +83,29 @@ jobs:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/download-artifact@v4
-        with:
-          name: output1031
+      - uses: actions/checkout@v3
+      - name: Build850
+        run: |
+          source /opt/rh/gcc-toolset-10/enable
+          rm -fr build
+          cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel   \
+                         -D PHOTON_ENABLE_ECOSYSTEM=ON    \
+                         -D PHOTON_BUILD_TESTING=ON       \
+                         -D PHOTON_ENABLE_SASL=ON         \
+                         -D PHOTON_ENABLE_FUSE=ON         \
+                         -D PHOTON_ENABLE_URING=ON        \
+                         -D PHOTON_ENABLE_EXTFS=ON
+          cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
       - name: test
         run: |
-          tar -x --use-compress-program=zstdmt -f output1031.tzs
           cd build/output/
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
-
-  gcc1121:
-    needs: gcc1031
-    runs-on: [self-hosted, compiler]
-    steps:
-      - name: Build1121
-        run: |
-          source /opt/rh/gcc-toolset-10/enable
-          cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
-          ln -f common/checksum/test/checksum.in build/output/
-          tar -c --use-compress-program=zstdmt -f output1121.tzs build/output/
-      - name: Upload1121
-        uses: actions/upload-artifact@v4
-        with:
-          name: output1121
-          path: output1121.tzs
-          retention-days: 5
-          compression-level: 0
 
   test1121:
-    needs: gcc1121
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -182,39 +116,29 @@ jobs:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/download-artifact@v4
-        with:
-          name: output1121
+      - uses: actions/checkout@v3
+      - name: Build850
+        run: |
+          source /opt/rh/gcc-toolset-11/enable
+          rm -fr build
+          cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel   \
+                         -D PHOTON_ENABLE_ECOSYSTEM=ON    \
+                         -D PHOTON_BUILD_TESTING=ON       \
+                         -D PHOTON_ENABLE_SASL=ON         \
+                         -D PHOTON_ENABLE_FUSE=ON         \
+                         -D PHOTON_ENABLE_URING=ON        \
+                         -D PHOTON_ENABLE_EXTFS=ON
+          cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
       - name: test
         run: |
-          tar -x --use-compress-program=zstdmt -f output1121.tzs
           cd build/output/
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
-
-  gcc1211:
-    needs: gcc1121
-    runs-on: [self-hosted, compiler]
-    steps:
-      - name: Build1211
-        run: |
-          source /opt/rh/gcc-toolset-10/enable
-          cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
-          ln -f common/checksum/test/checksum.in build/output/
-          tar -c --use-compress-program=zstdmt -f output1211.tzs build/output/
-      - name: Upload1211
-        uses: actions/upload-artifact@v4
-        with:
-          name: output1211
-          path: output1211.tzs
-          retention-days: 5
-          compression-level: 0
 
   test1211:
-    needs: gcc1211
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -225,17 +149,25 @@ jobs:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/download-artifact@v4
-        with:
-          name: output1211
+      - uses: actions/checkout@v3
+      - name: Build850
+        run: |
+          source /opt/rh/gcc-toolset-12/enable
+          rm -fr build
+          cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel   \
+                         -D PHOTON_ENABLE_ECOSYSTEM=ON    \
+                         -D PHOTON_BUILD_TESTING=ON       \
+                         -D PHOTON_ENABLE_SASL=ON         \
+                         -D PHOTON_ENABLE_FUSE=ON         \
+                         -D PHOTON_ENABLE_URING=ON        \
+                         -D PHOTON_ENABLE_EXTFS=ON
+          cmake --build build -j $(nproc) --clean-first -- VERBOSE=1
       - name: test
         run: |
-          tar -x --use-compress-program=zstdmt -f output1211.tzs
           cd build/output/
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=io_uring
           ctest -E test-lockfree --timeout 3600 -V
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
-
 

--- a/.github/workflows/ci.linux.x86-64.yml
+++ b/.github/workflows/ci.linux.x86-64.yml
@@ -13,12 +13,12 @@ jobs:
       image: ghcr.io/coldwings/photon-ut-base:latest
       options: --cpus 4 --privileged
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build850
         run: |
           rm -fr build
@@ -45,12 +45,12 @@ jobs:
       image: ghcr.io/coldwings/photon-ut-base:latest
       options: --cpus 4 --privileged
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build921
         run: |
           source /opt/rh/gcc-toolset-9/enable
@@ -78,12 +78,12 @@ jobs:
       image: ghcr.io/coldwings/photon-ut-base:latest
       options: --cpus 4 --privileged
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build1031
         run: |
           source /opt/rh/gcc-toolset-10/enable
@@ -111,12 +111,12 @@ jobs:
       image: ghcr.io/coldwings/photon-ut-base:latest
       options: --cpus 4 --privileged
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build1121
         run: |
           source /opt/rh/gcc-toolset-11/enable
@@ -144,12 +144,12 @@ jobs:
       image: ghcr.io/coldwings/photon-ut-base:latest
       options: --cpus 4 --privileged
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build1211
         run: |
           source /opt/rh/gcc-toolset-12/enable

--- a/.github/workflows/ci.linux.x86-64.yml
+++ b/.github/workflows/ci.linux.x86-64.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main", "release/*" ]
 
 jobs:
-  test850:
+  gcc850:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -39,7 +39,7 @@ jobs:
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
 
-  test921:
+  gcc921:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -51,7 +51,7 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v3
-      - name: Build850
+      - name: Build921
         run: |
           source /opt/rh/gcc-toolset-9/enable
           rm -fr build
@@ -72,7 +72,7 @@ jobs:
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
 
-  test1031:
+  gcc1031:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -84,7 +84,7 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v3
-      - name: Build850
+      - name: Build1031
         run: |
           source /opt/rh/gcc-toolset-10/enable
           rm -fr build
@@ -105,7 +105,7 @@ jobs:
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
 
-  test1121:
+  gcc1121:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -117,7 +117,7 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v3
-      - name: Build850
+      - name: Build1121
         run: |
           source /opt/rh/gcc-toolset-11/enable
           rm -fr build
@@ -138,7 +138,7 @@ jobs:
           export PHOTON_CI_EV_ENGINE=epoll_ng
           ctest -E test-lockfree --timeout 3600 -V
 
-  test1211:
+  gcc1211:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/coldwings/photon-ut-base:latest
@@ -150,7 +150,7 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v3
-      - name: Build850
+      - name: Build1211
         run: |
           source /opt/rh/gcc-toolset-12/enable
           rm -fr build

--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macos-14
 
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Shanghai"
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         shell: bash

--- a/.github/workflows/ci.macos.x86.yml
+++ b/.github/workflows/ci.macos.x86.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: macos-13
 
     steps:
-    - uses: szenius/set-timezone@v1.2
+    - uses: szenius/set-timezone@v2.0
       with:
         timezoneLinux: "Asia/Shanghai"
         timezoneMacos: "Asia/Shanghai"
         timezoneWindows: "China Standard Time"
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Dependencies
       shell: bash

--- a/common/iovector.h
+++ b/common/iovector.h
@@ -40,8 +40,10 @@ limitations under the License.
 #include <photon/common/io-alloc.h>
 
 #pragma GCC diagnostic push
-#if __GNUC__ >= 13
+#if defined(__clang__)
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#endif
+#if __GNUC__ >= 12
 #pragma GCC diagnostic ignored "-Wzero-length-bounds"
 #endif
 

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -247,7 +247,7 @@ TEST(Callback, virtual_function)
 //    Callback<int> ee([&](int x){ return RET + x/2; });
 
 #pragma GCC diagnostic push
-#if __GNUC__ >= 13
+#if __GNUC__ >= 12
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
 #endif
     THIS = (BB*)&c;

--- a/rpc/rpc.cpp
+++ b/rpc/rpc.cpp
@@ -325,8 +325,10 @@ namespace rpc {
                 return -1;
 
 #pragma GCC diagnostic push
-#if __GNUC__ >= 13
+#if defined(__clang__)
 #pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#endif
+#if __GNUC__ >= 12
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
 #endif
             ThreadLink node;

--- a/test/ci-tools.cpp
+++ b/test/ci-tools.cpp
@@ -7,6 +7,7 @@
 #include <photon/common/alog.h>
 #include <photon/common/alog-stdstring.h>
 #include <photon/photon.h>
+#include <pthread.h>
 
 
 namespace photon {

--- a/thread/test/test-pool.cpp
+++ b/thread/test/test-pool.cpp
@@ -13,6 +13,7 @@
 #include <photon/thread/thread11.h>
 #include <photon/thread/workerpool.h>
 #include "../../test/ci-tools.h"
+#include <thread>
 
 DEFINE_int32(ths_total, 100, "total threads when testing threadpool.");
 


### PR DESCRIPTION
Fix code that prevent warnings when compile in gcc 12.

CI UT actions go CMake config phase with same gcc version, so all tests binary are used to compiled by gcc850 only. Previous CI configure use self hosted compile machine with no parallels, so last test group have to wait till all compile tasks are finished. That will always spent about 26min. for UT.

All paralleled compile and tests have no dependencies between jobs, with base image that all dependencies are pre-installed, each round of compile + test runs about 18min. All test jobs may able to be finished in less than 20min.