### PR TITLE
fix iovector not checking size before extracting continuous buffer

### DIFF
--- a/common/iovector.h
+++ b/common/iovector.h
@@ -532,7 +532,9 @@ public:
         }
         
         auto buf = do_malloc(bytes);
-        extract_front(bytes, buf);
+        if (buf) {
+            extract_front(bytes, buf);
+        }
         return buf;
     }
 
@@ -624,7 +626,9 @@ public:
         }
 
         auto buf = do_malloc(bytes);
-        extract_back(bytes, buf);
+        if (buf) {
+            extract_back(bytes, buf);
+        }
         return buf;
     }
 


### PR DESCRIPTION
The comments for `extract_front_continuous` and `extract_back_continuous` indicate they should return nullptr if data are not enough. However this is not checked in code and result in crashes when deserializing invalid or malicious packets.