### PR TITLE
minor update for http url and headers

### DIFF
--- a/net/http/headers.cpp
+++ b/net/http/headers.cpp
@@ -33,22 +33,17 @@ public:
     const HeadersBase* _h;
     HeaderAssistant(const HeadersBase* h) : _h(h) {}
 
-    int icmp(estring_view k1, estring_view k2) const {
-        int r = (int)(k1.size() - k2.size());
-        return r ? r : strncasecmp(k1.data(), k2.data(), k1.size());
-    }
-
     bool equal_to(rstring_view16 _k, std::string_view key) const {
-        return icmp(_k | _h->m_buf, key) == 0;
+        return (_k | _h->m_buf).icmp(key) == 0;
     }
     bool less(rstring_view16 _k1, rstring_view16 _k2) const {
-        return icmp(_k1 | _h->m_buf, _k2 | _h->m_buf) < 0;
+        return (_k1 | _h->m_buf).icmp(_k2 | _h->m_buf) < 0;
     }
     bool less(rstring_view16 _k, std::string_view key) const {
-        return icmp(_k | _h->m_buf, key) < 0;
+        return (_k | _h->m_buf).icmp(key) < 0;
     }
     bool less(std::string_view key, rstring_view16 _k) const {
-        return icmp(key, _k | _h->m_buf) < 0;
+        return estring_view(key).icmp(_k | _h->m_buf) < 0;
     }
 
     bool operator()(HeadersBase::KV a, std::string_view b) const { return less(a.first, b); }

--- a/net/http/url.cpp
+++ b/net/http/url.cpp
@@ -103,13 +103,15 @@ static bool isunreserved(char c) {
     return false;
 }
 
-std::string url_escape(std::string_view url) {
+std::string url_escape(std::string_view url, bool escape_slash) {
     static const char hex[] = "0123456789ABCDEF";
     std::string ret;
     ret.reserve(url.size() * 2);
 
     for (auto c : url) {
         if (isunreserved(c)) {
+            ret.push_back(c);
+        } else if (!escape_slash && c == '/') {
             ret.push_back(c);
         } else {
             ret += '%';

--- a/net/http/url.h
+++ b/net/http/url.h
@@ -109,7 +109,7 @@ inline bool need_optional_port(const URL& u) {
     return false;
 }
 
-std::string url_escape(std::string_view url);
+std::string url_escape(std::string_view url, bool escape_slash = true);
 std::string url_unescape(std::string_view url);
 
 } // namespace http


### PR DESCRIPTION
- Change HeaderAssistant to dictionary order sorting, as some scenarios require traversing headers in dictionary order, such as OSS signature v4.
- Add a parameter to url_escape, as sometimes / does not need to be escaped.