### PR TITLE
fix: -Wvla-cxx-extension errors

### DIFF
--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -174,7 +174,7 @@ ssize_t Message::write_stream(IStream *input, size_t size_limit) {
     if (input == nullptr)
         return 0;
 
-    size_t buf_size = 65536;
+    const size_t buf_size = 65536;
     char seg_buf[buf_size + 4096];
     char *aligned_buf = (char*) (((uint64_t)(&seg_buf[0]) + 4095) / 4096 * 4096);
     size_t ret = 0;

--- a/net/http/server.cpp
+++ b/net/http/server.cpp
@@ -301,7 +301,7 @@ public:
                      client, client_ownership) {}
 
     int tunnel_copy(ISocketStream *src, ISocketStream *dst) {
-        size_t buf_size = 65536;
+        const size_t buf_size = 65536;
         char seg_buf[buf_size + 4096];
         char *aligned_buf = (char*) (((uint64_t)(&seg_buf[0]) + 4095) / 4096 * 4096);
 


### PR DESCRIPTION
These lines both cause a warning on the following line, which aborts the build due to -Werror:
`error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]`

This happens even though I am building with Clang (19.1.6).

Making them `const` resolves the error.