### PR TITLE
Make `new_skeleton` with one argument able to be call

### DIFF
--- a/rpc/rpc.h
+++ b/rpc/rpc.h
@@ -250,7 +250,7 @@ namespace rpc
     extern "C" Skeleton* new_skeleton(uint32_t pool_size = 128);
 
     __attribute__((deprecated))
-    inline Skeleton* new_skeleton(bool /*concurrent*/, uint32_t pool_size = 128) {
+    inline Skeleton* new_skeleton(bool /*concurrent*/, uint32_t pool_size) {
         return new_skeleton(pool_size);
     }
 


### PR DESCRIPTION
there is two `new_skeleton` overloads, one with
`new_skeleton(uint32_t pool_size = 128)`
and another one is deprecated,
`new_skeleton(bool, int)`

when user calling with a integer parameter, such as
`new_skeleton(32)`
since c++ allows explicit cast from int to bool, both of those overloads are able to be called, become ambiguous calling.

remove the default parameter value of deprecated one, when user trying goes with only one parameter, it will always call the first implementation.