### PR TITLE
[Pick][0.8 to 0.9] | Upgrade c++ version to 17 for macOS CI

### DIFF
--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build
         run: |
           cmake -B ${{github.workspace}}/build \
+            -D PHOTON_CXX_STANDARD=17 \
             -D PHOTON_ENABLE_ECOSYSTEM=ON \
             -D PHOTON_BUILD_TESTING=ON \
             -D CMAKE_BUILD_TYPE=MinSizeRel \

--- a/.github/workflows/ci.macos.x86_64.yml
+++ b/.github/workflows/ci.macos.x86_64.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build
         run: |
           cmake -B ${{github.workspace}}/build \
+            -D PHOTON_CXX_STANDARD=17 \
             -D PHOTON_ENABLE_ECOSYSTEM=ON \
             -D PHOTON_BUILD_TESTING=ON \
             -D CMAKE_BUILD_TYPE=MinSizeRel \


### PR DESCRIPTION
> Upgrade c++ version to 17 for macOS CI

Generated by Auto PR, by cherry-pick related commits