### PR TITLE
[Pick][0.8 to 0.9] | ensure at_photon_fini executed in PooledDialer when photon init and finish twice

### DIFF
--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -48,16 +48,13 @@ public:
     // multiple times, even for a thread_local instance. Therefore, ensure that there is no photon
     // thread switch inside the constructor. Place the initialization work in init() and ensure it
     // is initialized only once.
-    PooledDialer() {
-        photon::fini_hook({this, &PooledDialer::at_photon_fini});
-    }
-
     int init(TLSContext *_tls_ctx, std::vector<IPAddr> &src_ips) {
         if (initialized)
             return 0;
         SCOPED_LOCK(init_mtx);
         if (initialized)
             return 0;
+        photon::fini_hook({this, &PooledDialer::at_photon_fini});
         tls_ctx = _tls_ctx;
         if (!tls_ctx) {
             tls_ctx_ownership = true;


### PR DESCRIPTION
> ensure at_photon_fini executed in PooledDialer when photon init and finish twice

Generated by Auto PR, by cherry-pick related commits