### PR TITLE
return underlay file for extFS

### DIFF
--- a/doc/docs/introduction/how-to-build.md
+++ b/doc/docs/introduction/how-to-build.md
@@ -107,7 +107,7 @@ The examples and test code are built together.
 # Install additional dependencies
 dnf install epel-release
 dnf config-manager --set-enabled powertools
-dnf install gtest-devel gmock-devel gflags-devel fuse-devel libgsasl-devel
+dnf install gtest-devel gmock-devel gflags-devel fuse-devel libgsasl-devel nasm
 
 # Build examples and test code
 cmake -B build -D PHOTON_BUILD_TESTING=ON
@@ -125,7 +125,7 @@ ctest
   
 ```bash
 # Install additional dependencies
-apt install libgtest-dev libgmock-dev libgflags-dev libfuse-dev libgsasl7-dev
+apt install libgtest-dev libgmock-dev libgflags-dev libfuse-dev libgsasl7-dev nasm
 
 # Build examples and test code
 cmake -B build -D PHOTON_BUILD_TESTING=ON

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/introduction/how-to-build.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/introduction/how-to-build.md
@@ -111,7 +111,7 @@ cmake --build build -j 8
 # Install additional dependencies
 dnf install epel-release
 dnf config-manager --set-enabled powertools
-dnf install gtest-devel gmock-devel gflags-devel fuse-devel libgsasl-devel
+dnf install gtest-devel gmock-devel gflags-devel fuse-devel libgsasl-devel nasm
 
 # Build examples and test code
 cmake -B build -D PHOTON_BUILD_TESTING=ON
@@ -129,7 +129,7 @@ ctest
   
 ```bash
 # Install additional dependencies
-apt install libgtest-dev libgmock-dev libgflags-dev libfuse-dev libgsasl7-dev
+apt install libgtest-dev libgmock-dev libgflags-dev libfuse-dev libgsasl7-dev nasm
 
 # Build examples and test code
 cmake -B build -D PHOTON_BUILD_TESTING=ON

--- a/fs/extfs/extfs.cpp
+++ b/fs/extfs/extfs.cpp
@@ -1298,6 +1298,9 @@ public:
             extfs_io_manager = new_io_manager(_image_file);
         }
         fs = do_ext2fs_open(extfs_io_manager);
+        if (fs == nullptr) {
+            return;
+        }
         memset(fs->reserved, 0, sizeof(fs->reserved));
         auto reserved = reinterpret_cast<std::uintptr_t *>(fs->reserved);
         reserved[0] = reinterpret_cast<std::uintptr_t>(this);
@@ -1505,7 +1508,11 @@ int ExtFile::flush_buffer() {
 
 photon::fs::IFileSystem *new_extfs(photon::fs::IFile *file, bool buffer) {
     auto extfs = new ExtFileSystem(file, buffer);
-    return extfs->fs ? extfs : nullptr;
+    if (extfs->fs == nullptr) {
+        delete extfs;
+        return nullptr;
+    }
+    return extfs;
 }
 
 }

--- a/fs/extfs/test/test.cpp
+++ b/fs/extfs/test/test.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 #include "../extfs.h"
 #include <fcntl.h>
 #include <dirent.h>
+#include <unistd.h>
 #include <utime.h>
 #include <sys/sysmacros.h>
 #include <sys/time.h>
@@ -28,6 +29,7 @@ limitations under the License.
 #include <photon/common/alog-stdstring.h>
 #include <photon/common/enumerable.h>
 #include "../../../test/gtest.h"
+#include "photon/common/utility.h"
 
 #define FILE_SIZE (2 * 1024 * 1024)
 
@@ -990,6 +992,19 @@ TEST_F(ExtfsTest, Xattr) {
     ret = removexattr(xattr_fs, "/test_xattr2", "user.test1");
     EXPECT_EQ(-1, ret);
     EXPECT_EQ(ENOENT, errno);
+}
+
+
+TEST_F(ExtfsTest, InvalidFs) {
+    std::string rootfs = "/tmp/invalid_fs.img";
+    auto file = photon::fs::open_localfile_adaptor(rootfs.c_str(), O_CREAT|O_TRUNC|O_RDWR, 0666);
+    EXPECT_NE(nullptr, file);
+    DEFER({
+        delete file;
+        ::unlink(rootfs.c_str());
+    });
+    auto err_fs = photon::fs::new_extfs(file, false);
+    EXPECT_EQ(err_fs, nullptr);
 }
 
 int main(int argc, char **argv) {

--- a/fs/extfs/test/test.cpp
+++ b/fs/extfs/test/test.cpp
@@ -381,7 +381,8 @@ photon::fs::IFileSystem *init_extfs() {
         delete image_file;
         LOG_ERRNO_RETURN(0, nullptr, "failed open extfs");
     }
-
+    auto underlay_file = (photon::fs::IFile*)(extfs->get_underlay_object());
+    EXPECT_EQ(underlay_file, image_file);
     return extfs;
 }
 class ExtfsTest : public ::testing::Test {


### PR DESCRIPTION
- implement the method 'ExtFileSystem::get_underlay_object()' to return its underlay file
- fix memleak if init_extfs failed.