### PR TITLE
Re-add PHOTON_BUILD_DEPENDENCIES in x86 CI workflow

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -42,30 +42,25 @@ jobs:
           ctest -E test-lockfree --timeout 3600 -V
           pkill redis-server
 
-  gcc921-build-debug:
-    runs-on: [self-hosted, Linux, ARM64]
-
+  debug-build-from-source:
+    runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alibaba/photon-ut-base:latest
-      options: --cpus 4
-
+      image: almalinux:8
     steps:
-      - uses: szenius/set-timezone@v2.0
-        with:
-          timezoneLinux: "Asia/Shanghai"
-          timezoneMacos: "Asia/Shanghai"
-          timezoneWindows: "China Standard Time"
-
       - uses: actions/checkout@v4
-
       - name: Build
         run: |
+          dnf -q -y install git gcc-c++ cmake gcc-toolset-9-gcc-c++ openssl-devel libcurl-devel
+          dnf -q -y install autoconf automake libtool
           source /opt/rh/gcc-toolset-9/enable
-          cmake -B build \
-            -D CMAKE_BUILD_TYPE=Debug \
-            -D PHOTON_ENABLE_ECOSYSTEM=ON \
-            -D PHOTON_BUILD_TESTING=ON \
-            -D PHOTON_ENABLE_SASL=ON \
-            -D PHOTON_ENABLE_FUSE=ON \
-            -D PHOTON_ENABLE_EXTFS=ON
+          cmake -B build -D CMAKE_BUILD_TYPE=Debug        \
+                         -D PHOTON_ENABLE_ECOSYSTEM=ON    \
+                         -D PHOTON_BUILD_TESTING=ON       \
+                         -D PHOTON_ENABLE_SASL=OFF        \
+                         -D PHOTON_ENABLE_FUSE=OFF        \
+                         -D PHOTON_ENABLE_URING=ON        \
+                         -D PHOTON_ENABLE_EXTFS=OFF       \
+                         -D PHOTON_BUILD_DEPENDENCIES=ON  \
+                         -D PHOTON_OPENSSL_SOURCE=""      \
+                         -D PHOTON_CURL_SOURCE=""
           cmake --build build -j $(nproc) -- VERBOSE=1

--- a/CMake/Finduring.cmake
+++ b/CMake/Finduring.cmake
@@ -1,3 +1,5 @@
+set(URING_VERSION 2.3)
+
 find_path(URING_INCLUDE_DIRS liburing.h)
 
 find_library(URING_LIBRARIES uring)
@@ -5,3 +7,8 @@ find_library(URING_LIBRARIES uring)
 find_package_handle_standard_args(uring DEFAULT_MSG URING_LIBRARIES URING_INCLUDE_DIRS)
 
 mark_as_advanced(URING_INCLUDE_DIRS URING_LIBRARIES)
+
+get_filename_component(URING_LIB_BASE ${URING_LIBRARIES} DIRECTORY)
+if (NOT EXISTS "${URING_LIB_BASE}/liburing.so.${URING_VERSION}")
+    message(FATAL_ERROR "Requires liburing ${URING_VERSION}. Install it to system or try -D PHOTON_BUILD_DEPENDENCIES=ON")
+endif ()

--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -75,7 +75,7 @@ function(build_from_src [dep])
         ExternalProject_Get_Property(googletest SOURCE_DIR)
         ExternalProject_Get_Property(googletest BINARY_DIR)
         set(GOOGLETEST_INCLUDE_DIRS ${SOURCE_DIR}/googletest/include ${SOURCE_DIR}/googlemock/include PARENT_SCOPE)
-        set(GOOGLETEST_LIBRARIES ${BINARY_DIR}/lib/libgmock.a ${BINARY_DIR}/lib/libgtest.a PARENT_SCOPE)
+        set(GOOGLETEST_LIBRARIES ${BINARY_DIR}/lib/libgmock.a ${BINARY_DIR}/lib/libgtest_main.a ${BINARY_DIR}/lib/libgtest.a PARENT_SCOPE)
 
     elseif (dep STREQUAL "openssl")
         set(BINARY_DIR ${PROJECT_BINARY_DIR}/openssl-build)

--- a/common/test/test_objcache.cpp
+++ b/common/test/test_objcache.cpp
@@ -136,11 +136,11 @@ TEST(ObjectCache, ctor_may_yield_and_null) {
         photon::thread_create(&ph_act, &a);
     }
     sem.wait(10);
-    EXPECT_EQ(1, ocache._set.size());
+    EXPECT_EQ(1UL, ocache._set.size());
     ocache.expire();
     photon::thread_usleep(1100UL * 1000);
     ocache.expire();
-    EXPECT_EQ(0, ocache._set.size());
+    EXPECT_EQ(0UL, ocache._set.size());
 }
 
 TEST(ObjectCache, multithread) {

--- a/fs/test/test_exportfs.cpp
+++ b/fs/test/test_exportfs.cpp
@@ -54,7 +54,7 @@ static std::atomic<int> work(0);
 
 template<typename T, uint64_t val>
 int callback(void*, AsyncResult<T>* ret) {
-    EXPECT_EQ(val, ret->result);
+    EXPECT_EQ(val, (uint64_t) ret->result);
     LOG_DEBUG("DONE `", VALUE(ret->operation));
     work--;
     return 0;

--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -188,7 +188,7 @@ public:
         ioCtx timer_ctx(true, false);
         __kernel_timespec ts;
         auto usec = timeout.timeout_us();
-        if (usec < std::numeric_limits<int64_t>::max()) {
+        if (usec < (uint64_t) std::numeric_limits<int64_t>::max()) {
             sqe->flags |= IOSQE_IO_LINK;
             ts = usec_to_timespec(usec);
             sqe = _get_sqe();
@@ -334,7 +334,7 @@ public:
 
     ssize_t wait_and_fire_events(uint64_t timeout) override {
         // Prepare own timeout
-        if (timeout > std::numeric_limits<int64_t>::max()) {
+        if (timeout > (uint64_t) std::numeric_limits<int64_t>::max()) {
             timeout = std::numeric_limits<int64_t>::max();
         }
 

--- a/thread/test/test-pool.cpp
+++ b/thread/test/test-pool.cpp
@@ -174,7 +174,7 @@ TEST(workpool, async_work_lambda) {
             new auto ([r]() {
                 LOG_INFO("START ", VALUE(__cplusplus), VALUE(r->copy),
                          VALUE(r->move));
-                EXPECT_EQ(0, r->copy);
+                EXPECT_EQ(0UL, r->copy);
                 this_thread::sleep_for(std::chrono::seconds(1));
                 LOG_INFO("FINISH");
                 delete r;
@@ -200,7 +200,7 @@ TEST(workpool, async_work_lambda_threadcreate) {
             new auto ([&sem, r]() {
                 LOG_INFO("START ", VALUE(__cplusplus), VALUE(r->copy),
                          VALUE(r->move));
-                EXPECT_EQ(0, r->copy);
+                EXPECT_EQ(0UL, r->copy);
                 thread_sleep(1);
                 sem.signal(1);
                 LOG_INFO("FINISH");
@@ -229,7 +229,7 @@ TEST(workpool, async_work_lambda_threadpool) {
             new auto ([&sem, r]() {
                 LOG_INFO("START ", VALUE(__cplusplus), VALUE(r->copy),
                          VALUE(r->move));
-                EXPECT_EQ(0, r->copy);
+                EXPECT_EQ(0UL, r->copy);
                 thread_sleep(1);
                 sem.signal(1);
                 LOG_INFO("FINISH");
@@ -267,7 +267,7 @@ TEST(workpool, async_work_lambda_threadpool_append) {
             new auto ([&sem, r]() {
                 LOG_INFO("START ", VALUE(__cplusplus), VALUE(r->copy),
                          VALUE(r->move));
-                EXPECT_EQ(0, r->copy);
+                EXPECT_EQ(0UL, r->copy);
                 thread_sleep(1);
                 sem.signal(1);
                 LOG_INFO("FINISH");


### PR DESCRIPTION
It's been a long time we didn't run `DEBUG` build and verify `PHOTON_BUILD_DEPENDENCIES`.

So some warnings appeared.

Add it back in arm CI