### PR TITLE
CI add build_push actions

### DIFF
--- a/.github/workflows/images/base/build_push.yml
+++ b/.github/workflows/images/base/build_push.yml
@@ -1,0 +1,52 @@
+name: Build base image
+
+on:
+  # Manually trigger
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why ?'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: photon-ut-base
+
+jobs:
+  ghcr_build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          # path context
+          context: .github/workflows/base
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME}}:latest
+          platforms: linux/amd64

--- a/.github/workflows/images/fstack/Dockerfile
+++ b/.github/workflows/images/fstack/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:11
+
+RUN apt update -y && \
+    apt install -y build-essential git curl cmake libssl-dev libcurl4-openssl-dev libaio-dev zlib1g-dev libgtest-dev libgmock-dev libgflags-dev libfuse-dev libgsasl7-dev && \
+    apt install -y python3-pip python3-pyelftools libnuma-dev && \
+    pip3 install ninja meson && \
+    cd /root && \
+    curl -LO https://github.com/F-Stack/f-stack/archive/refs/tags/v1.22.tar.gz && \
+    tar xf v1.22.tar.gz && \
+    cd /root/f-stack-1.22/dpdk/ && \
+    CONFIG_RTE_LIBRTE_MLX5_PMD=y meson -Denable_kmods=false -Dtests=false build && \
+    cd build && \
+    ninja && \
+    ninja install && \
+    export FF_PATH=/root/f-stack-1.22 && \
+    cd /root/f-stack-1.22/lib && \
+    make -j && \
+    make install

--- a/.github/workflows/images/fstack/build_push.yml
+++ b/.github/workflows/images/fstack/build_push.yml
@@ -1,0 +1,52 @@
+name: Build fstack image
+
+on:
+  # Manually trigger
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why ?'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: photon-ut-fstack
+
+jobs:
+  ghcr_build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          # path context
+          context: .github/workflows/fstack
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME}}:latest
+          platforms: linux/amd64


### PR DESCRIPTION
把CI镜像的构建流程和Dockerfile脚本从个人仓库移到主仓库。

-----

Move the CI image build process and Dockerfile script from the personal repository to the main repository.