### PR TITLE
[Pick][0.9 to main] | FIX: estring split in non-consecutive merge mode (#1071) (#1072) (#1073) 

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -195,7 +195,7 @@ public:
             }
             iterator& operator++()
             {
-                _part = _host->find_part(_part.end());
+                _part = _host->find_part(_part.end() + 1);
                 return *this;
             }
             iterator& operator++(int)


### PR DESCRIPTION
> FIX: estring split in non-consecutive merge mode (#1071) (#1072) (#1073)

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits