### PR TITLE
[Pick][0.9 to main] | fix deserialize returning invalid message on failure (#1012) (#1015) (#1016) 

### DIFF
--- a/rpc/serialize.h
+++ b/rpc/serialize.h
@@ -436,7 +436,7 @@ namespace rpc
 
         void process_field(buffer& x)
         {
-            if (x.size()==0)
+            if (x.size() == 0)
                 return;
             x._ptr = _iov->extract_front_continuous(x.size());
             if (!x._ptr)
@@ -462,13 +462,9 @@ namespace rpc
                 "only Messages are permitted");
 
             // deserialize the main body from back
-            _iov=iov;
-            auto t = iov -> extract_back<T>();
-            if (t) {
-                if (!t->validate_checksum(iov, t, sizeof(*t))) {
-                    failed = true;
-                    return nullptr;
-                }
+            _iov = iov;
+            auto t = iov->extract_back<T>();
+            if (t && t->validate_checksum(iov, t, sizeof(*t))) {
                 // deserialize aligned fields, and non-aligned fields, from front
                 auto aligned = FilterAlignedFields(this, true);
                 t->process_fields(aligned);
@@ -477,7 +473,7 @@ namespace rpc
             } else {
                 failed = true;
             }
-            return t;
+            return failed ? nullptr : t;
         }
     };
 


### PR DESCRIPTION
> fix deserialize returning invalid message on failure (#1012) (#1015) (#1016)

* fix deserialize returning invalid message on failure

* Update serialize.h

* Update serialize.h

Co-authored-by: NewbieOrange <NewbieOrange@users.noreply.github.com>
Generated by Auto PR, by cherry-pick related commits