### PR TITLE
Add moveout feature for ObjectCache

### DIFF
--- a/rpc/rpc.cpp
+++ b/rpc/rpc.cpp
@@ -447,7 +447,8 @@ namespace rpc {
         }
 
         int put_stub(const net::EndPoint& endpoint, bool immediately) override {
-            return m_pool->release(endpoint, immediately);
+            m_pool->release(endpoint, immediately);
+            return 0;
         }
 
         Stub* acquire(const net::EndPoint& endpoint) override {


### PR DESCRIPTION
Make ObjectCache able to move-out managed object when releasing.

It will wait till all shared acquirements are released, and then return object back who is trying to move out.