### PR TITLE
Fix immediate enqueue for in kqueue

### DIFF
--- a/io/kqueue.cpp
+++ b/io/kqueue.cpp
@@ -69,7 +69,8 @@ public:
         auto entry = &_events[_n++];
         EV_SET(entry, fd, event, action, event_flags, 0, udata);
         if (immediate || _n == LEN(_events)) {
-            int ret = kevent(_kq, _events, _n, nullptr, 0, nullptr);
+            struct timespec tm {0, 0};
+            int ret = kevent(_kq, _events, _n, _events, 0, &tm);
             if (ret < 0)
                 LOG_ERRNO_RETURN(0, -1, "failed to submit events with kevent()");
             _n = 0;


### PR DESCRIPTION
It turns out the kevent API has a slight difference in defining immediate polling between FreeBSD and macOS. This fix ensures the usage of kqueue is applicable to the macOS API.