### PR TITLE
Fix on epoll-ng when testing in RpcTest shutdown

### DIFF
--- a/io/epoll-ng.cpp
+++ b/io/epoll-ng.cpp
@@ -299,6 +299,8 @@ public:
             return 0;  // Event arrived
         }
         rm_interest(event);
+        // fire events in case of event during notify
+        wait_and_fire_events(0);
         if (ret == 0) {
             errno = ETIMEDOUT;
             return -1;

--- a/rpc/test/test.cpp
+++ b/rpc/test/test.cpp
@@ -396,12 +396,10 @@ TEST_F(RpcTest, shutdown) {
     ASSERT_NE(nullptr, stub);
     DEFER(pool->put_stub(ep, true));
 
-    photon::thread_create11([&]{
+    auto stopper = photon::thread_enable_join(photon::thread_create11([&]{
         photon::thread_sleep(1);
         sk->shutdown();
-        delete sk;
-        sk = nullptr;
-    });
+    }));
 
     auto start = std::chrono::steady_clock::now();
     while (true) {
@@ -415,6 +413,8 @@ TEST_F(RpcTest, shutdown) {
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
     GTEST_ASSERT_GT(duration, 900);
     GTEST_ASSERT_LT(duration, 1100);
+
+    photon::thread_join(stopper);
 }
 
 TEST_F(RpcTest, passive_shutdown) {


### PR DESCRIPTION
RpcTest.shutdown case with epoll-ng io engine has chance failing.

Checked all code, found two problems:

1. EpollNG is possible still got event just after removed watching, makes wake-up notify context not available when waiting thread canceled. Fix by force notify after canceling.
2. The unit test required background thread have to be execute first, still, during calling `sk->shutdown`, it have chance to yield thread, makes main thread continue and cause object sk double free. Make it only delete once, and wait for background thread finish by thread join.