### PR TITLE
fix istarts_with bug in estring_view

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -158,7 +158,7 @@ public:
     estring tolower_fast() const;
     estring toupper_fast() const;
     bool istarts_with(std::string_view x) const {
-        return size() >= x.size() && icmp(x) == 0;
+        return size() >= x.size() && substr(0, x.size()).icmp(x) == 0;
     }
     bool iends_with(std::string_view x) const {
         return size() >= x.size() && substr(size() - x.size()).icmp(x) == 0;

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -886,6 +886,14 @@ TEST(estring, test)
 
     EXPECT_EQ(estring_view("1").hex_to_uint64(), 0x1);
     EXPECT_EQ(estring_view("1a2b3d4e5f").hex_to_uint64(), 0x1a2b3d4e5f);
+    
+    estring_view s1 = "sdfsf234sdfji2ljk34", s2 = "sdfsf", s3 = "SDFSF";
+    estring_view s4 = "sdfsf3", s5 = "sdfsf234sdfji3";
+    EXPECT_EQ(true, s1.istarts_with(s2));
+    EXPECT_EQ(true, s1.istarts_with(s3));
+    EXPECT_EQ(false, s1.istarts_with(s4));
+    EXPECT_EQ(false, s1.istarts_with(s5));
+    EXPECT_EQ(false, s2.istarts_with(s1));
 }
 
 TEST(generator, example)

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -712,6 +712,25 @@ TEST(url, path_fix) {
     EXPECT_EQ(u2.query(), "a=b");
 }
 
+TEST(url, utils) {
+    estring_view u1 = "http://www.taobao.com", u2 = "https://www.taobao.com";
+    estring_view u3 = "HTTPS://www.taobao.com/", u4 = "www.taobao.com";
+    ASSERT_EQ(1, what_protocol(u1));
+    ASSERT_EQ(2, what_protocol(u2));
+    ASSERT_EQ(2, what_protocol(u3));
+    ASSERT_EQ(0, what_protocol(u4));
+    URL url1("http://www.taobao.com:80"), url2("https://www.taobao.com:443");
+    URL url3("http://www.taobao.com:8080"), url4("https://www.taobao.com:4443");
+    ASSERT_EQ(false, need_optional_port(url1));
+    ASSERT_EQ(false, need_optional_port(url2));
+    ASSERT_EQ(true, need_optional_port(url3));
+    ASSERT_EQ(true, need_optional_port(url4));
+    estring_view ul1 = "http://www.taobao.com?a=1&b=2";
+    estring_view ul2 = "http%3A%2F%2Fwww.taobao.com%3Fa%3D1%26b%3D2";
+    ASSERT_EQ(0, url_escape(ul1).compare(ul2));
+    ASSERT_EQ(0, url_unescape(ul2).compare(ul1));
+}
+
 // Only for manual test
 // TEST(http_client, proxy) {
 //     auto client = new_http_client();


### PR DESCRIPTION
1. Function _istarts_with_ in estring_view isn't functioning correctly. Fix it by adding substr.
2. Add more unittest for estring_view and url utils.