### PR TITLE
RPC: Able to change socket type; Improve doc;  Example support echo perf test

### DIFF
--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          brew install cmake openssl gflags googletest gsasl
+          brew install openssl gflags googletest gsasl
 
       - name: Build
         run: |

--- a/.github/workflows/ci.macos.x86_64.yml
+++ b/.github/workflows/ci.macos.x86_64.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          brew install cmake openssl gflags googletest gsasl nasm
+          brew install openssl gflags googletest gsasl nasm
 
       - name: Build
         run: |

--- a/examples/perf/net-perf.cpp
+++ b/examples/perf/net-perf.cpp
@@ -215,7 +215,7 @@ static int echo_server() {
     photon::thread_enable_join(stop_th);
 
     server->set_handler(handler);
-    server->bind_v4localhost(FLAGS_port);
+    server->bind_v4any(FLAGS_port);
     server->listen();
     server->start_loop(true);
 

--- a/examples/rpc/client.cpp
+++ b/examples/rpc/client.cpp
@@ -62,6 +62,21 @@ std::string ExampleClient::RPCEcho(photon::net::EndPoint ep,
     return s;
 }
 
+void ExampleClient::RPCEchoPerf(photon::net::EndPoint ep, void *req_buf, void *resp_buf, size_t buf_size) {
+    Echo::Request req;
+    req.str.assign(req_buf, buf_size);
+    Echo::Response resp;
+    resp.str.assign(resp_buf, buf_size);
+
+    int ret = -1;
+    auto stub = pool->get_stub(ep, false);
+    if (!stub) exit(1);
+    DEFER(pool->put_stub(ep, ret < 0));
+
+    ret = stub->call<Echo>(req, resp);
+    if (ret < 0) exit(1);
+}
+
 ssize_t ExampleClient::RPCRead(photon::net::EndPoint ep, const std::string& fn,
                                const struct iovec* iovec, int iovcnt) {
     ReadBuffer::Request req;

--- a/examples/rpc/client_main.cpp
+++ b/examples/rpc/client_main.cpp
@@ -14,38 +14,59 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <chrono>
 #include <gflags/gflags.h>
 #include <photon/common/alog-stdstring.h>
 #include <photon/io/signal.h>
 #include <photon/photon.h>
+#include <photon/thread/thread11.h>
+#include <photon/net/socket.h>
 
 #include "client.h"
 
 DEFINE_int32(port, 0, "server port");
 DEFINE_string(host, "127.0.0.1", "server ip");
+DEFINE_bool(echo_perf, false, "Instead of a standalone demo, run echo performance test and show statistics");
+DEFINE_uint64(buf_size, 4096, "buffer size for echo perf test");
+DEFINE_uint64(depth, 4, "io-depth for echo perf test");
 
 static bool running = true;
-static photon::join_handle* heartbeat;
+static photon::join_handle* bg_thread;
 static photon::net::EndPoint ep;
+static uint64_t qps = 0;
+static uint64_t time_cost = 0;
 
-void* heartbeat_thread(void* arg) {
+void show_statistics() {
+    uint64_t lat = (qps != 0) ? (time_cost / qps) : 0;
+    LOG_INFO("QPS: `, latency: ` us", qps, lat);
+    qps = time_cost = 0;
+}
+
+void heartbeat(ExampleClient* client) {
+    auto start = photon::now;
+    auto ret = client->RPCHeartbeat(ep);
+    auto end = photon::now;
+    if (ret > 0) {
+        LOG_INFO("heartbeat round trip `us", end - start);
+    } else {
+        LOG_INFO("heartbeat failed in `us", end - start);
+    }
+}
+
+void* run_bg_thread(void* arg) {
     auto client = (ExampleClient*)arg;
     while (running) {
-        auto start = photon::now;
-        auto half = client->RPCHeartbeat(ep);
-        auto end = photon::now;
-        if (half > 0) {
-            LOG_INFO("single trip `us, round trip `us", half - start,
-                     end - start);
+        if (FLAGS_echo_perf) {
+            show_statistics();
         } else {
-            LOG_INFO("heartbeat failed in `us", end - start);
+            heartbeat(client);
         }
         photon::thread_sleep(1);
     }
     return nullptr;
 }
 
-void run_some_task(ExampleClient* client) {
+void run_some_task_and_stop(ExampleClient* client) {
     auto echo = client->RPCEcho(ep, "Hello");
     LOG_INFO(VALUE(echo));
 
@@ -64,15 +85,45 @@ void run_some_task(ExampleClient* client) {
     LOG_INFO("Read from tmpfile ` ret=`", tmpfile, ret);
     LOG_INFO(VALUE((char*)readbuf));
     client->RPCTestrun(ep);
+
+    // Sleep 1s and stop
+    photon::thread_sleep(1);
+    running = false;
+}
+
+void run_echo_perf_forever(ExampleClient* client) {
+    photon::semaphore sem;
+    for (size_t i = 0; i < FLAGS_depth; i++) {
+        photon::thread_create11([&] {
+            AlignedAlloc alloc(512);
+            void* send_buf = alloc.alloc(FLAGS_buf_size);
+            void* recv_buf = alloc.alloc(FLAGS_buf_size);
+            DEFER(alloc.dealloc(send_buf));
+            DEFER(alloc.dealloc(recv_buf));
+
+            while (running) {
+                auto start = std::chrono::system_clock::now();
+
+                client->RPCEchoPerf(ep, send_buf, recv_buf, FLAGS_buf_size);
+
+                auto end = std::chrono::system_clock::now();
+                time_cost += std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+                qps++;
+            }
+            sem.signal(1);
+        });
+    }
+    sem.wait(FLAGS_depth);
 }
 
 void handle_term(int) {
     running = false;
-    photon::thread_interrupt((photon::thread*)heartbeat);
+    photon::thread_interrupt((photon::thread*)bg_thread);
 }
 
 int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
+    set_log_output_level(ALOG_INFO);
     srand(time(NULL));
     photon::init();
     DEFER(photon::fini());
@@ -81,12 +132,16 @@ int main(int argc, char** argv) {
     photon::sync_signal(SIGINT, &handle_term);
 
     ExampleClient client;
-    ep = photon::net::EndPoint(photon::net::IPAddr(FLAGS_host.c_str()),
-                               FLAGS_port);
-    heartbeat = photon::thread_enable_join(
-        photon::thread_create(heartbeat_thread, &client));
-    run_some_task(&client);
-    photon::thread_join(heartbeat);
+    ep = photon::net::EndPoint(FLAGS_host.c_str(), FLAGS_port);
+
+    bg_thread = photon::thread_enable_join(photon::thread_create(run_bg_thread, &client));
+
+    if (FLAGS_echo_perf) {
+        run_echo_perf_forever(&client);
+    } else {
+        run_some_task_and_stop(&client);
+    }
+    photon::thread_join(bg_thread);
 
     return 0;
 }

--- a/examples/rpc/server.cpp
+++ b/examples/rpc/server.cpp
@@ -42,8 +42,8 @@ int ExampleServer::do_rpc_service(Testrun::Request* req,
 
 int ExampleServer::do_rpc_service(Echo::Request* req, Echo::Response* resp,
                                   IOVector*, IStream*) {
-    resp->str = req->str;
-
+    // Zerocopy assign. Equivalent to resp->str = req->str;
+    resp->str.assign(req->str.addr(), req->str.length());
     return 0;
 }
 
@@ -94,7 +94,7 @@ int ExampleServer::do_rpc_service(WriteBuffer::Request* req,
 }
 
 int ExampleServer::run(int port) {
-    if (server->bind_v4localhost(port) < 0)
+    if (server->bind_v4any(port) < 0)
         LOG_ERRNO_RETURN(0, -1, "Failed to bind port `", port)
     if (server->listen() < 0) LOG_ERRNO_RETURN(0, -1, "Failed to listen");
     server->set_handler({this, &ExampleServer::serve});

--- a/examples/rpc/server_main.cpp
+++ b/examples/rpc/server_main.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include <photon/common/utility.h>
 #include <photon/io/signal.h>
 #include <photon/photon.h>
+#include <photon/common/alog.h>
+#include <photon/net/socket.h>
 
 #include "server.h"
 
@@ -29,17 +31,18 @@ void handle_term(int) { rpcservice.reset(); }
 
 int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
+    set_log_output_level(ALOG_INFO);
     photon::init();
     DEFER(photon::fini());
 
     photon::sync_signal(SIGPIPE, &handle_null);
     photon::sync_signal(SIGTERM, &handle_term);
     photon::sync_signal(SIGINT, &handle_term);
-    // start server
 
     // construct rpcservice
     rpcservice.reset(new ExampleServer());
 
+    // start server
     rpcservice->run(FLAGS_port);
 
     return 0;


### PR DESCRIPTION
1. Able to change RPC socket type
2. Improve doc of rpc.h
3. RPC example now support echo_perf option, able to run performance test loop.
4. Fix example bind to localhost bug, cannot be tested on different hosts.