### PR TITLE
fini_hook should clear after executed

### DIFF
--- a/photon.cpp
+++ b/photon.cpp
@@ -131,6 +131,7 @@ int fini() {
     for (auto h : get_hook_vector()) {
         h.fire();
     }
+    get_hook_vector().clear();
 #ifdef __linux__
     FINI_IO(LIBAIO, libaio_wrapper)
     FINI_IO(SOCKET_EDGE_TRIGGER, et_poller)


### PR DESCRIPTION
Photon environment finish hook should clear after fired.

When photon init and finish execute twice in same vcpu, the second round of photon fini will also fires hook functions in first round, may cause problems.

Fixed by clear the thread-local vector after fired.