### PR TITLE
[Pick][0.9 to main] | worker_lock.lock() in WorkPool::~impl() to ensure destruction order (#1026) 

### DIFF
--- a/thread/workerpool.cpp
+++ b/thread/workerpool.cpp
@@ -62,6 +62,7 @@ public:
         } else {
             while (vcpus.size()) std::this_thread::yield();
         }
+        worker_lock.lock();
     }
 
     void enqueue(Delegate<void> call, AutoContext = {}) {


### PR DESCRIPTION
> worker_lock.lock() in WorkPool::~impl() to ensure destruction order (#1026)


Generated by Auto PR, by cherry-pick related commits