### PR TITLE
[Pick][0.9 to main] | fix iovector not checking size before extracting continuous buffer (#1010) (#1011) (#1013) 

### DIFF
--- a/common/iovector.h
+++ b/common/iovector.h
@@ -535,12 +535,15 @@ public:
             update(va);
             return ptr;
         }
-
+        if (va.sum() < bytes) {
+            return nullptr;
+        }
+        
         auto buf = do_malloc(bytes);
-        auto ret = extract_front(bytes, buf);
-        return ret == bytes ?
-            buf :
-            nullptr;
+        if (buf) {
+            extract_front(bytes, buf);
+        }
+        return buf;
     }
 
     // try to extract `bytes` bytes from the back
@@ -626,12 +629,15 @@ public:
             update(va);
             return ptr;
         }
+        if (va.sum() < bytes) {
+            return nullptr;
+        }
 
         auto buf = do_malloc(bytes);
-        auto ret = extract_back(bytes, buf);
-        return ret == bytes ?
-            buf :
-            nullptr;
+        if (buf) {
+            extract_back(bytes, buf);
+        }
+        return buf;
     }
 
     // copy data to a buffer of `size` bytes,


### PR DESCRIPTION
> fix iovector not checking size before extracting continuous buffer (#1010) (#1011) (#1013)

* fix iovec not checking size before extracting continuous buffer

Co-authored-by: NewbieOrange <NewbieOrange@users.noreply.github.com>
Generated by Auto PR, by cherry-pick related commits