### PR TITLE
feat(cache): implement two-tier LRU for full file cache to reduce memory usage

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -79,6 +79,12 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
     return nullptr;
   }
 
+  // Check cold container first
+  auto coldIt = coldIndex_.find(pathname);
+  if (coldIt != coldIndex_.end()) {
+    promoteToHot(coldIt);
+  }
+
   auto find = fileIndex_.find(pathname);
   if (find == fileIndex_.end()) {
     auto lruIter = lru_.push_front(fileIndex_.end());
@@ -88,6 +94,16 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
   } else {
     lru_.access(find->second->lruIter);
     find->second->openCount++;
+  }
+
+  // If hot LRU exceeds the limit, demote the LRU tail (only if not open) to cold
+  while (lru_.size() > hotLruLimit_) {
+    auto tailIter = lru_.back();
+    if (tailIter->second->openCount == 0) {
+      demoteToCold(tailIter);
+    } else {
+      break;
+    }
   }
 
   return new FileCacheStore(this, localFile, refillUnit_, find);
@@ -123,6 +139,12 @@ int FileCachePool::stat(CacheStat* stat, std::string_view pathname) {
 }
 
 int FileCachePool::evict(std::string_view filename) {
+  // Check cold container first
+  auto coldIt = coldIndex_.find(filename);
+  if (coldIt != coldIndex_.end()) {
+    return evictColdByIndex(coldIt->second) >= 0 ? 0 : -1;
+  }
+
   auto fileIter = fileIndex_.find(filename);
   if (fileIter == fileIndex_.end()) {
     LOG_ERROR("Evict no such file , name: `", filename);
@@ -135,9 +157,9 @@ int FileCachePool::evict(std::string_view filename) {
     lru_.mark_key_cleared(lruEntry->lruIter);
   }
   int err = 0;
-  auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
-  DEFER(cacheStore->release());
   {
+    auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+    DEFER(cacheStore->release());
     photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
     err = mediaFs_->truncate(filePath.data(), 0);
     lruEntry->truncate_done = false;
@@ -240,6 +262,10 @@ void FileCachePool::eviction() {
 
   isFull_ = true;
 
+  // Phase 1: evict from cold tier first.
+  actualEvict -= evictColdWhenFull(actualEvict);
+
+  // Phase 2: fall back to hot LRU eviction when cold tier is exhausted
   while (actualEvict > 0 && !lru_.empty() && !exit_) {
     auto fileIter = lru_.back();
     const auto& fileName = fileIter->first;
@@ -258,9 +284,9 @@ void FileCachePool::eviction() {
         continue;
     }
 
-    auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
-    DEFER(cacheStore->release());
     {
+      auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
+      DEFER(cacheStore->release());
       photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
       err = mediaFs_->truncate(fileName.data(), 0);
       lruEntry->truncate_done = false;
@@ -299,9 +325,9 @@ bool FileCachePool::afterFtrucate(FileNameMap::iterator iter) {
       if (err && (e.no == EBUSY)) {
         return false;
       }
-      lru_.remove(iter->second->lruIter);
-      fileIndex_.erase(iter);
     }
+    lru_.remove(iter->second->lruIter);
+    fileIndex_.erase(iter);
   }
   return true;
 }
@@ -321,12 +347,109 @@ int FileCachePool::insertFile(std::string_view file) {
   }
   auto fileSize = st.st_blocks * kDiskBlockSize;
 
-  auto lruIter = lru_.push_front(fileIndex_.end());
-  auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
-  auto iter = fileIndex_.emplace(file, std::move(entry)).first;
-  lru_.front() = iter;
+  if (lru_.size() >= hotLruLimit_) {
+    uint32_t idx = static_cast<uint32_t>(cold_.size());
+    auto nodeIt = coldIndex_.emplace(file, idx);
+    cold_.emplace_back(nodeIt.first, fileSize, photon::now);
+  } else {
+    auto lruIter = lru_.push_front(fileIndex_.end());
+    auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
+    auto iter = fileIndex_.emplace(file, std::move(entry)).first;
+    lru_.front() = iter;
+  }
   totalUsed_ += fileSize;
   return 0;
+}
+
+// Demote a hot-LRU entry (openCount must be 0) to the cold container.
+void FileCachePool::demoteToCold(FileNameMap::iterator iter) {
+  auto lruEntry = iter->second.get();
+
+  uint32_t idx = static_cast<uint32_t>(cold_.size());
+  auto nodeIt = coldIndex_.emplace(iter->first, idx);
+  cold_.emplace_back(nodeIt.first, lruEntry->size, photon::now);
+
+  lru_.remove(lruEntry->lruIter);
+  fileIndex_.erase(iter);
+}
+
+// Promote a cold entry back to the front of hot LRU.
+void FileCachePool::promoteToHot(ColdIndexMap::iterator iter) {
+  uint32_t idx = iter->second;
+  uint64_t size = cold_[idx].size;
+  std::string_view filename = iter->first;
+
+  // Re-insert into fileIndex_ and lru_ with openCount=0 (caller increments)
+  auto lruIter = lru_.push_front(fileIndex_.end());
+  std::unique_ptr<LruEntry> entry(new LruEntry{lruIter, 0, size});
+  auto newIter = fileIndex_.emplace(filename, std::move(entry)).first;
+  lru_.front() = newIter;
+
+  coldIndex_.erase(iter);
+  // swap-remove
+  if (idx + 1 < cold_.size()) {
+    std::swap(cold_[idx], cold_.back());
+    cold_[idx].iter->second = idx;
+  }
+  cold_.pop_back();
+}
+
+// Evict the cold entry at coldIndex and return the evicted file size.
+ssize_t FileCachePool::evictColdByIndex(uint32_t idx) {
+  assert(idx < cold_.size());
+  auto &entry = cold_[idx];
+  std::string_view filename = entry.iter->first;
+  uint64_t fileSize = entry.size;
+
+  if (fileSize > 0) {
+    int err = mediaFs_->truncate(filename.data(), 0);
+    if (err) {
+      ERRNO e;
+      LOG_ERRNO_RETURN(0, -1, "truncate(0) failed, name : `", filename);
+    }
+    totalUsed_ -= static_cast<int64_t>(fileSize);
+    entry.size = 0;
+    if (totalUsed_ < 0) totalUsed_ = 0;
+  }
+  int err = mediaFs_->unlink(filename.data());
+  if (err) {
+    ERRNO e;
+    LOG_ERRNO_RETURN(0, -1, "unlink failed, name : `", filename);
+  }
+
+  coldIndex_.erase(entry.iter);
+  if (idx + 1 < cold_.size()) {
+    std::swap(cold_[idx], cold_.back());
+    cold_[idx].iter->second = idx;
+  }
+  cold_.pop_back();
+  return fileSize;
+}
+
+uint64_t FileCachePool::evictColdWhenFull(uint64_t needEvict) {
+  uint64_t evictSize = 0;
+  while (evictSize < needEvict && !cold_.empty() && !exit_) {
+    uint32_t sz = cold_.size();
+    // Fixed candidates: head (0) and tail (sz-1), plus up to 5 random indices.
+    static const int kMaxCandidates = 7;
+    uint32_t oldest = 0;
+    uint64_t oldestTime = cold_[oldest].demoteTime;
+    if (cold_.back().demoteTime < oldestTime) {
+      oldest = sz - 1;
+      oldestTime = cold_[oldest].demoteTime;
+    }
+    for (int k = 2; k < kMaxCandidates; k++) {
+      uint32_t candidate = rand() % sz;
+      if (cold_[candidate].demoteTime < oldestTime) {
+        oldest = candidate;
+        oldestTime = cold_[oldest].demoteTime;
+      }
+    }
+    auto r = evictColdByIndex(oldest);
+    if (r >= 0) evictSize += r;
+    photon::thread_yield();
+  }
+  return evictSize;
 }
 
 }

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -42,6 +42,8 @@ public:
     static const uint64_t kDiskBlockSize = 512; // stat(2)
     static const uint64_t kDeleteDelayInUs = 1000;
     static const uint32_t kWaterMarkRatio = 90;
+    // max entries in hot LRU before demoting to cold (default: 100w)
+    static const uint32_t kDefaultHotLruLimit = 1'000'000;
 
     void Init();
 
@@ -109,6 +111,28 @@ protected:
     LRUContainer lru_;
     // filename -> lruEntry
     FileNameMap fileIndex_;
+
+    uint32_t hotLruLimit_ = kDefaultHotLruLimit;
+
+    // If hotLruLimit_ is reached, files are demoted to cold container.
+    using ColdIndexMap = unordered_map_string_key<uint32_t>;
+    struct ColdEntry {
+        ColdEntry(ColdIndexMap::iterator iter, uint64_t size, uint64_t demoteTime)
+            : iter(iter), size(size), demoteTime(demoteTime) {}
+        ColdIndexMap::iterator iter;
+        uint64_t size;
+        uint64_t demoteTime; // timestamp when demoted to cold
+        std::string_view filename() const { return iter->first; }
+    };
+    std::vector<ColdEntry> cold_;
+    ColdIndexMap coldIndex_;
+
+    void demoteToCold(FileNameMap::iterator iter);
+    void promoteToHot(ColdIndexMap::iterator iter);
+    uint64_t evictColdWhenFull(uint64_t needEvict);
+    ssize_t evictColdByIndex(uint32_t idx);
+
+    friend struct FileCachePoolTest;
 };
 
 }

--- a/fs/cache/full_file_cache/quota_pool.cpp
+++ b/fs/cache/full_file_cache/quota_pool.cpp
@@ -195,9 +195,9 @@ int QuotaFilePool::evict(std::string_view filename) {
   int err;
   auto lruEntry = static_cast<QuotaLruEntry*>(fileIter->second.get());
 
-  auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
-  DEFER(cacheStore->release());
   {
+    auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+    DEFER(cacheStore->release());
     photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
     lru.mark_key_cleared(lruEntry->QuotaLruIter);
     err = mediaFs_->truncate(filePath.data(), 0);
@@ -238,9 +238,9 @@ void QuotaFilePool::dirEviction() {
       int err;
       bool flags_dir_delete = false;
 
-      auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
-      DEFER(cacheStore->release());
       {
+        auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
+        DEFER(cacheStore->release());
         photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
         if (lruEntry->openCount==0){
           dir->lru.mark_key_cleared(lruEntry->QuotaLruIter);

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -33,6 +33,8 @@ limitations under the License.
 #include <photon/thread/thread.h>
 #include <photon/common/io-alloc.h>
 #include <photon/fs/cache/cache.h>
+
+#include "../full_file_cache/cache_pool.h"
 #include "random_generator.h"
 
 namespace photon {
@@ -711,6 +713,198 @@ TEST(CachePool, open_same_file) {
         cacheStore->release();
       }
     }
+  }
+}
+
+// Friend accessor — declared as friend in FileCachePool.
+struct FileCachePoolTest {
+  static void set_hot_lru_limit(FileCachePool *p, uint32_t limit) {
+    p->hotLruLimit_ = limit;
+  }
+  static size_t hot_size (FileCachePool *p) { return p->lru_.size(); }
+  static size_t cold_size(FileCachePool *p) { return p->cold_.size(); }
+  static bool in_hot (FileCachePool *p, std::string_view n) {
+    return p->fileIndex_.find(n) != p->fileIndex_.end();
+  }
+  static bool in_cold(FileCachePool *p, std::string_view n) {
+    return p->coldIndex_.find(n) != p->coldIndex_.end();
+  }
+};
+
+// Open through the pool then immediately release.
+static bool openClose(ICachePool* pool, const char* name) {
+  auto s = pool->open(name, O_CREAT | O_RDWR, 0644);
+  bool success = (s != nullptr);
+  if (s) s->release();
+  return success;
+}
+
+TEST(CachePool, test_hot_lru_limit) {
+  std::string root = "/tmp/ease/cache/test_hot_lru_limit/";
+  SetupTestDir(root);
+  const size_t hotLimit = 10;
+  const size_t fileNum = 100;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_hot_lru_limit(pool, hotLimit);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(100);
+    std::string name = "/f" + std::to_string(i);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+  }
+
+  EXPECT_LE(T::hot_size(pool), hotLimit);
+  EXPECT_EQ(T::hot_size(pool) + T::cold_size(pool), fileNum);
+
+  // first fileNum-hotLimit files are in cold
+  for (size_t i = 0; i < fileNum - hotLimit; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::in_cold(pool, name));
+    EXPECT_FALSE(T::in_hot(pool, name));
+  }
+  // last hotLimit files are in hot
+  for (size_t i = fileNum - hotLimit; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::in_hot(pool, name));
+    EXPECT_FALSE(T::in_cold(pool, name));
+  }
+  // re-open /f0 — must promote to hot
+  ASSERT_TRUE(openClose(pool, "/f0"));
+  EXPECT_TRUE(T::in_hot(pool, "/f0"));
+  EXPECT_FALSE(T::in_cold(pool, "/f0"));
+
+  EXPECT_LE(T::hot_size(pool), hotLimit);
+  EXPECT_EQ(T::hot_size(pool) + T::cold_size(pool), fileNum);
+
+  // random access
+  for (size_t i = 0; i < 100; i++) {
+    int r = rand() % fileNum;
+    std::string name = "/f" + std::to_string(r);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+
+    if (rand() % 3 == 0) {
+      EXPECT_EQ(T::hot_size(pool) + T::cold_size(pool), fileNum);
+    }
+  }
+}
+
+TEST(CachePool, evict_cold_file) {
+  std::string root = "/tmp/ease/cache/evict_cold_file/";
+  SetupTestDir(root);
+  const size_t hotLimit = 10;
+  const size_t fileNum = 100;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_hot_lru_limit(pool, hotLimit);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(100);
+    std::string name = "/f" + std::to_string(i);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+  }
+
+  photon::thread_sleep(1);
+  ASSERT_TRUE(T::in_cold(pool, "/f0"));
+  EXPECT_LE(T::hot_size(pool), hotLimit);
+  EXPECT_EQ(T::hot_size(pool) + T::cold_size(pool), fileNum);
+
+  ASSERT_EQ(0, pool->evict("/f0"));
+  EXPECT_FALSE(T::in_cold(pool, "/f0"));
+  EXPECT_FALSE(T::in_hot(pool, "/f0"));
+  EXPECT_EQ(T::hot_size(pool), hotLimit);
+  EXPECT_EQ(T::hot_size(pool) + T::cold_size(pool), fileNum - 1);
+
+  std::vector<bool> evicted(fileNum, false);
+  evicted[0] = true;
+  for (size_t i = 0; i < 9; i++) {
+    int index = rand() % fileNum;
+    std::string name = "/f" + std::to_string(index);
+    while (evicted[index] || !T::in_cold(pool, name)) {
+      index = rand() % fileNum;
+      name = "/f" + std::to_string(index);
+    }
+    ASSERT_EQ(0, pool->evict(name));
+    evicted[index] = true;
+    EXPECT_FALSE(T::in_cold(pool, name));
+    EXPECT_EQ(T::cold_size(pool), fileNum - hotLimit - 2 - i);
+  }
+}
+
+TEST(CachePool, evict_cold_first_when_full) {
+  std::string root = "/tmp/ease/cache/evict_cold_first_when_full/";
+  SetupTestDir(root);
+  const uint64_t capacityGB = 1;
+  const size_t hotLimit = 5;
+  const size_t fileNum = 40;
+  const size_t fileSizeMB = 60;
+  const size_t fileSizeBytes = fileSizeMB * 1024 * 1024;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      capacityGB, 0, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_hot_lru_limit(pool, hotLimit);
+
+  IOVector buffer(*cacheAllocator);
+  buffer.push_back(fileSizeBytes);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(1000);
+    std::string name = "/g" + std::to_string(i);
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    store->release();
+  }
+
+  size_t remaining = T::hot_size(pool) + T::cold_size(pool);
+  EXPECT_LT(remaining, fileNum);
+  EXPECT_LE(T::hot_size(pool), (size_t)hotLimit);
+
+  for (size_t i = fileNum - hotLimit; i < fileNum; i++) {
+    std::string name = "/g" + std::to_string(i);
+    EXPECT_TRUE(T::in_hot(pool, name)) << name << " should still be in hot";
+    EXPECT_FALSE(T::in_cold(pool, name)) << name << " must not be in cold";
+  }
+
+  // Write a new file to trigger eviction, the cold file should be evicted first
+  std::string name = "/g" + std::to_string(fileNum);
+  auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, store);
+  store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+  store->release();
+  for (size_t i = fileNum - hotLimit; i < fileNum; i++) {
+    std::string name = "/g" + std::to_string(i);
+    bool existed = T::in_hot(pool, name) || T::in_cold(pool, name);
+    EXPECT_TRUE(existed) << name << " must still exist";
   }
 }
 


### PR DESCRIPTION
* Add two-tier LRU cache implementation to reduce memory usage under large-file-count scenarios:
    * Introduce hotLruLimit parameter to control LRU size (default 1M entries)
    * When LRU exceeds limit, demote LRU tail entries to cold tier
    * When cold file is re-accessed, promote it back to LRU
    * During eviction, prioritize cold tier before hot LRU
<!--- * With 10 million files, memory usage drops about 700 MB, approximately 30% reduction --->
* Currently enabled only in non-quota mode.