### PR TITLE
io_uring cascading engine supports for I/O

### DIFF
--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 
-#include <gtest/gtest.h>
+#include "../../../test/gtest.h"
 
 #include <fcntl.h>
 #include <sys/types.h>
@@ -455,7 +455,7 @@ void* worker(void* arg) {
   auto f = fs->open("/huge", O_RDONLY);
   DEFER(delete f);
   for (int i=0;i<4;i++) {
-    std::random_shuffle(offset.begin(), offset.end());
+    shuffle(offset.begin(), offset.end());
     for (const auto &x : offset) {
       EXPECT_EQ((ssize_t)(1UL<<20), ::pread(fd, buffersrc, 1024*1024, x));
       f->pread(buffer, 1024*1024, x);

--- a/io/fd-events.h
+++ b/io/fd-events.h
@@ -145,6 +145,7 @@ struct iouring_args {
     bool setup_sqpoll = false;
     bool setup_sq_aff = false;
     bool setup_iopoll = false;
+    bool eager_submit = false;
     uint32_t sq_thread_cpu;
     uint32_t sq_thread_idle_ms = 1000;     // by default polls for 1s
 };

--- a/io/iouring-wrapper.h
+++ b/io/iouring-wrapper.h
@@ -26,77 +26,79 @@ limitations under the License.
 
 namespace photon {
 
+class CascadingEventEngine;
+
 static const uint64_t IouringFixedFileFlag = 1UL << 32;
 
-ssize_t iouring_pread(int fd, void* buf, size_t count, off_t offset, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_pread(int fd, void* buf, size_t count, off_t offset, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_pwrite(int fd, const void* buf, size_t count, off_t offset, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_pwrite(int fd, const void* buf, size_t count, off_t offset, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_preadv(int fd, const iovec* iov, int iovcnt, off_t offset, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_preadv(int fd, const iovec* iov, int iovcnt, off_t offset, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_pwritev(int fd, const iovec* iov, int iovcnt, off_t offset, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_pwritev(int fd, const iovec* iov, int iovcnt, off_t offset, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_send(int fd, const void* buf, size_t len, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_send(int fd, const void* buf, size_t len, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_send_zc(int fd, const void* buf, size_t len, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_send_zc(int fd, const void* buf, size_t len, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_sendmsg(int fd, const msghdr* msg, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_sendmsg(int fd, const msghdr* msg, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_sendmsg_zc(int fd, const msghdr* msg, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_sendmsg_zc(int fd, const msghdr* msg, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_recv(int fd, void* buf, size_t len, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_recv(int fd, void* buf, size_t len, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-ssize_t iouring_recvmsg(int fd, msghdr* msg, uint64_t flags = 0, Timeout timeout = {});
+ssize_t iouring_recvmsg(int fd, msghdr* msg, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-int iouring_connect(int fd, const sockaddr* addr, socklen_t addrlen, Timeout timeout = {});
+int iouring_connect(int fd, const sockaddr* addr, socklen_t addrlen, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-int iouring_accept(int fd, sockaddr* addr, socklen_t* addrlen, Timeout timeout = {});
+int iouring_accept(int fd, sockaddr* addr, socklen_t* addrlen, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-int iouring_fsync(int fd);
+int iouring_fsync(int fd, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-int iouring_fdatasync(int fd);
+int iouring_fdatasync(int fd, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-int iouring_open(const char* path, int flags, mode_t mode);
+int iouring_open(const char* path, int flags, mode_t mode, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-int iouring_mkdir(const char* path, mode_t mode);
+int iouring_mkdir(const char* path, mode_t mode, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
-int iouring_close(int fd);
+int iouring_close(int fd, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
 bool iouring_register_files_enabled();
 
-int iouring_register_files(int fd);
+int iouring_register_files(int fd, CascadingEventEngine* ce = nullptr);
 
-int iouring_unregister_files(int fd);
+int iouring_unregister_files(int fd, CascadingEventEngine* ce = nullptr);
 
 struct iouring
 {
-    static ssize_t pread(int fd, void *buf, size_t count, off_t offset, Timeout timeout = {})
+    static ssize_t pread(int fd, void *buf, size_t count, off_t offset, Timeout timeout = {}, CascadingEventEngine* ce = nullptr)
     {
-        return iouring_pread(fd, buf, count, offset, 0, timeout);
+        return iouring_pread(fd, buf, count, offset, 0, timeout, ce);
     }
-    static ssize_t preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset, Timeout timeout = {})
+    static ssize_t preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset, Timeout timeout = {}, CascadingEventEngine* ce = nullptr)
     {
-        return iouring_preadv(fd, iov, iovcnt, offset, 0, timeout);
+        return iouring_preadv(fd, iov, iovcnt, offset, 0, timeout, ce);
     }
-    static ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset, Timeout timeout = {})
+    static ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset, Timeout timeout = {}, CascadingEventEngine* ce = nullptr)
     {
-        return iouring_pwrite(fd, buf, count, offset, 0, timeout);
+        return iouring_pwrite(fd, buf, count, offset, 0, timeout, ce);
     }
-    static ssize_t pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset, Timeout timeout = {})
+    static ssize_t pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset, Timeout timeout = {}, CascadingEventEngine* ce = nullptr)
     {
-        return iouring_pwritev(fd, iov, iovcnt, offset, 0, timeout);
+        return iouring_pwritev(fd, iov, iovcnt, offset, 0, timeout, ce);
     }
-    static int fsync(int fd, Timeout timeout = {})
+    static int fsync(int fd, Timeout timeout = {}, CascadingEventEngine* ce = nullptr)
     {
-        return iouring_fsync(fd);
+        return iouring_fsync(fd, timeout, ce);
     }
-    static int fdatasync(int fd, Timeout timeout = {})
+    static int fdatasync(int fd, Timeout timeout = {}, CascadingEventEngine* ce = nullptr)
     {
-        return iouring_fdatasync(fd);
+        return iouring_fdatasync(fd, timeout, ce);
     }
-    static int close(int fd)
+    static int close(int fd, Timeout timeout = {}, CascadingEventEngine* ce = nullptr)
     {
-        return iouring_close(fd);
+        return iouring_close(fd, timeout, ce);
     }
 };
 

--- a/net/vdma/shm.cpp
+++ b/net/vdma/shm.cpp
@@ -56,11 +56,11 @@ public:
     ~SharedMemoryBuffer() {}
 
     bool is_registered() const override {
-        return true; 
+        return true;
     }
 
-    bool is_valid() const override { 
-        return true; 
+    bool is_valid() const override {
+        return true;
     }
 
     std::string_view id() const override {
@@ -110,7 +110,7 @@ public:
         }
         LOG_DEBUG("SharedMemoryBufferAllocator: ", VALUE(shm_fd_), VALUE(shm_size_), VALUE(unit_));
 
-        ftruncate(shm_fd_, shm_size_);
+        int ret = ftruncate(shm_fd_, shm_size_); (void)ret;
         shm_begin_ptr_ = (char*)mmap(NULL, shm_size_, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd_, 0);
         if (!shm_begin_ptr_) {
             close(shm_fd_);
@@ -121,7 +121,7 @@ public:
         used_mark_.resize(nbuffer_);
         LOG_DEBUG("SharedMemoryBufferAllocator: ", VALUE(shm_begin_ptr_), VALUE(nbuffer_));
         LOG_DEBUG("SharedMemoryBufferAllocator: ", VALUE(used_mark_.size()), VALUE(buffers_.size()));
-        
+
         for (size_t i=0; i<nbuffer_; i++) {
             buffers_.emplace_back(i, shm_begin_ptr_ + i * unit_, unit_, vDMABufferType::kSharedMem);
         }
@@ -162,13 +162,13 @@ public:
     }
 
     size_t unit() const { return unit_; }
-    
+
 private:
     std::string shm_name_;
     int shm_fd_;
     size_t shm_size_;
     char* shm_begin_ptr_;
-    
+
     size_t unit_;
     size_t nbuffer_;
 
@@ -228,7 +228,7 @@ class SharedMemoryInitiator : public vDMAInitiator {
 public:
     SharedMemoryInitiator(const char* shm_name, size_t shm_size)
     :
-    shm_name_(shm_name), shm_size_(shm_size) 
+    shm_name_(shm_name), shm_size_(shm_size)
     {
         shm_fd_ = shm_open(shm_name, O_RDWR, 0666);
         if (shm_fd_ < 0) {
@@ -236,7 +236,7 @@ public:
         }
         LOG_DEBUG("SharedMemoryInitiator: ", VALUE(shm_fd_), VALUE(shm_size_));
 
-        ftruncate(shm_fd_, shm_size_);
+        int ret = ftruncate(shm_fd_, shm_size_); (void)ret;
         shm_begin_ptr_ = (char*)mmap(NULL, shm_size_, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd_, 0);
         if (!shm_begin_ptr_) {
             LOG_ERROR("SharedMemoryInitiator, mmap failed");


### PR DESCRIPTION
It is observed that, when using io_uring to interact with libfuse, it's more performant to submit I/O requests to ```fuse_dev_fd``` without blocking on io_uring. So we need to use cascading engine to issue I/O and block on eventfd and epoll master engine.