### PR TITLE
FIX compile in gcc14

### DIFF
--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -154,8 +154,8 @@ public:
     static FlexQueue* create(size_t c) {
         size_t space = required_space(c);
         void* ptr = nullptr;
-        posix_memalign(&ptr, CPUCacheLine::SIZE, required_space(c));
-        if (!ptr) return nullptr;
+        auto err = posix_memalign(&ptr, CPUCacheLine::SIZE, required_space(c));
+        if (err) return nullptr;
         memset(ptr, 0, space);
         return new (ptr) FlexQueue(c);
     }


### PR DESCRIPTION
In GCC14 it will check posix_memalign return value.
Make FlexQueue check return value instead of checking pointer