### PR TITLE
fast case conversion and comparison

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -658,3 +658,42 @@ struct hash<estring> {
 };
 } // namespace std
 
+namespace photon {
+
+inline char tolower_fast(char c) {
+    return c + ('a' - 'A') * ('A' <= c && c <= 'Z');
+}
+
+inline char toupper_fast(char c) {
+    return c - ('a' - 'A') * ('a' <= c && c <= 'z');
+}
+
+inline uint64_t tolower_fast8(uint64_t x) {
+    uint64_t all_bytes = 0x0101010101010101;
+    uint64_t heptets = x & (0x7f * all_bytes);
+    uint64_t is_ascii = ~x & (0x80 * all_bytes);
+    uint64_t is_gt_Z = heptets + (0x7f - 'Z') * all_bytes;
+    uint64_t is_ge_A = heptets + (0x80 - 'A') * all_bytes;
+    uint64_t is_upper = (is_ge_A ^ is_gt_Z) & is_ascii;
+    return x | (is_upper >> 2);
+}
+
+inline uint64_t toupper_fast8(uint64_t x) {
+    uint64_t all_bytes = 0x0101010101010101;
+    uint64_t heptets = x & (0x7f * all_bytes);
+    uint64_t is_ascii = ~x & (0x80 * all_bytes);
+    uint64_t is_gt_z = heptets + (0x7f - 'z') * all_bytes;
+    uint64_t is_ge_a = heptets + (0x80 - 'a') * all_bytes;
+    uint64_t is_lower = (is_ge_a ^ is_gt_z) & is_ascii;
+    return x ^ (is_lower >> 2);
+}
+
+// convert string to lower or upper, the storage of out must be >= len + 1
+// it's possible that out == in
+void tolower_fast(char* out, const char* in, size_t len);
+void toupper_fast(char* out, const char* in, size_t len);
+
+// compare 2 strings without case sensitive
+int stricmp_fast(std::string_view a, std::string_view b);
+
+} // namespace photon

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -45,6 +45,7 @@ limitations under the License.
 #include <vector>
 #include <memory>
 #include <string>
+#include <string.h>
 //#include <gmock/gmock.h>
 //#include <malloc.h>
 #ifndef __clang__
@@ -1271,6 +1272,38 @@ TEST(PooledAllocator, allocFailed) {
     alloc.dealloc(p1);
     auto p2 = alloc.alloc(1024 * 1024 + 1);
     EXPECT_EQ(nullptr, p2);
+}
+
+TEST(tolowerupper, basic) {
+    EXPECT_EQ(tolower_fast('A'), 'a');
+    EXPECT_EQ(tolower_fast('3'), '3');
+    EXPECT_EQ(tolower_fast('Z'), 'z');
+    EXPECT_EQ(toupper_fast('a'), 'A');
+    EXPECT_EQ(toupper_fast('3'), '3');
+    EXPECT_EQ(toupper_fast('z'), 'Z');
+
+    const static char s1[]="abC1dEf2%^&", s2[]="ABc1DeF2%^&";
+    EXPECT_EQ(toupper_fast8(*(uint64_t*)s1),
+              toupper_fast8(*(uint64_t*)s2));
+    EXPECT_EQ(tolower_fast8(*(uint64_t*)s1),
+              tolower_fast8(*(uint64_t*)s2));
+    EXPECT_EQ(stricmp_fast(string_view(s1), string_view(s2)), 0);
+}
+
+const static char S1[]="ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+                  S2[]="abcdefghijklmnopqrstuvwxyz";
+TEST(tolowerupper, perf_strncasecmp) {
+    for (int i = 1000000; i; --i) {
+        auto ret = strncasecmp(S1, S2, LEN(S1) - 1);
+        asm volatile(""::"r"(ret));
+    }
+}
+
+TEST(tolowerupper, perf_photon_stricmp) {
+    for (int i = 1000000; i; --i) {
+        auto ret = stricmp_fast(S1, S2);
+        asm volatile(""::"r"(ret));
+    }
 }
 
 TEST(update_now, after_idle_sleep) {


### PR DESCRIPTION
comparison is 4+ times faster on MBP M1:
```
[ RUN      ] tolowerupper.perf_strncasecmp
[       OK ] tolowerupper.perf_strncasecmp (3270 ms)
[ RUN      ] tolowerupper.perf_photon__stricmp
[       OK ] tolowerupper.perf_photon__stricmp (777 ms)
```