### PR TITLE
Add mfence for ringchannel send

### DIFF
--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -560,7 +560,8 @@ public:
         while (!push(x)) {
             Pause::pause();
         }
-        if (idler.load(std::memory_order_acquire)) queue_sem.signal(1);
+        // meke sure that idler load happends after push work done.
+        if (idler.load(std::memory_order_seq_cst)) queue_sem.signal(1);
     }
     T recv(uint64_t max_yield_turn, uint64_t max_yield_usec) {
         T x;


### PR DESCRIPTION
`RingChannel::send` may have chance that`idler.load()` happens before the `push` work done.

The acquire flags at load only make sured that load after `idler.load()` have to be happened after `idler.load()`, and last store action in `push(x)` keeps only sequence of store order only. Make it in seq_cst order to make sure load action must after push done.