### PR TITLE
FIX: estring split in non-consecutive merge mode

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -195,7 +195,7 @@ public:
             }
             iterator& operator++()
             {
-                _part = _host->find_part(_part.end());
+                _part = _host->find_part(_part.end() + 1);
                 return *this;
             }
             iterator& operator++(int)


### PR DESCRIPTION
`estring`/`estring_view` split with `consecutive_merge = false` can only capture first part of spliced string and not able to iterate, since when not in consecutive, when getting next part of string, it never skip current part end, so always stopped at first part infinitely.

FIX by add one more character when iterating.