### PR TITLE
[Pick][0.7 to 0.8] | fix potential race condition in DefaultResolver when discard_cache()

### DIFF
--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -263,18 +263,20 @@ protected:
         IPAddr addr;
         IPAddrNode(IPAddr addr) : addr(addr) {}
     };
-    using IPAddrList = intrusive_list<IPAddrNode>;
-
-    IPAddr do_resolve(std::string_view host, Delegate<bool, IPAddr> filter) {
+    struct IPAddrList : public intrusive_list<IPAddrNode>, rwlock {
+        ~IPAddrList() { delete_all(); }
+    };
+public:
+    DefaultResolver(uint64_t cache_ttl, uint64_t resolve_timeout)
+        : dnscache_(cache_ttl), resolve_timeout_(resolve_timeout) {}
+    IPAddr resolve(const char *host) override {
         auto ctr = [&]() -> IPAddrList* {
             auto addrs = new IPAddrList();
             photon::semaphore sem;
             std::thread([&]() {
                 auto now = std::chrono::steady_clock::now();
                 IPAddrList ret;
-                auto cb = [&](IPAddr addr) -> int {
-                    if (filter && !filter.fire(addr))
-                        return 0;
+                auto cb = [&](IPAddr addr) {
                     ret.push_back(new IPAddrNode(addr));
                     return 0;
                 };
@@ -284,34 +286,17 @@ protected:
                 if ((uint64_t)time_elapsed <= resolve_timeout_) {
                     addrs->push_back(std::move(ret));
                     sem.signal(1);
-                } else {
-                    LOG_ERROR("resolve timeout");
-                    while(!ret.empty())
-                        delete ret.pop_front();
                 }
             }).detach();
             sem.wait(1, resolve_timeout_);
             return addrs;
         };
         auto ips = dnscache_.borrow(host, ctr);
-        if (ips->empty()) LOG_ERRNO_RETURN(0, IPAddr(), "Domain resolution for '`' failed", host);
+        if (ips->empty()) LOG_ERRNO_RETURN(0, IPAddr(), "Domain resolution for ` failed", host);
+        scoped_rwlock _(*ips, RLOCK);
         auto ret = ips->front();
         ips->node = ret->next();  // access in round robin order
         return ret->addr;
-    }
-
-public:
-    DefaultResolver(uint64_t cache_ttl, uint64_t resolve_timeout)
-        : dnscache_(cache_ttl), resolve_timeout_(resolve_timeout) {}
-    ~DefaultResolver() {
-        for (auto it : dnscache_) {
-            ((IPAddrList*)it->_obj)->delete_all();
-        }
-        dnscache_.clear();
-    }
-
-    IPAddr resolve(std::string_view host) override {
-        return do_resolve(host, nullptr);
     }
 
     IPAddr resolve_filter(std::string_view host, Delegate<bool, IPAddr> filter) override {
@@ -321,9 +306,9 @@ public:
     void discard_cache(std::string_view host, IPAddr ip) override {
         auto ipaddr = dnscache_.borrow(host);
         if (ip.undefined() || ipaddr->empty()) {
-            ipaddr->delete_all();
             ipaddr.recycle(true);
         } else {
+            scoped_rwlock _(*ipaddr, WLOCK);
             for (auto itr = ipaddr->rbegin(); itr != ipaddr->rend(); itr++) {
                 if ((*itr)->addr == ip) {
                     ipaddr->erase(*itr);


### PR DESCRIPTION
> fix potential race condition in DefaultResolver when discard_cache()

delete_all() and recycle() is not atomic; and there may be read-write race as well.

Generated by Auto PR, by cherry-pick related commits