### PR TITLE
[Pick][0.7 to 0.8] | Fix double free in socket pool on unexpected photon thread switch (#1029) 

### DIFF
--- a/net/pooled_socket.cpp
+++ b/net/pooled_socket.cpp
@@ -159,7 +159,6 @@ protected:
         list.erase(node);
         if (list.empty()) fdmap.erase(it);
         rm_watch(node);
-        delete node;
     }
 
 public:
@@ -250,6 +249,7 @@ public:
                 // socket shutdown
                 drop_from_pool(nodes[i]);
             }
+            for (int i = 0; i < ret; i++) delete nodes[i];
         }
     }
 };


### PR DESCRIPTION
> Fix double free in socket pool on unexpected photon thread switch (#1029)


Generated by Auto PR, by cherry-pick related commits