### PR TITLE
objcachev2

### DIFF
--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -20,7 +20,7 @@ limitations under the License.
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <mutex>
+#include <memory>
 #include <thread>
 #include <utility>
 #ifndef __aarch64__
@@ -90,16 +90,23 @@ struct PhotonPause : PauseBase {
     }
 };
 
+template <typename T>
+struct is_shared_ptr : std::false_type {};
+template <typename T>
+struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
+
 template <typename T, size_t N>
 class LockfreeRingQueueBase {
 public:
 #if __cplusplus < 201402L
-    static_assert(std::has_trivial_copy_constructor<T>::value &&
-                      std::has_trivial_copy_assign<T>::value,
+    static_assert((std::has_trivial_copy_constructor<T>::value &&
+                   std::has_trivial_copy_assign<T>::value) ||
+                      is_shared_ptr<T>::value,
                   "T should be trivially copyable");
 #else
-    static_assert(std::is_trivially_copy_constructible<T>::value &&
-                      std::is_trivially_copy_assignable<T>::value,
+    static_assert((std::is_trivially_copy_constructible<T>::value &&
+                   std::is_trivially_copy_assignable<T>::value) ||
+                      is_shared_ptr<T>::value,
                   "T should be trivially copyable");
 #endif
 

--- a/common/objectcachev2.h
+++ b/common/objectcachev2.h
@@ -110,14 +110,14 @@ protected:
     }
 
     template <typename KeyType>
-    Box* __find_or_create_item(const KeyType& key) {
+    Box* __find_or_create_item(KeyType&& key) {
         Box keyitem(key);
         auto pkey = &keyitem;
         Box* item = nullptr;
         SCOPED_LOCK(maplock);
         auto it = map.find(pkey);
         if (it == map.end()) {
-            item = new Box(key);
+            item = new Box(std::forward<KeyType>(key));
             map.emplace(item);
         } else
             item = *it;
@@ -217,7 +217,7 @@ public:
 
     template <typename KeyType>
     Borrow borrow(KeyType&& key) {
-        return borrow(&key, [&]() { return new V(); });
+        return borrow(std::forward<KeyType>(key), [&]() { return new V(); });
     }
 
     template <typename KeyType, typename Ctor>

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -5,6 +5,10 @@ add_executable(test-objcache test_objcache.cpp)
 target_link_libraries(test-objcache PRIVATE photon_shared)
 add_test(NAME test-objcache COMMAND $<TARGET_FILE:test-objcache>)
 
+add_executable(perf-objcache perf_objcache.cpp)
+target_link_libraries(perf-objcache PRIVATE photon_shared)
+add_test(NAME perf-objcache COMMAND $<TARGET_FILE:test-objcache>)
+
 add_executable(test-common test.cpp)
 target_link_libraries(test-common PRIVATE photon_shared)
 add_test(NAME test-common COMMAND $<TARGET_FILE:test-common>)

--- a/common/test/perf_objcache.cpp
+++ b/common/test/perf_objcache.cpp
@@ -2,16 +2,15 @@
 #include <photon/photon.h>
 #include <photon/thread/thread.h>
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <random>
 #include <thread>
-#include <unordered_map>
 #include <vector>
-#include <algorithm>
-#include "../../test/ci-tools.h"
 
 #include "../expirecontainer.h"
+#include "../objectcachev2.h"
 
 constexpr size_t count = 10UL * 1024;
 
@@ -29,11 +28,15 @@ void ready() {
     LOG_INFO("Random key generated");
 }
 
+template <template <class, class> class OC>
 void *task(void *arg) {
-    auto oc = (ObjectCache<std::string, std::string *> *)arg;
+    auto oc = (OC<std::string, std::string *> *)arg;
     std::array<uint64_t, count> k = keys;
-    std::random_shuffle(k.begin(), k.end());
+    std::random_device rd;
+    std::mt19937 g(rd());
+    std::shuffle(k.begin(), k.end(), g);
 
+    auto start = std::chrono::steady_clock::now();
     for (const auto &x : k) {
         auto strx = std::to_string(x);
         auto b = oc->borrow(strx, [&strx] {
@@ -42,38 +45,47 @@ void *task(void *arg) {
             return new std::string(strx);
         });
     }
-    return nullptr;
-}
-
-void test_objcache(ObjectCache<std::string, std::string *> &oc) {
-    std::vector<photon::join_handle *> jhs;
-    LOG_INFO("Query to ObjectCache");
-    auto start = std::chrono::steady_clock::now();
-    for (int i = 0; i < 4; i++)
-        jhs.emplace_back(
-            photon::thread_enable_join(photon::thread_create(task, &oc)));
-    for (auto &x : jhs) photon::thread_join(x);
     auto done = std::chrono::steady_clock::now();
     LOG_INFO("spent ` ms",
              std::chrono::duration_cast<std::chrono::milliseconds>(done - start)
                  .count());
+    return nullptr;
 }
 
-int main() {
-    photon::init(0, 0);
-    DEFER(photon::fini());
-    ObjectCache<std::string, std::string *> oc(-1UL);
-    ready();
+template <template <class, class> class OC>
+void test_objcache(OC<std::string, std::string *> &oc, const char *name) {
+    std::vector<photon::join_handle *> jhs;
+    LOG_INFO("Query to ", name);
+    for (int i = 0; i < 4; i++)
+        jhs.emplace_back(
+            photon::thread_enable_join(photon::thread_create(task<OC>, &oc)));
+    for (auto &x : jhs) photon::thread_join(x);
+}
+
+template <template <class, class> class OC>
+void test(const char *name) {
+    OC<std::string, std::string *> oc(-1UL);
     std::vector<std::thread> ths;
+    photon::semaphore sem(0);
     for (int i = 0; i < 10; i++) {
         ths.emplace_back([&] {
-            photon::init(0, 0);
-            DEFER(photon::fini());
-            test_objcache(oc);
+            photon::vcpu_init();
+            DEFER(photon::vcpu_fini());
+            test_objcache<OC>(oc, name);
+            sem.signal(1);
         });
     }
+    sem.wait(10);
     for (auto &x : ths) {
         x.join();
     }
+}
+
+int main() {
+    photon::vcpu_init();
+    DEFER(photon::vcpu_fini());
+    ready();
+    test<ObjectCache>("ObjectCache");
+    test<ObjectCacheV2>("ObjectCacheV2");
     return 0;
 }

--- a/common/test/perf_objcache.cpp
+++ b/common/test/perf_objcache.cpp
@@ -40,7 +40,7 @@ void *task(void *arg) {
     for (const auto &x : k) {
         auto strx = std::to_string(x);
         auto b = oc->borrow(strx, [&strx] {
-            photon::thread_usleep(1 * 1000);
+            // photon::thread_usleep(1 * 1000);
             // LOG_INFO("CTOR `", photon::now);
             return new std::string(strx);
         });
@@ -64,7 +64,7 @@ void test_objcache(OC<std::string, std::string *> &oc, const char *name) {
 
 template <template <class, class> class OC>
 void test(const char *name) {
-    OC<std::string, std::string *> oc(-1UL);
+    OC<std::string, std::string *> oc(0);
     std::vector<std::thread> ths;
     photon::semaphore sem(0);
     for (int i = 0; i < 10; i++) {

--- a/include/photon/common/objectcachev2.h
+++ b/include/photon/common/objectcachev2.h
@@ -1,0 +1,1 @@
+../../../common/objectcachev2.h


### PR DESCRIPTION
A simpler but effective object cache implementation.

`ObjectCacheV2` shows better performance compare to `ObjectCache`, with several
improvements:

1. Less lock in both read and write.
2. Object destruction always goes in background photon thread called reclaimer.
3. Self adjustable timeout for reclaimer. No needs to set cycler timer.
4. New `update` API, able to immediately substitute objects.
5. `ObjectCacheV2` no longer support acquire/release API.

It should work as `ObjectCache` in code do not depends on acquire/release API.