### PR TITLE
Fix alog DEC(0) shows -0

### DIFF
--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -181,7 +181,7 @@ void LogFormatter::put_integer_dec(ALogBuffer& buf, ALogInteger x)
     uint64_t ndigits;
     auto begin = buf.ptr;
     // print (in reversed order)
-    if (!x.is_signed() || x.svalue() > 0)
+    if (!x.is_signed() || x.svalue() >= 0)
     {
         put_uint64(this, buf, x.uvalue());
         ndigits = buf.ptr - begin;

--- a/common/test/test_alog.cpp
+++ b/common/test/test_alog.cpp
@@ -576,6 +576,14 @@ TEST(ALOG, IPAddr) {
     EXPECT_STREQ("abcd:1111:222:33:4:5:6:7", log_output_test.log_start());
 }
 
+TEST(ALOG, signed_zero) {
+    log_output = &log_output_test;
+    DEFER(log_output = log_output_stdout);
+
+    LOG_INFO(DEC(0));
+    EXPECT_STREQ("0", log_output_test.log_start());
+}
+
 int main(int argc, char **argv)
 {
     if (!photon::is_using_default_engine()) return 0;


### PR DESCRIPTION
DEC(0) via ALOG shows strange "-0" result, since conditions for positive integer missed `x.svalue() == 0` condition.

Fix and add test for that situation