### PR TITLE
fix include in pool_store.h

### DIFF
--- a/cache/pool_store.h
+++ b/cache/pool_store.h
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #pragma once
+#include <string>
 #include <vector>
 #include <assert.h>
 #include <inttypes.h>


### PR DESCRIPTION
Fix compilation errors encountered in some environment
```bash
xxxxx/build/_deps/photon-src/include/photon/cache/pool_store.h:266:21: error: field ‘src_name_’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
  266 |         std::string src_name_;
      |           
```