### PR TITLE
[Pick][0.9 to main] | Since macos-13 test image are retired, move on to macos-15 by github advise (#1065) (#1067) 

### DIFF
--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   macOS14-arm:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - uses: szenius/set-timezone@v2.0
@@ -31,7 +31,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=MinSizeRel \
             -D PHOTON_ENABLE_SASL=ON \
             -D PHOTON_ENABLE_LIBCURL=ON \
-            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@1.1/1.1.1w
+            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.6.0
           cmake --build ${{github.workspace}}/build -j $(sysctl -n hw.logicalcpu)
 
       - name: Test

--- a/.github/workflows/ci.macos.x86_64.yml
+++ b/.github/workflows/ci.macos.x86_64.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   macOS13-x86:
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - uses: szenius/set-timezone@v2.0
@@ -31,7 +31,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=MinSizeRel \
             -D PHOTON_ENABLE_SASL=ON \
             -D PHOTON_ENABLE_LIBCURL=ON \
-            -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl@3
+            -D OPENSSL_ROOT_DIR=/opt/homebrew/Cellar/openssl@3/3.6.0
           cmake --build ${{github.workspace}}/build -j $(sysctl -n hw.logicalcpu)
 
       - name: Test


### PR DESCRIPTION
> Since macos-13 test image are retired, move on to macos-15 by github advise (#1065) (#1067)

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits