### PR TITLE
[Pick][0.7 to 0.8] | Fix on RPC async_serve accessing count after context call (#763)

### DIFF
--- a/rpc/rpc.cpp
+++ b/rpc/rpc.cpp
@@ -236,6 +236,8 @@ namespace rpc {
                 COPY(func);
                 COPY(stream);
                 COPY(sk);
+                COPY(stream_serv_count);
+                COPY(stream_cv);
                 COPY(w_lock);
 #undef COPY
             }
@@ -375,14 +377,14 @@ namespace rpc {
         }
         static void* async_serve(void* args_)
         {
-            auto ctx = (Context*)args_;
-            Context context(std::move(*ctx));
-            ctx->got_it = true;
+            bool &got_it = ((Context*)args_)->got_it;
+            Context context(std::move(*(Context*)args_));
+            got_it = true;
             thread_yield();
             context.serve_request();
             // serve done, here reduce refcount
-            (*ctx->stream_serv_count) --;
-            ctx->stream_cv->notify_all();
+            (*context.stream_serv_count) --;
+            context.stream_cv->notify_all();
             return nullptr;
         }
         virtual int shutdown(bool no_more_requests) override {


### PR DESCRIPTION
> Fix on RPC async_serve accessing count after context call (#763)


Generated by Auto PR, by cherry-pick related commits