### PR TITLE
[Pick][0.9 to main] | Fix X86 linux asan start call

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -753,6 +753,7 @@ R"(
 
 DEF_ASM_FUNC(_photon_thread_stub)
 R"(
+        call    _asan_start
         mov     0x40(%rbp), %rdi
         movq    $0, 0x40(%rbp)
         call    *0x48(%rbp)


### PR DESCRIPTION
> Fix X86 linux asan start call

Generated by Auto PR, by cherry-pick related commits