### PR TITLE
fix deserialize returning invalid message on failure

### DIFF
--- a/rpc/serialize.h
+++ b/rpc/serialize.h
@@ -436,6 +436,8 @@ namespace rpc
 
         void process_field(buffer& x)
         {
+            if (x.size() == 0)
+                return;
             x._ptr = _iov->extract_front_continuous(x.size());
             if (!x._ptr)
                 failed = true;


### PR DESCRIPTION
After #1010, `extract_front_continuous` now failed with invalid cases and returns `nullptr`, but `DeserializerIOV::deserialize` is missing the error handling path, and invoke rpc service with invalid message (`x._ptr == nullptr`)

Fixed by checking `failed` flag on return. `nullptr` is handled by rpc layer and will disconnect on invalid message instead of processing.