### PR TITLE
[Pick][0.8 to 0.9] | invoke dtor for arguments passed to thread_create11() (#987) (#988) 

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -221,7 +221,7 @@ public:
         buf.consume(s.size);
     }
 
-    void put(ALogBuffer& buf, void* p)
+    void put(ALogBuffer& buf, const void* p)
     {
         put(buf, HEX((uint64_t)p).width(16));
     }

--- a/thread/test/test.cpp
+++ b/thread/test/test.cpp
@@ -621,6 +621,25 @@ TEST(thread11, test)
     }
 }
 
+TEST(thread11, dtor)
+{
+    struct Foo {
+        Foo() { LOG_DEBUG("ctor ", this); }
+        Foo(const Foo&) { LOG_DEBUG("copy ctor ", this); }
+        Foo(Foo&&) = delete;
+        ~Foo() { LOG_DEBUG("dtor ", this); }
+        int x = 100;
+    };
+    Foo foo;
+    LOG_DEBUG("thread_create11");
+    auto th = thread_create11([foo]{
+        LOG_DEBUG(&foo, ":thread");
+        LOG_DEBUG(foo.x);
+    });
+    auto jh = thread_enable_join(th);
+    thread_join(jh);
+    LOG_DEBUG("end");
+}
 
 void semaphore_test_hold(semaphore* sem, int &step) {
     int ret = 0;

--- a/thread/thread11.h
+++ b/thread/thread11.h
@@ -29,6 +29,7 @@ namespace photon {
     static void* __stub11(void*) {
         auto p = thread_reserved_space<Pair>(CURRENT);
         tuple_assistance::apply(std::move(p->first), std::move(p->second));
+        p->~Pair();
         return nullptr;
     }
 


### PR DESCRIPTION
> invoke dtor for arguments passed to thread_create11() (#987) (#988)

Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits