### PR TITLE
[Pick][0.9 to main] | fix basic_map_string_kv's assignment function (#1084) 

### DIFF
--- a/common/string-keyed.h
+++ b/common/string-keyed.h
@@ -281,18 +281,20 @@ public:
         for (auto& p : init) insert(p);
     }
     basic_map_string_kv(const basic_map_string_kv& other) {
-      insert(other.begin(), other.end());
+        insert(other.begin(), other.end());
     }
     basic_map_string_kv& operator=(const basic_map_string_kv& other) {
-      if (this != &other) insert(other.begin(), other.end());
-      return *this;
+        if (this != &other) {
+            basic_map_string_kv(other).swap(*this); 
+        }
+        return *this;
     }
     basic_map_string_kv(basic_map_string_kv&& other) noexcept {
-      other.swap(*this);
+        other.swap(*this);
     }
     basic_map_string_kv& operator=(basic_map_string_kv&& other) noexcept {
-      other.swap(*this);
-      return *this;
+        other.swap(*this);
+        return *this;
     }
 
     struct MutableValue : public std::string_view {

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -1312,6 +1312,19 @@ TEST(string_key, unordered_map_string_kv) {
 
     test_map["qwer"] = "1111";
     EXPECT_EQ(test_map["qwer"], "1111");
+
+    unordered_map_string_kv new_map{test_map};
+    EXPECT_EQ(new_map.size(), test_map.size());
+    new_map.clear();
+    new_map["2xxx"] = "2";
+    new_map = test_map;
+    EXPECT_EQ(new_map.size(), test_map.size());
+    new_map.clear();
+    new_map["3yyy"] = "3";
+    new_map = unordered_map_string_kv{test_map};
+    EXPECT_EQ(new_map.size(), test_map.size());
+    unordered_map_string_kv new_map2{unordered_map_string_kv{test_map}};
+    EXPECT_EQ(new_map2.size(), test_map.size());
 }
 
 TEST(string_key, unordered_map_string_kv_perf) {


### PR DESCRIPTION
> fix basic_map_string_kv's assignment function (#1084)

* fix basic_map_string_kv's assignment function

* remove unnecessary std::move
Generated by Auto PR, by cherry-pick related commits