### PR TITLE
make simple dom preseving the nodes' order of the document, by

### DIFF
--- a/common/stream.cpp
+++ b/common/stream.cpp
@@ -27,11 +27,14 @@ IStream::ReadAll IStream::readall(size_t max_buf, size_t min_buf) {
                 buf.size = -buf.size;
                 LOG_ERROR_RETURN(ENOBUFS, buf, "content size in stream exceeds upper limit ", max_buf);
             }
-            auto ptr = realloc(buf.ptr.get(), capacity *= 2);
+            capacity *= 2;
+            if ((size_t) capacity > max_buf) capacity = max_buf;
+            auto ptr = realloc(buf.ptr.get(), capacity);
             if (!ptr) {
                 buf.size = -buf.size;
                 LOG_ERROR_RETURN(ENOBUFS, buf, "failed to realloc(`)", capacity);
             }
+            buf.ptr.release();
             buf.ptr.reset(ptr);
         }
     }

--- a/ecosystem/simple_dom_impl.h
+++ b/ecosystem/simple_dom_impl.h
@@ -37,9 +37,10 @@ using str = estring_view;
 class NodeImpl : public Object {
 protected:
     NodeImpl() = default;
-    const static uint8_t FLAG_IS_ROOT       = 1;
-    const static uint8_t FLAG_IS_LAST       = 2;
-    const static uint8_t FLAG_TEXT_OWNERSHIP= 4;
+    const static uint8_t FLAG_IS_ROOT       = 1;    // the root node
+    const static uint8_t FLAG_IS_LAST       = 2;    // last sibling node
+    const static uint8_t FLAG_EQUAL_KEY_LAST= 4;    // last node with same key
+    const static uint8_t FLAG_TEXT_OWNERSHIP= 8;
     const static size_t  MAX_NODE_SIZE      = 256;
     const static size_t  MAX_NCHILDREN      = UINT16_MAX;
     const static size_t  MAX_KEY_OFFSET     = UINT32_MAX;
@@ -53,19 +54,17 @@ union { struct  { // for non-root nodes
         uint16_t _k_len : 12;       // key length (12 bits)
         uint16_t _v_off : 12;       // value offset (12 bits) to key end
     }__attribute__((packed));
-    uint32_t _k_off;                // key offset to _text_begin
     const NodeImpl* _root;          // root node
-    uint32_t _v_len;                // value length
-}                       ;           // packed as 20 bytes
+};                                  // packed as 20 bytes
 struct {         // for the root node
     uint8_t _flags_;                // the same as _flags
     uint8_t _node_size;             // sizeof(the node implementation)
     mutable uint16_t _refcnt;       // reference counter of the document
-    uint32_t _k_off_;
     const char* _text_begin;
-    uint32_t _v_len_;
 }; };
-    uint16_t _nchildren;            // for all nodes
+    uint32_t _k_off;                // key offset to _text_begin
+    uint32_t _v_len;                // value length
+    uint32_t _nchildren;            // for all nodes
 
     using AT16 = std::atomic<uint16_t>;
     static_assert(sizeof(AT16) == sizeof(_refcnt), "...");
@@ -107,10 +106,10 @@ public:
         return is_root() ? this : _root;
     }
     str get_key() const {
-        return {get_root()->_text_begin + _k_off, _k_len};
+        return get_key(get_root()->_text_begin);
     }
     str get_value() const {
-        return {get_key().end() + _v_off, _v_len};
+        return get_value(get_root()->_text_begin);
     }
     str get_key(const char* text_begin) const {
         return {text_begin + _k_off, _k_len};

--- a/ecosystem/test/test_simple_dom.cpp
+++ b/ecosystem/test/test_simple_dom.cpp
@@ -53,6 +53,7 @@ const static char xml[] = R"(
       <DisplayName>1305433xxx</DisplayName>
     </Owner>
   </Contents>
+  <asdf>asdf</asdf>
   <Contents>
     <Key>test100.txt</Key>
     <LastModified>2020-05-26T07:50:20.000Z</LastModified>
@@ -141,15 +142,9 @@ TEST(simple_dom, oss_list) {
     string marker;
     do_list_object("", list, &marker);
     static ObjectList truth = {
-        {0, DT_REG, "test100.txt", 1, false},
         {0, DT_REG, "test10.txt",  1, false},
+        {0, DT_REG, "test100.txt", 1, false},
     };
-    using T = decltype(truth[0]);
-    auto cmp = [](T& a, T& b) {
-        return std::get<2>(a) < std::get<2>(b);
-    };
-    std::sort(truth.begin(), truth.end(), cmp);
-    std::sort(list.begin(),  list.end(),  cmp);
     EXPECT_EQ(list, truth);
     EXPECT_EQ(marker, "test100.txt");
 }


### PR DESCRIPTION
make simple dom preseving the nodes' order of the document, by creating and sorting an index, instead of the nodes themselves.