### PR TITLE
[Pick][0.7 to 0.8] | make thread_yield_to() less prone to starve threads (#982) 

### DIFF
--- a/fs/test/test.cpp
+++ b/fs/test/test.cpp
@@ -874,11 +874,8 @@ TEST(range_split_power2, basic) {
 }
 
 TEST(range_split_power2, random_test) {
-    uint64_t offset, length, interval;
-    offset = rand();
-    length = rand();
-    auto interval_shift = rand()%32 + 1;
-    interval = uint64_t(1) << interval_shift;
+    uint64_t offset = rand(), length = rand();
+    uint64_t interval = 1UL << (rand()%32 + 1);
     fs::range_split_power2 split(offset, length, interval);
     EXPECT_EQ(offset, split.begin);
     EXPECT_EQ(offset + length, split.end);

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -635,6 +635,8 @@ namespace photon
         }
         Switch try_goto(thread* th) const {
             assert(th->vcpu == vcpu);
+            th->remove_from_list();
+            current->insert_after(th);
             return _do_goto(th);
         }
         bool single() const {
@@ -1261,6 +1263,8 @@ R"(
             assert(th->state == states::READY);
         } else if (unlikely(th->state != states::READY)) {
             LOG_ERROR_RETURN(EINVAL, -1, "target thread ` must be READY!", th);
+        } else if (unlikely(rq.current->next() == th)) {
+            return thread_yield();
         }
 
         auto sw = AtomicRunQ(rq).try_goto(th);


### PR DESCRIPTION
> make thread_yield_to() less prone to starve threads (#982)


Generated by Auto PR, by cherry-pick related commits