### PR TITLE
getpagesize() when first used; Fix -Wshadow warning; Add photon::rand32() and photon::rand64()

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -595,8 +595,8 @@ struct __LogAppender : public Builder {
     using Builder::logger;
     using Builder::done;
     Append append;
-    explicit __LogAppender(Builder&& rhs, Append&& append)
-        : Builder(std::move(rhs)), append(std::move(append)) {}
+    explicit __LogAppender(Builder&& rhs, Append&& append_)
+        : Builder(std::move(rhs)), append(std::move(append_)) {}
     __LogAppender(__LogAppender&& rhs)
         : Builder(std::move(rhs)), append(std::move(rhs.append)) {}
     ~__LogAppender() {

--- a/common/iovector.h
+++ b/common/iovector.h
@@ -1008,24 +1008,24 @@ public:
     }
 };
 
-inline size_t iovector_view::memcpy_to(iovector_view* iov, size_t size) const {
-    IOVectorEntity<32, 0> co_iov(this->iov, iovcnt);
-    return co_iov.view().memcpy_to(iov, size);
+inline size_t iovector_view::memcpy_to(iovector_view* iov_, size_t size) const {
+    IOVectorEntity<32, 0> co_iov(iov, iovcnt);
+    return co_iov.view().memcpy_to(iov_, size);
 }
 
-inline size_t iovector_view::memcpy_from(iovector_view* iov, size_t size) const {
-    IOVectorEntity<32, 0> co_iov(this->iov, iovcnt);
-    return co_iov.view().memcpy_from(iov, size);
+inline size_t iovector_view::memcpy_from(iovector_view* iov_, size_t size) const {
+    IOVectorEntity<32, 0> co_iov(iov, iovcnt);
+    return co_iov.view().memcpy_from(iov_, size);
 }
 
-inline size_t iovector_view::memcpy_to(const iovector_view* iov, size_t size) const {
-    IOVectorEntity<32, 0> co_iov(this->iov, iovcnt);
-    return co_iov.view().memcpy_from(iov, size);
+inline size_t iovector_view::memcpy_to(const iovector_view* iov_, size_t size) const {
+    IOVectorEntity<32, 0> co_iov(iov, iovcnt);
+    return co_iov.view().memcpy_from(iov_, size);
 }
 
-inline size_t iovector_view::memcpy_from(const iovector_view* iov, size_t size) const {
-    IOVectorEntity<32, 0> co_iov(this->iov, iovcnt);
-    return co_iov.view().memcpy_from(iov, size);
+inline size_t iovector_view::memcpy_from(const iovector_view* iov_, size_t size) const {
+    IOVectorEntity<32, 0> co_iov(iov, iovcnt);
+    return co_iov.view().memcpy_from(iov_, size);
 }
 
 

--- a/common/memory-stream/memory-stream.cpp
+++ b/common/memory-stream/memory-stream.cpp
@@ -134,7 +134,7 @@ public:
 
     static inline bool gen()
     {
-        if (rand() % 100 < 1)
+        if (photon::rand32() % 100 < 1)
         {
             static const uint16_t e[] = {
                    1,    2,   83,  111,  112,
@@ -163,7 +163,7 @@ public:
                 1143, 1144, 1145, 1146, 1147,
                 1148, 1149, 1150, 1151, 1152,
             };
-            errno = e[rand() % LEN(e)];
+            errno = e[photon::rand32() % LEN(e)];
             return true;
         }
         return false;

--- a/common/memory-stream/test/test.cpp
+++ b/common/memory-stream/test/test.cpp
@@ -40,7 +40,7 @@ void* stream_writer(void* stream_)
         auto p = STR;
         while(count > 0)
         {
-            size_t len = rand() % 8;
+            size_t len = photon::rand32() % 8;
             len = min(len, count);
             LOG_DEBUG("Begin write ", VALUE(len));
             auto ret = s->write(p, len);

--- a/common/metric-meter/test/example.cpp
+++ b/common/metric-meter/test/example.cpp
@@ -58,7 +58,7 @@ int main() {
         SCOPE_LATENCY(table.pread_latency);
         SCOPE_LATENCY(table.pread_max);
         table.maxv.put(photon::now % 10000000 / 1000000);
-        photon::thread_usleep(1000 + rand() % 1000);
+        photon::thread_usleep(1000 + photon::rand32() % 1000);
     }
     photon::thread_usleep(5000 * 1000);
 }

--- a/common/retval.h
+++ b/common/retval.h
@@ -71,7 +71,7 @@ struct retval : public retval_base {
 
 template<>
 struct retval<void> : public retval_base {
-    retval(int _errno = 0) : retval_base{(uint64_t)_errno} { }
+    retval(int errno_ = 0) : retval_base{(uint64_t)errno_} { }
     retval(const retval_base& rvb) : retval_base(rvb) { }
     void get() const { }
     retval_base base() const {

--- a/common/test/perf_rcuptr.cpp
+++ b/common/test/perf_rcuptr.cpp
@@ -37,7 +37,7 @@ int main() {
                 for (int i = 0; i < 100; i++) {
                     photon::thread_create11([&cntr, &ptr, &sem]() {
                         for (int j = 0; j < 1000; j++) {
-                            auto x = rand() % 10;
+                            auto x = photon::rand32() % 10;
                             if (x) {  // 99% reader
                                 // ptr.read_lock();
                                 auto x = ptr->val;
@@ -92,7 +92,7 @@ int main() {
                 for (int i = 0; i < 100; i++) {
                     photon::thread_create11([&cntr, &ptr, &sem, &rwlock]() {
                         for (int j = 0; j < 1000; j++) {
-                            auto x = rand() % 10;
+                            auto x = photon::rand32() % 10;
                             if (x) {  // 90% reader
                                 photon::scoped_rwlock _(rwlock, photon::RLOCK);
                                 (void)ptr.load()->val;

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -256,7 +256,7 @@ TEST(Callback, virtual_function)
 
     for (int i=0; i<100; ++i)
     {
-        int x = rand();
+        int x = photon::rand32();
         EXPECT_EQ(ca(x), RET + x);
         EXPECT_EQ(cb(x), RET - x);
         EXPECT_EQ(cc(x), RET + x*2);

--- a/common/test/test_throttle.cpp
+++ b/common/test/test_throttle.cpp
@@ -16,7 +16,7 @@ TEST(Throttle, basic) {
     auto start = std::chrono::steady_clock::now();
     while (total) {
         // assume each step may consume about 4K ~ 1M
-        auto step = rand() % (1UL * 1024 * 1024 - 4096) + 4096;
+        auto step = photon::rand32() % (1UL * 1024 * 1024 - 4096) + 4096;
         if (step > total) step = total;
         total -= step;
     }
@@ -36,7 +36,7 @@ TEST(Throttle, basic) {
     start = std::chrono::steady_clock::now();
     while (total) {
         // assume each step may consume about 4K ~ 1M
-        auto step = rand() % (1UL * 1024 * 1024 - 4096) + 4096;
+        auto step = photon::rand32() % (1UL * 1024 * 1024 - 4096) + 4096;
         if (step > total) step = total;
         t.consume(step);
         total -= step;
@@ -61,11 +61,11 @@ TEST(Throttle, restore) {
     auto start = std::chrono::steady_clock::now();
     while (total) {
         // assume each step may consume about 4K ~ 1M
-        auto step = rand() % (1UL * 1024 * 1024 - 4096) + 4096;
+        auto step = photon::rand32() % (1UL * 1024 * 1024 - 4096) + 4096;
         if (step > total) step = total;
         submit += step;
         t.consume(step);
-        if (rand() % 2) {
+        if (photon::rand32() % 2) {
             // 1 of 2 chance to fail and restore consumed chance
             t.restore(step);
             restore += step;

--- a/common/utility.cpp
+++ b/common/utility.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <sys/utsname.h>
 #include <execinfo.h>
+#include <random>
 #include "utility.h"
 #include "estring.h"
 #include "alog.h"
@@ -70,3 +71,28 @@ void print_stacktrace() {
     free(stacktrace);
 }
 
+namespace photon {
+
+static std::random_device rd;
+thread_local std::mt19937 gen32(rd());
+thread_local std::mt19937_64 gen64(rd());
+
+uint32_t rand32() {
+    return gen32();
+}
+
+uint32_t rand32_distribution(uint32_t min, uint32_t max) {
+    std::uniform_int_distribution<uint32_t> dist(min, max);
+    return dist(gen32);
+}
+
+uint64_t rand64() {
+    return gen64();
+}
+
+uint64_t rand64_distribution(uint64_t min, uint64_t max) {
+    std::uniform_int_distribution<uint64_t> dist(min, max);
+    return dist(gen64);
+}
+
+}

--- a/common/utility.h
+++ b/common/utility.h
@@ -309,6 +309,22 @@ uint64_t sat_sub(uint64_t x, uint64_t y) {
     return c ? 0 : z;
 }
 
+// Generate random number in [0, UINT32_MAX]
+// The random engine is std::mt19937, which is even faster then rand() in C lib
+uint32_t rand32();
+
+// Generate random number, uniformly distributed on the closed interval [min, max]
+// Equals to rand32() % (max - min + 1) + min, but slower than it
+uint32_t rand32_distribution(uint32_t min, uint32_t max);
+
+// Generate random number in [0, UINT64_MAX]
+// The random engine is std::mt19937, which is even faster then rand() in C lib
+uint64_t rand64();
+
+// Generate random number, uniformly distributed on the closed interval [min, max]
+// Equals to rand64() % (max - min + 1) + min, but slower than it
+uint64_t rand64_distribution(uint64_t min, uint64_t max);
+
 }
 
 

--- a/examples/rpc/client_main.cpp
+++ b/examples/rpc/client_main.cpp
@@ -52,7 +52,7 @@ void run_some_task(ExampleClient* client) {
     IOVector iov;
     char writebuf[] = "write data like pwrite";
     iov.push_back(writebuf, sizeof(writebuf));
-    auto tmpfile = "/tmp/test_file_" + std::to_string(rand());
+    auto tmpfile = "/tmp/test_file_" + std::to_string(photon::rand32());
     auto ret = client->RPCWrite(ep, tmpfile, iov.iovec(), iov.iovcnt());
     LOG_INFO("Write to tmpfile ` ret=`", tmpfile, ret);
 
@@ -73,7 +73,6 @@ void handle_term(int) {
 
 int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
-    srand(time(NULL));
     photon::init();
     DEFER(photon::fini());
 

--- a/fs/test/test.cpp
+++ b/fs/test/test.cpp
@@ -830,7 +830,7 @@ TEST(range_split, range_split_aligned_case)
 }
 
 TEST(range_split, random_test) {
-    uint64_t begin=rand(), length=rand(), interval=rand();
+    uint64_t begin=photon::rand32(), length=photon::rand32(), interval=photon::rand32();
     LOG_DEBUG("begin=", begin, " length=", length, " interval=", interval);
     fs::range_split split(begin, length, interval);
     EXPECT_EQ(split.begin, begin);
@@ -870,9 +870,9 @@ TEST(range_split_power2, basic) {
 
 TEST(range_split_power2, random_test) {
     uint64_t offset, length, interval;
-    offset = rand();
-    length = rand();
-    auto interval_shift = rand()%32 + 1;
+    offset = photon::rand32();
+    length = photon::rand32();
+    auto interval_shift = photon::rand32()%32 + 1;
     interval = uint64_t(1) << interval_shift;
     fs::range_split_power2 split(offset, length, interval);
     EXPECT_EQ(offset, split.begin);
@@ -939,7 +939,7 @@ std::unique_ptr<char[]> random_block(uint64_t size) {
     std::unique_ptr<char[]> buff(new char[size]);
     char * p = buff.get();
     while (size--) {
-        *(p++) = rand() % UCHAR_MAX;
+        *(p++) = photon::rand32() % UCHAR_MAX;
     }
     return buff;
 }
@@ -1199,7 +1199,7 @@ TEST(XFile, error_stiuation) {
 
 void fill_random_buff(char * buff, size_t length) {
     for (size_t i = 0; i< length; i++) {
-        buff[i] = rand() % UCHAR_MAX;
+        buff[i] = photon::rand32() % UCHAR_MAX;
     }
 }
 
@@ -1210,8 +1210,8 @@ void pread_pwrite_test(IFile *target, IFile *standard) {
     char data[max_piece_length];
     char buff[max_piece_length];
     for (int i = 0;i < test_round; i++) {
-        off_t off = rand() % max_file_size / getpagesize() * getpagesize();
-        size_t len = rand() % max_piece_length / getpagesize() * getpagesize();
+        off_t off = photon::rand32() % max_file_size / getpagesize() * getpagesize();
+        size_t len = photon::rand32() % max_piece_length / getpagesize() * getpagesize();
         if (off+len > max_file_size) {
             continue;
         }
@@ -1228,8 +1228,8 @@ void pread_pwrite_test(IFile *target, IFile *standard) {
         EXPECT_EQ(0, memcmp(data, buff, ret));
     }
     for (int i = 0;i < test_round; i++) {
-        off_t off = rand() % max_file_size;
-        size_t len = rand() % max_piece_length;
+        off_t off = photon::rand32() % max_file_size;
+        size_t len = photon::rand32() % max_piece_length;
         if (off+len > max_file_size) {
             len = max_file_size - off;
         }
@@ -1373,7 +1373,6 @@ TEST(Walker, basic) {
 }
 
 int main(int argc, char **argv){
-    srand(time(nullptr));
     ::testing::InitGoogleTest(&argc, argv);
     if (photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE))
         return -1;

--- a/io/test/test-iouring.cpp
+++ b/io/test/test-iouring.cpp
@@ -615,7 +615,6 @@ TEST_F(event_engine, cascading_one_shot) {
 }
 
 int main(int argc, char** arg) {
-    srand(time(nullptr));
     set_log_output_level(ALOG_INFO);
     testing::InitGoogleTest(&argc, arg);
     testing::FLAGS_gtest_break_on_failure = true;

--- a/io/test/test-syncio.cpp
+++ b/io/test/test-syncio.cpp
@@ -51,7 +51,7 @@ void* rand_read(void* _args)
 
     for (size_t i = 0; i < args->n; ++i)
     {
-        off_t offset = rand() % length * alignment + args->start;
+        off_t offset = photon::rand32() % length * alignment + args->start;
         ssize_t ret;
         // LOG_DEBUG("rand_read round:`", i);
         if (i&1)
@@ -89,7 +89,7 @@ void* rand_write(void* _args)
 
     for (size_t i = 0; i < args->n; ++i)
     {
-        off_t offset = rand() % length * alignment + args->start;
+        off_t offset = photon::rand32() % length * alignment + args->start;
         ssize_t ret;
         if (i&1)
         {

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -318,7 +318,7 @@ int chunked_handler_pt(void*, ISocketStream* sock) {
             break;
         }
         auto max_seg = std::min(remain - 1024, 2 * 4 * 1024UL);
-        auto seg = 1024 + rand() % max_seg;
+        auto seg = 1024 + photon::rand32() % max_seg;
         chunked_send(offset, seg, sock);
         rec.push_back(seg);
         offset += seg;
@@ -373,7 +373,6 @@ TEST(http_client, chunked) {
     for (auto &c : std_data) {
         c = '0' + ((++num) % 10);
     }
-    srand(time(0));
     server->set_handler({nullptr, &chunked_handler_pt});
     for (auto tmp = 0; tmp < 20; tmp++) {
         auto op_test = client->new_operation(Verb::GET, url);

--- a/net/http/test/headers_test.cpp
+++ b/net/http/test/headers_test.cpp
@@ -94,7 +94,7 @@ public:
         // assert(count > remain);
         // LOG_DEBUG(remain);
         if (remain > 200) {
-            auto len = rand() % 100 + 1;
+            auto len = photon::rand32() % 100 + 1;
             // cout << string(ptr, len);
             memcpy(buf, ptr, len);
             ptr += len;
@@ -154,7 +154,6 @@ TEST(headers, resp_header) {
 
     char rand_buf[64 * 1024 - 1];
     Response rand_header(rand_buf, sizeof(rand_buf));
-    srand(time(0));
     test_stream stream(2000);
     do {
         auto ret = rand_header.receive_bytes(&stream);
@@ -174,7 +173,6 @@ TEST(headers, resp_header) {
 
     char exceed_buf[64 * 1024 - 1];
     Response exceed_header(exceed_buf, sizeof(exceed_buf));
-    srand(time(0));
     test_stream exceed_stream(3000);
     do {
         auto ret = exceed_header.receive_bytes(&exceed_stream);

--- a/net/http/test/server_function_test.cpp
+++ b/net/http/test/server_function_test.cpp
@@ -232,7 +232,7 @@ int chunked_handler_pt(void*, net::ISocketStream* sock) {
             break;
         }
         auto max_seg = std::min(remain - 1024, 2 * 4 * 1024UL);
-        auto seg = 1024 + rand() % max_seg;
+        auto seg = 1024 + photon::rand32() % max_seg;
         chunked_send(offset, seg, sock);
         rec.push_back(seg);
         offset += seg;
@@ -271,7 +271,6 @@ TEST(http_server, proxy_handler_get) {
     for (auto &c : std_data) {
         c = '0' + ((++num) % 10);
     }
-    srand(time(0));
     //------------start source server---------------
     auto source_server = net::new_tcp_socket_server();
     DEFER({ delete source_server; });
@@ -459,7 +458,6 @@ TEST(http_server, mux_handler) {
     for (auto &c : std_data) {
         c = '0' + ((++num) % 10);
     }
-    srand(time(0));
     //------------start source server---------------
     auto source_server = net::new_tcp_socket_server();
     DEFER({ delete source_server; });

--- a/net/socket.h
+++ b/net/socket.h
@@ -154,9 +154,9 @@ namespace net {
         IPAddr addr;
         uint16_t port = 0;
         EndPoint() = default;
-        EndPoint(IPAddr ip, uint16_t port) : addr(ip), port(port) {}
+        EndPoint(IPAddr ip, uint16_t port_) : addr(ip), port(port_) {}
         explicit EndPoint(const char* ep);
-        EndPoint(const char* ip, uint16_t port) : addr(ip), port(port) {}
+        EndPoint(const char* ip, uint16_t port_) : addr(ip), port(port_) {}
         bool is_ipv4() const {
             return addr.is_ipv4();
         };

--- a/photon.cpp
+++ b/photon.cpp
@@ -73,8 +73,7 @@ int __photon_init(uint64_t event_engine, uint64_t io_engine, const PhotonOptions
     const uint64_t ALL_ENGINES =
             INIT_EVENT_EPOLL   | INIT_EVENT_EPOLL_NG |
             INIT_EVENT_IOURING | INIT_EVENT_KQUEUE |
-            INIT_EVENT_SELECT  | INIT_EVENT_IOCP |
-            INIT_EVENT_EPOLL_NG;
+            INIT_EVENT_SELECT  | INIT_EVENT_IOCP;
     if (event_engine & ALL_ENGINES) {
         bool ok = false;
         for (auto x : recommended_order) {

--- a/rpc/test/test-ooo.cpp
+++ b/rpc/test/test-ooo.cpp
@@ -187,7 +187,7 @@ TEST(OutOfOrder, heavy_test) {
 }
 
 inline int error_issue(void*, OutOfOrderContext* args) {
-    if ((rand()%2) == 0) {
+    if ((photon::rand32()%2) == 0) {
         return -1;
     }
     return heavy_issue(nullptr, args);
@@ -196,7 +196,7 @@ inline int error_issue(void*, OutOfOrderContext* args) {
 inline int error_complete(void*, OutOfOrderContext* args) {
     while (processing_queue.empty()) { thread_yield_to(nullptr); } //waiting till something comming
     args->tag = processing_queue.front();
-    if (rand()%2)
+    if (photon::rand32()%2)
         return -1;
     processing_queue.pop();
     return 0;
@@ -207,7 +207,7 @@ inline int error_process() {
         thread_yield_to(nullptr);
         shuffle(issue_list.begin(), issue_list.end());
         auto val = issue_list.back();
-        if (rand()%2)
+        if (photon::rand32()%2)
             val = UINT64_MAX;
         processing_queue.push(val);
         issue_list.pop_back();

--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(perf_workpool perf_workpool.cpp)
 target_link_libraries(perf_workpool PRIVATE photon_shared)
 add_test(NAME perf_workpool COMMAND $<TARGET_FILE:perf_workpool>)
 
-add_executable(test-thread test.cpp x.cpp)
+add_executable(test-thread test-thread.cpp x.cpp)
 target_link_libraries(test-thread PRIVATE photon_shared)
 add_test(NAME test-thread COMMAND $<TARGET_FILE:test-thread>)
 

--- a/thread/test/test-pool.cpp
+++ b/thread/test/test-pool.cpp
@@ -22,7 +22,7 @@ using namespace photon;
 
 void *func1(void *)
 {
-    thread_sleep(rand()%5);
+    thread_sleep(photon::rand32()%5);
     return nullptr;
 }
 

--- a/thread/test/test-thread.cpp
+++ b/thread/test/test-thread.cpp
@@ -378,7 +378,7 @@ void test_thread_switch(uint64_t nth, uint64_t stack_size)
 
 TEST(Perf, ThreadSwitch)
 {
-    test_thread_switch(10, 16 * PAGE_SIZE);
+    test_thread_switch(10, 16 * getpagesize());
     return;
 
     const uint64_t stack_size = 8 * 1024 * 1024;
@@ -400,7 +400,7 @@ TEST(Perf, ThreadSwitchWithStandaloneTSUpdater)
 {
     timestamp_updater_init();
     DEFER(timestamp_updater_fini());
-    test_thread_switch(10, 16 * PAGE_SIZE);
+    test_thread_switch(10, 16 * getpagesize());
     return;
 }
 
@@ -685,7 +685,7 @@ TEST(Semaphore, heavy) {
     semaphore sem(0);
     const int thread_num = 100000;
     for (int i=1; i<=thread_num;i++) {
-        thread_create11(16 * PAGE_SIZE, semaphore_heavy, sem, i);
+        thread_create11(16 * getpagesize(), semaphore_heavy, sem, i);
     }
     LOG_DEBUG("created ` threads", thread_num);
     sem.signal(1);
@@ -1763,12 +1763,13 @@ TEST(future, test2) {
 
 int main(int argc, char** arg)
 {
+    srand(time(0));
     if (!photon::is_using_default_engine()) return 0;
     ::testing::InitGoogleTest(&argc, arg);
     gflags::ParseCommandLineFlags(&argc, &arg, true);
     default_audit_logger.log_output = log_output_stdout;
+    set_log_output_level(ALOG_INFO);
     photon::vcpu_init();
-    set_log_output_level(ALOG_DEBUG);
 
     if (FLAGS_vcpus <= 1)
     {
@@ -1790,8 +1791,6 @@ int main(int argc, char** arg)
     // return 0;
     test_sat_add();
 //    test_sleepqueue();
-
-    srand(time(0));
 
     //aSem.wait(1);
     aSem.wait(3);

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -919,7 +919,7 @@ R"(
         RunQ rq;
         if (unlikely(!rq.current))
             LOG_ERROR_RETURN(ENOSYS, nullptr, "Photon not initialized in this vCPU (OS thread)");
-        size_t randomizer = (rand() % 512) * 8;
+        size_t randomizer = (photon::rand32() % 512) * 8;
         // stack contains struct, randomizer space, and reserved_space
         size_t least_stack_size = sizeof(thread) + randomizer + 63 + reserved_space;
         // at least a whole page for mprotect


### PR DESCRIPTION
关于引入 photon::rand32() 和 photon::rand64()的原因：

test-thread CI 在arm下偶发出现了core，但重复跑又不能复现。有点怀疑是rand()，且这个case之前没srand，重复跑是相同结果。

考虑到用户程序可能不会调用srand，因此在common/utility里面引入std::random_device，用新的函数封装替换所有的rand()

并且，实测mt19937比rand()更快