### PR TITLE
[Pick][0.7 to 0.8] | fix iovector not checking size before extracting continuous buffer (#1010) 

### DIFF
--- a/common/iovector.h
+++ b/common/iovector.h
@@ -529,12 +529,15 @@ public:
             update(va);
             return ptr;
         }
-
+        if (va.sum() < bytes) {
+            return nullptr;
+        }
+        
         auto buf = do_malloc(bytes);
-        auto ret = extract_front(bytes, buf);
-        return ret == bytes ?
-            buf :
-            nullptr;
+        if (buf) {
+            extract_front(bytes, buf);
+        }
+        return buf;
     }
 
     // try to extract `bytes` bytes from the back
@@ -620,12 +623,15 @@ public:
             update(va);
             return ptr;
         }
+        if (va.sum() < bytes) {
+            return nullptr;
+        }
 
         auto buf = do_malloc(bytes);
-        auto ret = extract_back(bytes, buf);
-        return ret == bytes ?
-            buf :
-            nullptr;
+        if (buf) {
+            extract_back(bytes, buf);
+        }
+        return buf;
     }
 
     // copy data to a buffer of size `size`,


### PR DESCRIPTION
> fix iovector not checking size before extracting continuous buffer (#1010)

* fix iovec not checking size before extracting continuous buffer
Generated by Auto PR, by cherry-pick related commits