### PR TITLE
[Pick][0.7 to 0.8] | Fix incorrect char usage in estring trim function

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -46,14 +46,14 @@ struct charset : std::bitset<256>
     // charset(const char (&s) [N]) :
     //     charset(std::string_view(s, N - 1)) { }
 
-    // bool test(char ch) const
-    // {
-    //     return std::bitset<256>::test((unsigned char)ch);
-    // }
-    // bitset& set(char ch, bool value = true)
-    // {
-    //     return std::bitset<256>::set((unsigned char)ch, value);
-    // }
+    bool test(char ch) const
+    {
+        return std::bitset<256>::test((unsigned char)ch);
+    }
+    bitset& set(char ch, bool value = true)
+    {
+        return std::bitset<256>::set((unsigned char)ch, value);
+    }
 };
 
 class estring_view : public std::string_view

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -872,9 +872,9 @@ TEST(estring, test)
     auto ps = estring::snprintf("%d%d%d", 2, 3, 4);
     EXPECT_EQ(ps, "234");
 
-    estring as = "   \tasdf  \t\r\n";
+    estring as = "   \tasdf中文  \t\r\n";
     auto trimmed = as.trim();
-    EXPECT_EQ(trimmed, "asdf");
+    EXPECT_EQ(trimmed, "asdf中文");
 
     EXPECT_EQ(estring_view("234423").to_uint64(), 234423);
     EXPECT_EQ(estring_view("-234423").to_int64(), -234423);


### PR DESCRIPTION
> Fix incorrect char usage in estring trim function

The trim function previously used 'char' type for comparing characters,
which causes sign-extension issues when character values are in the range
128~255.

Change to use 'unsigned char' ensures correct comparison and fixes the bug.

Generated by Auto PR, by cherry-pick related commits