### PR TITLE
makes mprotect page and thread struct in the stack.

### DIFF
--- a/thread/stack-allocator.cpp
+++ b/thread/stack-allocator.cpp
@@ -26,6 +26,8 @@ limitations under the License.
 
 namespace photon {
 
+constexpr static size_t PAGE_SIZE = 4UL * 1024;
+
 template <size_t MIN_ALLOCATION_SIZE = 4UL * 1024,
           size_t MAX_ALLOCATION_SIZE = 64UL * 1024 * 1024,
           size_t ALIGNMENT = 64>
@@ -57,6 +59,7 @@ protected:
 #if defined(__linux__)
         madvise(ptr, alloc_size, MADV_NOHUGEPAGE);
 #endif
+        mprotect(ptr, PAGE_SIZE, PROT_NONE);
         return ptr;
     }
 

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -58,6 +58,8 @@ namespace photon
     // Reserved space can be used to passed large arguments to the new thread.
     typedef void* (*thread_entry)(void*);
     const uint64_t DEFAULT_STACK_SIZE = 8 * 1024 * 1024;
+    // Thread stack size should be at least 16KB. The thread struct located at stack bottom,
+    // and the mprotect page is located at stack top-end.
     thread* thread_create(thread_entry start, void* arg,
         uint64_t stack_size = DEFAULT_STACK_SIZE, uint16_t reserved_space = 0);
 


### PR DESCRIPTION
Makes all photon::thread struct and mprotect page inside of the thread.
So thread stack now do not need to set mprotect repeatedly in pooled stack allocator,
and stack-allocation will be exactly size as it requested, more friendly to most of memory allocators.