### PR TITLE
remove weak

### DIFF
--- a/common/checksum/test/crc32_iscsi_00.asm
+++ b/common/checksum/test/crc32_iscsi_00.asm
@@ -425,7 +425,7 @@ section .text
 ;;;    crc_init = r8
 ;;;
 
-mk_global  crc32_iscsi_00, weak, function
+mk_global  crc32_iscsi_00, function
 crc32_iscsi_00:
 	endbranch
 

--- a/common/checksum/test/crc32_iscsi_crc_ext.S
+++ b/common/checksum/test/crc32_iscsi_crc_ext.S
@@ -186,10 +186,6 @@
   .global	cdecl(crc32_iscsi_crc_ext)
 #ifndef __APPLE__
 	.type	crc32_iscsi_crc_ext, %function
-  .weak cdecl(crc32_iscsi_crc_ext)
-#else
-  /* todo: failed to be a weak symbol in MacOS */
-  .weak_definition cdecl(crc32_iscsi_crc_ext)
 #endif
 cdecl(crc32_iscsi_crc_ext):
 	crc32_hw_common	crc32c

--- a/common/checksum/test/crc64_ecma_refl_by8.asm
+++ b/common/checksum/test/crc64_ecma_refl_by8.asm
@@ -376,7 +376,7 @@ section .text
 
 
 align 16
-mk_global 	FUNCTION_NAME, weak, function
+mk_global 	FUNCTION_NAME, function
 FUNCTION_NAME:
 	endbranch
         ; uint64_t c = crc ^ 0xffffffff,ffffffffL;

--- a/common/checksum/test/crc64_ecma_refl_pmull.S
+++ b/common/checksum/test/crc64_ecma_refl_pmull.S
@@ -404,9 +404,6 @@ crc64_tab:
 	.global	cdecl(\name)
 #ifndef __APPLE__
 	.type	\name, %function
-	.weak cdecl(\name)
-#else
-	.weak_definition cdecl(\name)
 #endif
 
 /* uint64_t crc64_refl_func(uint64_t seed, const uint8_t * buf, uint64_t len) */


### PR DESCRIPTION
The "weak" declarations in common/checksum/test/*.asm are no longer useful, and they sometimes cause compilation issues when binutils or nasm are not new enough.