### PR TITLE
[Pick][0.7 to 0.8] | Force libcurl using http/1.1 since photon wrapper does not support using http/2

### DIFF
--- a/net/curl.h
+++ b/net/curl.h
@@ -242,6 +242,7 @@ public:
         setopt(CURLOPT_ERRORBUFFER, m_errmsg);
         setopt(CURLOPT_NOSIGNAL, 1L);
         setopt(CURLOPT_TCP_NODELAY, 1L);
+        setopt(CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
         m_errmsg[0] = '\0';
     }
     ~cURL() { curl_easy_cleanup(m_curl); }


### PR DESCRIPTION
> Force libcurl using http/1.1 since photon wrapper does not support using http/2

Generated by Auto PR, by cherry-pick related commits