### PR TITLE
Fix split iteration meets empty parts

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -163,7 +163,7 @@ public:
                 _part = _host->find_part(_part.end() + 1);
                 return *this;
             }
-            iterator& operator++(int)
+            iterator operator++(int)
             {
                 auto ret = *this;
                 ++(*this);
@@ -171,7 +171,8 @@ public:
             }
             bool operator == (const iterator& rhs) const
             {
-                return _part == rhs._part;
+                return _part.data() == rhs._part.data() &&
+                       _part.length() == rhs._part.length();
             }
             bool operator != (const iterator& rhs) const
             {

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -863,6 +863,51 @@ TEST(estring, test)
     EXPECT_EQ(a[1], "q3r1234");
     EXPECT_EQ(a[2], "poiu");
 
+    sp = s.split(cs, false);
+    it = sp.begin();
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "alskdjf");
+    EXPECT_EQ(remainder, ";;,q3r1234;poiu");
+    it ++;
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "");
+    EXPECT_EQ(remainder, ";,q3r1234;poiu");
+    it ++;
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "");
+    EXPECT_EQ(remainder, ",q3r1234;poiu");
+    it ++;
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "");
+    EXPECT_EQ(remainder, "q3r1234;poiu");
+    it ++;
+    front = *it;
+    remainder = it.remainder();
+    LOG_DEBUG(VALUE(front), VALUE(remainder));
+    EXPECT_EQ(front, "q3r1234");
+    EXPECT_EQ(remainder, "poiu");
+
+    a.clear();
+    for (auto x: sp)
+    {
+        a.push_back(x);
+        LOG_DEBUG(x);
+    }
+
+    EXPECT_EQ(a.size(), 6);
+    EXPECT_EQ(a[0], "alskdjf");
+    EXPECT_EQ(a[4], "q3r1234");
+    EXPECT_EQ(a[5], "poiu");
+
+
     auto sv = s;//.view();
     EXPECT_TRUE(sv.starts_with("alskdjf"));
     EXPECT_FALSE(sv.starts_with("alsk32"));


### PR DESCRIPTION
Makes iterator operator++ return new iterator instead of on-stack temporary reference.

Makes iterator compare use actually character pointer instead of plain string view because parts may be empty and should not equal to end of stirng.

Add more tests for non-consecutive-merge split