### PR TITLE
[Pick][0.8 to 0.9] | fix iovector not checking size before extracting continuous buffer (#1010) (#1011) 

### DIFF
--- a/common/iovector.h
+++ b/common/iovector.h
@@ -529,12 +529,15 @@ public:
             update(va);
             return ptr;
         }
-
+        if (va.sum() < bytes) {
+            return nullptr;
+        }
+        
         auto buf = do_malloc(bytes);
-        auto ret = extract_front(bytes, buf);
-        return ret == bytes ?
-            buf :
-            nullptr;
+        if (buf) {
+            extract_front(bytes, buf);
+        }
+        return buf;
     }
 
     // try to extract `bytes` bytes from the back
@@ -620,12 +623,15 @@ public:
             update(va);
             return ptr;
         }
+        if (va.sum() < bytes) {
+            return nullptr;
+        }
 
         auto buf = do_malloc(bytes);
-        auto ret = extract_back(bytes, buf);
-        return ret == bytes ?
-            buf :
-            nullptr;
+        if (buf) {
+            extract_back(bytes, buf);
+        }
+        return buf;
     }
 
     // copy data to a buffer of size `size`,


### PR DESCRIPTION
> fix iovector not checking size before extracting continuous buffer (#1010) (#1011)

* fix iovec not checking size before extracting continuous buffer

Co-authored-by: NewbieOrange <NewbieOrange@users.noreply.github.com>
Generated by Auto PR, by cherry-pick related commits