### PR TITLE
TLSContext now able to set X509 cert verify

### DIFF
--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -62,6 +62,7 @@ public:
         if (!tls_ctx) {
             tls_ctx_ownership = true;
             tls_ctx = new_tls_context(nullptr, nullptr, nullptr);
+            tls_ctx->set_verify_mode(VerifyMode::PEER);  // act like curl
         }
         auto tcp_cli = new_tcp_socket_client();
         auto tls_cli = new_tls_client(tls_ctx, new_tcp_socket_client(), true);

--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -361,7 +361,22 @@ public:
         int err = 0;
         while ((err = ERR_get_error())) {
             LOG_ERROR("SSL error: `", ERR_error_string(err, nullptr));
-            errno = EPERM;
+            switch (ERR_GET_REASON(err)) {
+                case ERR_R_BIO_LIB:
+                    errno = ECONNRESET;
+                    break;
+                case ERR_R_FATAL:
+                case ERR_R_MALLOC_FAILURE:
+                case ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED:
+                case ERR_R_PASSED_NULL_PARAMETER:
+                case ERR_R_INTERNAL_ERROR:
+                case ERR_R_DISABLED:
+                    errno = EIO;
+                    break;
+                default:
+                    errno = EPERM;
+                    break;
+            }
         }
     }
 

--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -174,6 +174,12 @@ public:
         }
         return 0;
     }
+
+    int set_verify_mode(VerifyMode mode) override {
+        SSL_CTX_set_default_verify_paths(ctx);
+        SSL_CTX_set_verify(ctx, (int)mode, nullptr);
+        return 0;
+    }
 };
 
 void __OpenSSLGlobalInit() {
@@ -351,8 +357,18 @@ public:
         SSL_free(ssl);
     }
 
+    void deal_error() {
+        int err = 0;
+        while ((err = ERR_get_error())) {
+            LOG_ERROR("SSL error: `", ERR_error_string(err, nullptr));
+            errno = EPERM;
+        }
+    }
+
     ssize_t recv(void* buf, size_t cnt, int flags = 0) override {
-        return SSL_read(ssl, buf, cnt);
+        auto ret = SSL_read(ssl, buf, cnt);
+        if (ret < 0) deal_error();
+        return ret;
     }
 
     ssize_t recv(const struct iovec* iov, int iovcnt, int flags = 0) override {
@@ -360,7 +376,9 @@ public:
         return recv(iov[0].iov_base, iov[0].iov_len);
     }
     ssize_t send(const void* buf, size_t cnt, int flags = 0) override {
-        return SSL_write(ssl, buf, cnt);
+        auto ret = SSL_write(ssl, buf, cnt);
+        if (ret < 0) deal_error();
+        return ret;
     }
     ssize_t send(const struct iovec* iov, int iovcnt, int flags = 0) override {
         // since send allows partial write

--- a/net/security-context/tls-stream.h
+++ b/net/security-context/tls-stream.h
@@ -32,14 +32,23 @@ enum class SecurityRole {
     Server = 2,
 };
 
+enum class VerifyMode : int {
+    NONE = 0x00,                  // SSL_VERIFY_NONE
+    PEER = 0x01,                  // SSL_VERIFY_PEER
+    FAIL_IF_NO_PEER_CERT = 0x02,  // SSL_VERIFY_IF_NO_PEER_CERT
+    CLIENT_ONCE = 0x04,           // SSL_VERIFY_CLIENT_ONCE
+};
+
 /**
  * @brief TLSContext managers TLS key and cert
  * These parameters is able to set after created
  */
 class TLSContext : public Object {
+public:
     virtual int set_pass_phrase(const char* pass) = 0;
     virtual int set_cert(const char* cert_str) = 0;
     virtual int set_pkey(const char* key_str, const char* passphrase) = 0;
+    virtual int set_verify_mode(VerifyMode mode = VerifyMode::NONE) = 0;
 };
 
 enum class TLSVersion{


### PR DESCRIPTION
Also makes http client verify X509 certs by default when requesting HTTPS server.