### PR TITLE
Fix double free in socket pool on unexpected photon thread switch

### DIFF
--- a/net/pooled_socket.cpp
+++ b/net/pooled_socket.cpp
@@ -158,7 +158,6 @@ protected:
         list.erase(node);
         if (list.empty()) fdmap.erase(it);
         rm_watch(node);
-        delete node;
     }
 
 public:
@@ -246,6 +245,7 @@ public:
                 // socket shutdown
                 drop_from_pool(nodes[i]);
             }
+            for (int i = 0; i < ret; i++) delete nodes[i];
         }
     }
 };


### PR DESCRIPTION
在以下场景中发现存在double free问题：

测试环境：阿里云ECS，Alibaba Cloud Linux 3，5.10.134-17版本内核，2核4GB内存机器。
测试方法：使用https协议向阿里云OSS不断发送GET请求（http暂未验证），同时使用python脚本反复分配大量内存至OOM，模拟系统内存、CPU压力极大场景。运行一段时间后发生crash。

分析：日志中发现在SocketPool的collect中，一次性批量获取nodes串行执行drop_from_pool函数，但该函数内部发生了非预期的协程切换。随后其他协程使用get_from_pool函数复用了nodes中未被drop的节点，导致double free。

结论：目前定位到切换应该发生在delete node中，delete流程中隐式调用了不少函数，具体位置还需要进一步分析。先将delete node的流程延后，保证能一次性将所有的nodes都从map中移除后，再执行delete操作，此时再发生切换也不会导致错误的get行为发生。