### PR TITLE
extract_c_str() for estring_view

### DIFF
--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -107,7 +107,7 @@ ISocketStream* PooledDialer::dial(std::string_view host, uint16_t port, bool sec
     if (secure) {
         tlssock->timeout(timeout);
         sock = tlssock->connect(ep);
-        tls_stream_set_hostname(sock, host.data());
+        tls_stream_set_hostname(sock, estring_view(host).extract_c_str());
     } else {
         tcpsock->timeout(timeout);
         sock = tcpsock->connect(ep);


### PR DESCRIPTION
This implementation tries to avoid memory allocation and memcpy. It does so only when necessary.