### PR TITLE
fuse-adaptor:Add splice api for all loop mode

### DIFF
--- a/fs/fuse_adaptor/session_loop.cpp
+++ b/fs/fuse_adaptor/session_loop.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #include "session_loop.h"
 
+
 #if FUSE_USE_VERSION >= 30
 #include <fuse3/fuse_lowlevel.h>
 #else
@@ -34,7 +35,8 @@ limitations under the License.
 #endif
 #include <sys/ioctl.h>
 #include <unistd.h>
-#include <liburing.h>
+#include <errno.h>
+#include <string.h>
 
 #include <photon/common/alog.h>
 #include <photon/io/fd-events.h>
@@ -48,8 +50,234 @@ limitations under the License.
 namespace photon {
 namespace fs {
 
+#if FUSE_USE_VERSION >= 30
+struct fuse_pipe {
+    size_t size;
+    int pipefd[2] = {-1, -1};
+    ssize_t flush() {
+        int nuldev_fd = open("/dev/null", O_WRONLY);
+        if (nuldev_fd < 0) {
+            LOG_ERROR("fuse-adaptor failed to open null device: `", strerror(errno));
+            return -1;
+        }
+
+        return splice(pipefd[0], NULL, nuldev_fd, NULL, size, SPLICE_F_MOVE);
+    }
+
+    int setup() {
+        int rv;
+        if ((pipefd[0] != -1) && (pipefd[1] != -1))
+            return 0;
+
+#if !defined(HAVE_PIPE2) || !defined(O_CLOEXEC)
+        rv = pipe(pipefd);
+        if (rv == -1)
+            return rv;
+
+        if (fcntl(pipefd[0], F_SETFL, O_NONBLOCK) == -1 ||
+            fcntl(pipefd[1], F_SETFL, O_NONBLOCK) == -1 ||
+            fcntl(pipefd[0], F_SETFD, FD_CLOEXEC) == -1 ||
+            fcntl(pipefd[1], F_SETFD, FD_CLOEXEC) == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
+            return -1;
+        }
+#else
+        rv = pipe2(pipefd, O_CLOEXEC | O_NONBLOCK);
+        if (rv == -1)
+            return rv;
+#endif
+
+        size_t page_size = getpagesize();
+        fcntl(pipefd[0], F_SETPIPE_SZ, page_size *(256 + 1));
+        size = page_size * (256 + 1);
+        return 0;
+    }
+
+    int setdown() {
+        if (pipefd[0] != -1)
+            close(pipefd[0]);
+        if (pipefd[1] != -1)
+            close(pipefd[1]);
+
+        pipefd[0] = -1;
+        pipefd[1] = -1;
+        size = 0;
+
+        return 0;
+    }
+};
+
+int fuse_session_receive_splice(
+        struct fuse_session *se,
+        struct fuse_buf *buf,
+        struct fuse_pipe *iopipe) {
+    return fuse_session_receive_splice(se, buf, iopipe, fuse_session_fd(se));
+}
+
+int fuse_session_receive_splice(
+        struct fuse_session *se,
+        struct fuse_buf *buf,
+        struct fuse_pipe *iopipe,
+        int fd) {
+
+    // proto_minor and conn.want_ext are defined internally in libfuse and are
+    // not visible here, so we cannot use the following two conditions to determine
+    // the availability of splice_read. For now, we assume that splice_read is
+    // always enabled.
+    // if (se->conn.proto_minor < 14 ||
+    //    !(se->conn.want_ext & FUSE_CAP_SPLICE_READ))
+
+    errno = 0;
+    ssize_t res = splice(fd, NULL, iopipe->pipefd[1], NULL, iopipe->size, 0);
+    int err = errno;
+
+    if (fuse_session_exited(se))
+        return 0;
+
+    if (res == -1) {
+        if (err == ENODEV) {
+            fuse_session_exit(se);
+            return 0;
+        }
+
+        if (err == EINVAL) {
+            iopipe->flush();
+        }
+
+        if (err != EINTR && err != EAGAIN)
+            LOG_INFO("splice from device error `", err);
+        return -err;
+    }
+
+    // The struct fuse_in_header is defined internally within libfuse and is not
+    // visible externally, so we cannot truly obtain its size. Although we all
+    // know that its size is likely 40.
+    // if (res < sizeof(struct fuse_in_header)) {
+    //    LOG_ERROR("short splice from fuse device `", res);
+    //    iopipe->flush();
+    //    return -EIO;
+    // }
+
+    struct fuse_buf tmpbuf = (struct fuse_buf) {
+        .size = (size_t)res,
+        .flags = FUSE_BUF_IS_FD,
+        .fd = iopipe->pipefd[0],
+    };
+
+    buf->fd = tmpbuf.fd;
+    buf->flags = tmpbuf.flags;
+    buf->size = tmpbuf.size;
+
+    return res;
+}
+
+int fuse_session_receive_fd(
+        struct fuse_session *se,
+        struct fuse_buf *buf,
+        int fd) {
+    int err = 0;
+    ssize_t res = 0;
+    size_t bufsize = getpagesize() * (256 + 1);
+
+    if (!buf->mem) {
+        buf->mem = malloc(bufsize);
+    }
+restart:
+    errno = 0;
+    res = read(fd, buf->mem, bufsize);
+    err = errno;
+    if (res == -1 && err == EWOULDBLOCK) {
+        return 0;
+    }
+
+    if (fuse_session_exited(se)) {
+        return 0;
+    }
+
+    if (res == -1) {
+        // ENOENT means the operation was interrupted, it's safe to restart
+        if (err == ENOENT)
+            goto restart;
+
+        if (err == ENODEV) {
+			// Filesystem was unmounted, or connection was aborted
+            //  via /sys/fs/fuse/connections
+            fuse_session_exit(se);
+            return 0;
+        }
+
+        // Errors occurring during normal operation: EINTR (read
+        // interrupted), EAGAIN (nonblocking I/O), ENODEV (filesystem
+        // umounted) */
+        if (err != EINTR && err != EAGAIN) {
+            LOG_ERROR("reading device was interrupted");
+        }
+
+        return -err;
+    }
+
+    return res;
+}
+
+int fuse_session_receive_uring_splice(struct fuse_session *se, struct fuse_buf *buf,
+        int fd, struct fuse_pipe *iopipe, CascadingEventEngine *cee) {
+
+    // proto_minor and conn.want_ext are defined internally in libfuse and are
+    // not visible here, so we cannot use the following two conditions to determine
+    // the availability of splice_read. For now, we assume that splice_read is
+    // always enabled.
+    // if (se->conn.proto_minor < 14 ||
+    //    !(se->conn.want_ext & FUSE_CAP_SPLICE_READ))
+
+    errno = 0;
+    ssize_t res = iouring_splice(fd, 0, iopipe->pipefd[1], -1, iopipe->size, 0, -1, cee);
+    int err = errno;
+
+    if (fuse_session_exited(se))
+        return 0;
+
+    if (res == -1) {
+        if (err == ENODEV) {
+            fuse_session_exit(se);
+            return 0;
+        }
+
+        if (err == EINVAL) {
+            iopipe->flush();
+        }
+
+        if (err != EINTR && err != EAGAIN)
+            LOG_INFO("splice from device error `", err);
+        return -err;
+    }
+
+    // The struct fuse_in_header is defined internally within libfuse and is not
+    // visible externally, so we cannot truly obtain its size. Although we all
+    // know that its size is likely 40.
+    // if (res < sizeof(struct fuse_in_header)) {
+    //    LOG_ERROR("short splice from fuse device `", res);
+    //    iopipe->flush();
+    //    return -EIO;
+    // }
+
+    struct fuse_buf tmpbuf = (struct fuse_buf) {
+        .size = (size_t)res,
+        .flags = FUSE_BUF_IS_FD,
+        .fd = iopipe->pipefd[0],
+    };
+
+    buf->fd = tmpbuf.fd;
+    buf->flags = tmpbuf.flags;
+    buf->size = tmpbuf.size;
+
+    return res;
+}
+#endif
+
 class EPollSessionLoop : public FuseSessionLoop {
 private:
+    loop_args args_;
     struct fuse_session *se;
 #if FUSE_USE_VERSION < FUSE_MAKE_VERSION(3, 0)
     struct fuse_chan *ch;
@@ -57,6 +285,7 @@ private:
     IdentityPool<void, 32> bufpool;
 #else
     IdentityPool<struct fuse_buf, 32> bufpool;
+    IdentityPool<struct fuse_pipe, 32> pipepool;
 #endif
     ThreadPool<32> threadpool;
     EventLoop *loop;
@@ -80,6 +309,7 @@ private:
     }
 
     static void *fuse_do_work(void *args) {
+        int res;
         auto obj = (EPollSessionLoop *)args;
 #if FUSE_USE_VERSION < FUSE_MAKE_VERSION(3, 0)
         struct fuse_buf fbuf;
@@ -90,13 +320,22 @@ private:
         DEFER({
             obj->bufpool.put(fbuf.mem);
         });
-        auto res = fuse_session_receive_buf(obj->se, &fbuf, &tmpch);
+        res = fuse_session_receive_buf(obj->se, &fbuf, &tmpch);
 #else
         struct fuse_buf *pfbuf = obj->bufpool.get();
         DEFER({
             obj->bufpool.put(pfbuf);
         });
-        auto res = fuse_session_receive_buf(obj->se, pfbuf);
+        if (!obj->args_.force_splice_read)
+            res = fuse_session_receive_buf(obj->se, pfbuf);
+        else {
+            struct fuse_pipe *pfpipe = obj->pipepool.get();
+            pfpipe->setup();
+            DEFER({
+                obj->pipepool.put(pfpipe);
+            });
+            res = fuse_session_receive_splice(obj->se, pfbuf, pfpipe);
+        }
 #endif
         DEFER({
             if (--obj->ref == 0) obj->cond.notify_all();
@@ -165,7 +404,8 @@ public:
           loop(new_event_loop({this, &EPollSessionLoop::wait_for_readable},
                               {this, &EPollSessionLoop::on_accept})) {}
 
-    int init() {
+    int init(const loop_args &args) {
+        args_ = args;
 #if FUSE_USE_VERSION < FUSE_MAKE_VERSION(3, 0)
         auto ch = fuse_session_next_chan(se, NULL);
         auto fd = fuse_chan_fd(ch);
@@ -191,8 +431,8 @@ public:
     void run() { loop->run(); }
 };
 
-FuseSessionLoop* new_epoll_session_loop(struct fuse_session *se) {
-    return NewObj<EPollSessionLoop>(se)->init();
+FuseSessionLoop* new_epoll_session_loop(struct fuse_session *se, loop_args args) {
+    return NewObj<EPollSessionLoop>(se)->init(args);
 }
 
 
@@ -202,6 +442,7 @@ FuseSessionLoop* new_epoll_session_loop(struct fuse_session *se) {
 #define FUSE_DEV_IOC_CLONE  _IOR(FUSE_DEV_IOC_MAGIC, 0, uint32_t)
 
 static photon::thread_local_ptr<int> iofd;
+static photon::thread_local_ptr<struct fuse_pipe> iopipe;
 
 static ssize_t custom_writev(int fd, struct iovec *iov, int count, void *userdata)
 {
@@ -216,16 +457,32 @@ static ssize_t custom_read(int fd, void *buf, size_t len, void *userdata)
     return read(*iofd, buf, len);
 }
 
-template <typename ...Args>
-class WorkerArgs {
-public:
-    std::tuple<Args...> args;
-};
+static ssize_t custom_splice_receive(
+    int fdin, off_t *offin,
+    int fdout, off_t *offout, size_t len,
+    unsigned int flags, void *userdata)
+{
+    // flags |= SPLICE_F_NONBLOCK;
+    return splice(*iofd, offin, iopipe->pipefd[1], offout, len, 0);
+}
+
+static ssize_t custom_splice_send(
+    int fdin, off_t *offin,
+    int fdout, off_t *offout, size_t len,
+    unsigned int flags, void *userdata)
+{
+    return splice(iopipe->pipefd[0], offin, *iofd, offout, len, flags);
+}
 
 class SyncSessionLoop : public FuseSessionLoop {
 public:
-    int init() {
+    int init(const loop_args &args) {
+        args_ = args;
         set_fd();
+        max_workers_ = args_.max_threads;
+        if (max_workers_ <= 0)
+            max_workers_ = 32;
+
         for (int i = 0; i < max_workers_; ++i) {
             auto th = photon::thread_create11(
                 &SyncSessionLoop::fuse_do_work, this, i);
@@ -264,8 +521,8 @@ public:
         const struct fuse_custom_io custom_io = {
             .writev = photon::fs::custom_writev,
 	        .read = photon::fs::custom_read,
-	        .splice_receive = NULL,
-	        .splice_send = NULL,
+	        .splice_receive = photon::fs::custom_splice_receive,
+	        .splice_send = photon::fs::custom_splice_send,
 #if FUSE_USE_VERSION >= FUSE_MAKE_VERSION(3, 17)
         	.clone_fd = NULL,
 #endif
@@ -280,6 +537,7 @@ public:
     }
 
 private:
+    loop_args args_;
     struct fuse_session *se_;
     int blk_fd_;
     int nonblk_fd_;
@@ -334,22 +592,30 @@ private:
         fcntl(noblk_fd, F_SETFL, (flags | O_NONBLOCK));
         nonblk_fd_ = noblk_fd;
 
-        LOG_INFO("masterfd:`", masterfd, " block fd `", blk_fd_, "  nonblock fd: `", nonblk_fd_);
+        LOG_INFO("masterfd:`", masterfd,
+                 " block fd `", blk_fd_,
+                 "  nonblock fd: `", nonblk_fd_);
         return 0;
     }
 
     void *fuse_do_work(int id) {
+        int res;
         auto wrk_id = id;
         struct fuse_buf fbuf = {
             .mem = NULL,
         };
 
+        if (args_.force_splice_read)
+            (*iopipe).setup();
         sem_.wait(1);
         idlers_.erase(wrk_id);
         while(!fuse_session_exited(se_)) {
             if (idlers_.size() == (workers_.size() - 1)) {
                 *iofd = blk_fd_;
-                int res = fuse_session_receive_buf(se_, &fbuf);
+                if (args_.force_splice_read)
+                    res = fuse_session_receive_splice(se_, &fbuf, &*iopipe, *iofd);
+                else
+                    res = fuse_session_receive_fd(se_, &fbuf, *iofd);
                 if (res <= 0) {
                     break;
                 }
@@ -361,7 +627,10 @@ private:
                 fuse_session_process_buf(se_, &fbuf);
             } else {
                 *iofd = nonblk_fd_;
-                int res = fuse_session_receive_buf(se_, &fbuf);
+                if (args_.force_splice_read)
+                    res = fuse_session_receive_splice(se_, &fbuf, &*iopipe, *iofd);
+                else
+                    res = fuse_session_receive_fd(se_, &fbuf, *iofd);
                 if (res < 0) {
                     if (res != -EWOULDBLOCK || res != -EAGAIN) {
                         break;
@@ -393,6 +662,8 @@ private:
             }
         }
 
+        if (args_.force_splice_read)
+            (*iopipe).setdown();
         for (const auto& wrk : idlers_) {
             photon::thread_interrupt(workers_[wrk]);
         }
@@ -400,8 +671,8 @@ private:
     }
 };
 
-FuseSessionLoop *new_sync_session_loop(struct fuse_session *se) {
-    return NewObj<SyncSessionLoop>(se)->init();
+FuseSessionLoop *new_sync_session_loop(struct fuse_session *se, loop_args args) {
+    return NewObj<SyncSessionLoop>(se)->init(args);
 }
 
 int set_sync_custom_io(struct fuse_session *se) {
@@ -436,8 +707,12 @@ public:
         delete io_engine_;
     }
 
-    int init() {
+    int init(const loop_args &args) {
+        args_ = args;
         set_fd();
+        max_workers_ = args.max_threads;
+        if (max_workers_ <= 0)
+            max_workers_ = 32;
         for (int i = 0; i < max_workers_; ++i) {
             auto th = photon::thread_create11(
                 &IouringSessionLoop::fuse_do_work, this);
@@ -478,6 +753,7 @@ public:
     static thread_local int io_fd;
 
 private:
+    loop_args args_;
     struct fuse_session *se_;
     int max_workers_;
     std::vector<photon::thread *> workers_;
@@ -486,17 +762,22 @@ private:
     CascadingEventEngine *io_engine_;
 
     void wait_all_fini() {
-        while (!workers_.empty()) {
-            auto th = workers_.back();
-            photon::thread_join((photon::join_handle *)th);
-            workers_.pop_back();
-        }
-
         if (poller_) {
             photon::thread_interrupt(poller_);
             photon::thread_join((photon::join_handle *)poller_);
             poller_ = nullptr;
         }
+
+        // Since the poller exits after detecting that the session has exited,
+        // and some workers may still be in a permanent sleep state, we interrupt
+        // all workers to break any potential long-term sleep.
+        while (!workers_.empty()) {
+            auto th = workers_.back();
+            photon::thread_interrupt(th, EOK);
+            photon::thread_join((photon::join_handle *)th);
+            workers_.pop_back();
+        }
+
     }
 
     int set_fd() {
@@ -527,12 +808,16 @@ private:
             .mem = NULL,
         };
 
+        if (args_.force_splice_read)
+            (*iopipe).setup();
         sem_.wait(1);
         while (!fuse_session_exited(se_)) {
             int res;
-            {
+            if (!args_.force_splice_read)
                 res = fuse_session_receive_buf(se_, &fbuf);
-            }
+            else
+                res = fuse_session_receive_uring_splice(
+                          se_, &fbuf, io_fd, &*iopipe, io_engine_);
             if (res == -EINTR)
                 continue;
             if (res <= 0)  {// Returned 0 indeicate that session has exited
@@ -542,7 +827,10 @@ private:
                 break;
             }
             fuse_session_process_buf(se_, &fbuf);
-       }
+        }
+
+        if (args_.force_splice_read)
+            (*iopipe).setdown();
        return NULL;
     }
 
@@ -551,6 +839,7 @@ private:
             ssize_t ret = io_engine_->wait_for_events(nullptr, 0, -1);
             (void) ret;
         }
+
         return nullptr;
     }
 };
@@ -574,8 +863,8 @@ ssize_t custom_iou_read(int fd, void *buf, size_t len, void *userdata)
     return ret;
 }
 
-FuseSessionLoop *new_iouring_session_loop(struct fuse_session *se) {
-    return NewObj<IouringSessionLoop>(se)->init();
+FuseSessionLoop *new_iouring_session_loop(struct fuse_session *se, loop_args args) {
+    return NewObj<IouringSessionLoop>(se)->init(args);
 }
 
 int set_iouring_custom_io(struct fuse_session *se) {

--- a/fs/fuse_adaptor/session_loop.h
+++ b/fs/fuse_adaptor/session_loop.h
@@ -42,6 +42,11 @@ const uint64_t FUSE_SESSION_LOOP_DEFAULT = FUSE_SESSION_LOOP_EPOLL |
                                            FUSE_SESSION_LOOP_IOURING;
 #undef SHIFT
 
+struct loop_args {
+    uint64_t looptype = FUSE_SESSION_LOOP_EPOLL;
+    bool force_splice_read = false;
+    int max_threads = 32;
+};
 
 class FuseSessionLoop {
 public:
@@ -54,7 +59,7 @@ int set_sync_custom_io(struct fuse_session *);
 int set_iouring_custom_io(struct fuse_session *);
 
 #define DECLARE_SESSION_LOOP(name)  \
-FuseSessionLoop *new_##name##_session_loop(struct fuse_session *)
+FuseSessionLoop *new_##name##_session_loop(struct fuse_session *, loop_args = {})
 
 DECLARE_SESSION_LOOP(epoll);
 #if FUSE_USE_VERSION >= FUSE_MAKE_VERSION(3, 13)
@@ -63,18 +68,18 @@ DECLARE_SESSION_LOOP(iouring);
 #endif
 
 inline FuseSessionLoop *
-new_session_loop(struct fuse_session *se, uint64_t loop_type) {
-    switch (loop_type) {
+new_session_loop(struct fuse_session *se, loop_args args = {}) {
+    switch (args.looptype) {
 // The API function `fuse_session_custom_io` was introduced in version 3.13.0
 #if FUSE_USE_VERSION >= FUSE_MAKE_VERSION(3, 13)
         case FUSE_SESSION_LOOP_SYNC:
-            return new_sync_session_loop(se);
+            return new_sync_session_loop(se, args);
         case FUSE_SESSION_LOOP_IOURING_CASCADING:
-            return new_iouring_session_loop(se);
+            return new_iouring_session_loop(se, args);
 #endif
         case FUSE_SESSION_LOOP_EPOLL:
         default:
-            return new_epoll_session_loop(se);
+            return new_epoll_session_loop(se, args);
     }
 }
 

--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -595,6 +595,12 @@ inline iouringEngine* get_ring(CascadingEventEngine* cee) {
                  static_cast<iouringEngine*>(get_vcpu()->master_event_engine);
 }
 
+ssize_t iouring_splice(int fd_in, int64_t off_in, int fd_out, int64_t off_out, unsigned int nbytes, uint64_t flags, Timeout timeout, CascadingEventEngine *cee) {
+    uint32_t splice_flags = flags & 0xffffffff;
+    uint32_t ring_flags = flags >> 32;
+    return get_ring(cee)->async_io(&io_uring_prep_splice, timeout, ring_flags, fd_in, off_in, fd_out, off_out, nbytes, splice_flags);
+}
+
 ssize_t iouring_pread(int fd, void* buf, size_t count, off_t offset, uint64_t flags, Timeout timeout, CascadingEventEngine* cee) {
     uint32_t ring_flags = flags >> 32;
     return get_ring(cee)->async_io(&io_uring_prep_read, timeout, ring_flags, fd, buf, count, offset);

--- a/io/iouring-wrapper.h
+++ b/io/iouring-wrapper.h
@@ -30,6 +30,9 @@ class CascadingEventEngine;
 
 static const uint64_t IouringFixedFileFlag = 1UL << 32;
 
+ssize_t iouring_splice(int fd_in, int64_t off_in, int fd_out, int64_t off_out,
+                       unsigned int nbytes, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
+
 ssize_t iouring_pread(int fd, void* buf, size_t count, off_t offset, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);
 
 ssize_t iouring_pwrite(int fd, const void* buf, size_t count, off_t offset, uint64_t flags = 0, Timeout timeout = {}, CascadingEventEngine* ce = nullptr);


### PR DESCRIPTION
This patch adds splice I/O support to the fuse request receive process for all three loop modes. Due to some invisible struct definitions in the libfuse code, parts of the libfuse interfaces have to be rewritten, which are all placed in fuse-compat.cpp. For the same reason, we cannot automatically switch between splice(2) and read(2) as libfuse does internally, so currently only the forced splice method and the normal read interface are supported.