### PR TITLE
Since macos-13 test image are retired, move on to macos-15

### DIFF
--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   macOS14-arm:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - uses: szenius/set-timezone@v2.0
@@ -31,7 +31,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=MinSizeRel \
             -D PHOTON_ENABLE_SASL=ON \
             -D PHOTON_ENABLE_LIBCURL=ON \
-            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@1.1/1.1.1w
+            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.6.0
           cmake --build ${{github.workspace}}/build -j $(sysctl -n hw.logicalcpu)
 
       - name: Test

--- a/.github/workflows/ci.macos.x86_64.yml
+++ b/.github/workflows/ci.macos.x86_64.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   macOS13-x86:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - uses: szenius/set-timezone@v2.0
@@ -31,7 +31,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=MinSizeRel \
             -D PHOTON_ENABLE_SASL=ON \
             -D PHOTON_ENABLE_LIBCURL=ON \
-            -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl@3
+            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.6.0
           cmake --build ${{github.workspace}}/build -j $(sysctl -n hw.logicalcpu)
 
       - name: Test


### PR DESCRIPTION
> GitHub Actions is starting the deprecation process for macOS 13 and macOS 13 arm64. While the images are being deprecated, You may experience longer queue times during peak usage hours. Deprecation will begin on September 22nd, 2025 and the images will be fully unsupported by December 8th, 2025 for GitHub Actions and Azure DevOps.
> To raise awareness of the upcoming removal, we will temporarily fail jobs using macOS 13 and macOS 13 arm64. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> November 4, 14:00 UTC - November 5, 00:00 UTC
> November 11, 14:00 UTC - November 12, 00:00 UTC
> November 18, 14:00 UTC - November 19, 00:00 UTC
> November 25, 14:00 UTC - November 26, 00:00 UTC
> For users that require the x86_64 (Intel) environment, we are also introducing a new label to migrate to: macos-15-intel. The new label will run on macOS 15 and will be available from now until August 2027. This will be the last available x86_64 image from Actions, and after that date the x86_64 architecture will not be supported on GitHub Actions. For more information see this announcement: https://github.com/actions/runner-images/issues/13045