### PR TITLE
FIX: wait_for_fd in epoll reap events when timeout is 0

### DIFF
--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -322,7 +322,7 @@ ok:     entry.interests |= eint;
             }
             return ret;
         }
-        ret = thread_usleep(timeout.timeout() ? timeout : Timeout(10));
+        ret = thread_usleep(timeout);
         ERRNO err;
         if (ret == -1 && err.no == EOK) {
             return 0;  // Event arrived

--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -301,7 +301,9 @@ ok:     entry.interests |= eint;
             return rm_interest({fd, EVENT_RWE| ONE_SHOT, 0}); // remove fd from epoll
         int ret = add_interest({fd, interest | ONE_SHOT, CURRENT});
         if (ret < 0) LOG_ERROR_RETURN(0, -1, "failed to add event interest");
-        ret = thread_usleep(timeout);
+        // if timeout is just simple 0, wait for a tiny little moment
+        // so that events can be collect.
+        ret = thread_usleep(timeout.timeout() ? timeout : Timeout(10));
         ERRNO err;
         if (ret == -1 && err.no == EOK) {
             return 0;  // Event arrived

--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -303,6 +303,24 @@ ok:     entry.interests |= eint;
         if (ret < 0) LOG_ERROR_RETURN(0, -1, "failed to add event interest");
         // if timeout is just simple 0, wait for a tiny little moment
         // so that events can be collect.
+        if (timeout.expired()) {
+            ret = -1;
+            wait_for_events(
+                0,
+                [&](void* data) __INLINE__ {
+                    if ((thread*)data == CURRENT) {
+                        ret = 0;
+                    } else {
+                        thread_interrupt((thread*)data, EOK);
+                    }
+                },
+                [&]() __INLINE__ { return true; });
+            if (ret < 0) {
+                rm_interest({fd, interest, 0});
+                errno = ETIMEDOUT;
+            }
+            return ret;
+        }
         ret = thread_usleep(timeout.timeout() ? timeout : Timeout(10));
         ERRNO err;
         if (ret == -1 && err.no == EOK) {

--- a/io/kqueue.cpp
+++ b/io/kqueue.cpp
@@ -99,7 +99,7 @@ public:
             return 0;
         short ev = (interests == EVENT_READ) ? EVFILT_READ : EVFILT_WRITE;
         enqueue(fd, ev, EV_ADD | EV_ONESHOT, 0, CURRENT);
-        int ret = thread_usleep(timeout);
+        int ret = thread_usleep(timeout.timeout() ? timeout : Timeout(10));
         ERRNO err;
         if (ret == -1 && err.no == EOK) {
             return 0;  // event arrived

--- a/io/kqueue.cpp
+++ b/io/kqueue.cpp
@@ -84,7 +84,8 @@ public:
         auto entry = &_events[_n++];
         EV_SET(entry, fd, event, action, event_flags, 0, udata);
         if (immediate || _n == LEN(_events)) {
-            int ret = kevent(_kq, _events, _n, nullptr, 0, nullptr);
+            struct timespec tm {0, 0};
+            int ret = kevent(_kq, _events, _n, nullptr, 0, &tm);
             if (ret < 0) {
                 // debug_breakpoint();
                 LOG_ERRNO_RETURN(0, -1, "failed to submit events with kevent()");

--- a/io/kqueue.cpp
+++ b/io/kqueue.cpp
@@ -94,22 +94,8 @@ public:
         return 0;
     }
 
-    int wait_for_fd(int fd, uint32_t interests, Timeout timeout) override {
-        if (unlikely(interests == 0))
-            return 0;
-        short ev = (interests == EVENT_READ) ? EVFILT_READ : EVFILT_WRITE;
-        enqueue(fd, ev, EV_ADD | EV_ONESHOT, 0, CURRENT);
-        int ret = thread_usleep(timeout.timeout() ? timeout : Timeout(10));
-        ERRNO err;
-        if (ret == -1 && err.no == EOK) {
-            return 0;  // event arrived
-        }
-
-        errno = (ret == 0) ? ETIMEDOUT : err.no;
-        return -1;
-    }
-
-    ssize_t wait_and_fire_events(uint64_t timeout) override {
+    template<typename EVCB>
+    ssize_t do_wait_and_fire_events(uint64_t timeout, EVCB&& event_callback) {
         ssize_t nev = 0;
         struct timespec tm;
         tm.tv_sec = timeout / 1000 / 1000;
@@ -124,14 +110,51 @@ public:
         nev += ret;
         for (int i = 0; i < ret; ++i) {
             if (_events[i].filter == EVFILT_USER) continue;
-            auto th = (thread*) _events[i].udata;
-            if (th) thread_interrupt(th, EOK);
+            event_callback(_events[i].udata);
         }
         if (ret == (int) LEN(_events)) {  // there may be more events
             tm.tv_sec = tm.tv_nsec = 0;
             goto again;
         }
         return nev;
+    }
+
+    int wait_for_fd(int fd, uint32_t interests, Timeout timeout) override {
+        if (unlikely(interests == 0))
+            return 0;
+        short ev = (interests == EVENT_READ) ? EVFILT_READ : EVFILT_WRITE;
+        enqueue(fd, ev, EV_ADD | EV_ONESHOT, 0, CURRENT, timeout.expired());
+        if (timeout.expired()) {
+            int ret = -1;
+            do_wait_and_fire_events(0, [&](void* data) {
+                auto th = (thread*)data;
+                if (th == CURRENT)
+                    ret = 0;
+                else
+                    thread_interrupt(th);
+            });
+            if (ret <0) {
+                enqueue(fd, ev, EV_DELETE, 0, CURRENT, true);
+                errno = ETIMEDOUT;
+            }
+            return ret;
+        }
+        int ret = thread_usleep(timeout);
+        ERRNO err;
+        if (ret == -1 && err.no == EOK) {
+            return 0;  // event arrived
+        }
+    
+        errno = (ret == 0) ? ETIMEDOUT : err.no;
+        enqueue(fd, ev, EV_DELETE, 0, CURRENT, true);
+        return -1;
+    }
+
+    ssize_t wait_and_fire_events(uint64_t timeout) override {
+        return do_wait_and_fire_events(timeout, [](void* data) {
+            auto th = (thread*)data;
+            thread_interrupt(th);
+        });
     }
 
     int cancel_wait() override {


### PR DESCRIPTION
socket pool use `wait_for_fd` to check if released fd still have bytes left to read, but set timeout to 0.

since thread_usleep will always timedout when sleep time left 0, set 10us timeout, so that thread can actually put into sleep and wait for notify.