### PR TITLE
feat(cache): add idle LRU for full file cache to reduce memory usage

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -79,6 +79,12 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
     return nullptr;
   }
 
+  // Check idle container first
+  auto idleIt = idleFileIndex_.find(pathname);
+  if (idleIt != idleFileIndex_.end()) {
+    promoteFromIdle(idleIt);
+  }
+
   auto find = fileIndex_.find(pathname);
   if (find == fileIndex_.end()) {
     auto lruIter = lru_.push_front(fileIndex_.end());
@@ -88,6 +94,16 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
   } else {
     lru_.access(find->second->lruIter);
     find->second->openCount++;
+  }
+
+  // If LRU exceeds the limit, demote the tail (only if not open) to idle
+  while (lru_.size() > demoteThreshold_) {
+    auto tailIt = lru_.back();
+    if (tailIt->second->openCount == 0) {
+      demoteToIdle(tailIt);
+    } else {
+      break;
+    }
   }
 
   return new FileCacheStore(this, localFile, refillUnit_, find);
@@ -123,6 +139,12 @@ int FileCachePool::stat(CacheStat* stat, std::string_view pathname) {
 }
 
 int FileCachePool::evict(std::string_view filename) {
+  // Check idle container first
+  auto idleIt = idleFileIndex_.find(filename);
+  if (idleIt != idleFileIndex_.end()) {
+    return evictIdleEntry(idleIt) >= 0 ? 0 : -1;
+  }
+
   auto fileIter = fileIndex_.find(filename);
   if (fileIter == fileIndex_.end()) {
     LOG_ERROR("Evict no such file , name: `", filename);
@@ -135,9 +157,9 @@ int FileCachePool::evict(std::string_view filename) {
     lru_.mark_key_cleared(lruEntry->lruIter);
   }
   int err = 0;
-  auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
-  DEFER(cacheStore->release());
   {
+    auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+    DEFER(cacheStore->release());
     photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
     err = mediaFs_->truncate(filePath.data(), 0);
     lruEntry->truncate_done = false;
@@ -240,6 +262,10 @@ void FileCachePool::eviction() {
 
   isFull_ = true;
 
+  // Phase 1: evict from idle tier first.
+  actualEvict -= evictIdleWhenFull(actualEvict);
+
+  // Phase 2: fall back to LRU eviction when idle tier is exhausted
   while (actualEvict > 0 && !lru_.empty() && !exit_) {
     auto fileIter = lru_.back();
     const auto& fileName = fileIter->first;
@@ -258,9 +284,9 @@ void FileCachePool::eviction() {
         continue;
     }
 
-    auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
-    DEFER(cacheStore->release());
     {
+      auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
+      DEFER(cacheStore->release());
       photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
       err = mediaFs_->truncate(fileName.data(), 0);
       lruEntry->truncate_done = false;
@@ -299,9 +325,9 @@ bool FileCachePool::afterFtrucate(FileNameMap::iterator iter) {
       if (err && (e.no == EBUSY)) {
         return false;
       }
-      lru_.remove(iter->second->lruIter);
-      fileIndex_.erase(iter);
     }
+    lru_.remove(lruEntry->lruIter);
+    fileIndex_.erase(iter);
   }
   return true;
 }
@@ -321,12 +347,88 @@ int FileCachePool::insertFile(std::string_view file) {
   }
   auto fileSize = st.st_blocks * kDiskBlockSize;
 
-  auto lruIter = lru_.push_front(fileIndex_.end());
-  auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
-  auto iter = fileIndex_.emplace(file, std::move(entry)).first;
-  lru_.front() = iter;
+  if (lru_.size() >= demoteThreshold_) {
+    auto idleLruIt = idleLru_.push_front(idleFileIndex_.end());
+    auto iter = idleFileIndex_.emplace(file, idleLruIt).first;
+    idleLru_.front() = iter;
+  } else {
+    auto lruIter = lru_.push_front(fileIndex_.end());
+    auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
+    auto iter = fileIndex_.emplace(file, std::move(entry)).first;
+    lru_.front() = iter;
+  }
   totalUsed_ += fileSize;
   return 0;
+}
+
+// Demote a LRU entry (openCount must be 0) to the idle container.
+void FileCachePool::demoteToIdle(FileNameMap::iterator iter) {
+  auto idleLruIt = idleLru_.push_front(idleFileIndex_.end());
+  auto idleIndexIt = idleFileIndex_.emplace(iter->first, idleLruIt).first;
+  idleLru_.front() = idleIndexIt;
+
+  lru_.remove(iter->second->lruIter);
+  fileIndex_.erase(iter);
+}
+
+// Promote an idle entry back to the front of LRU.
+void FileCachePool::promoteFromIdle(IdleFileNameMap::iterator idleIt) {
+  uint32_t idleLruIter = idleIt->second;
+  const auto& filename = idleIt->first;
+
+  struct stat st = {};
+  uint64_t fileSize = 0;
+  if (mediaFs_->stat(filename.data(), &st) == 0) {
+    fileSize = st.st_blocks * kDiskBlockSize;
+  }
+
+  auto lruIter = lru_.push_front(fileIndex_.end());
+  auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
+  auto iter = fileIndex_.emplace(filename, std::move(entry)).first;
+  lru_.front() = iter;
+
+  idleLru_.remove(idleLruIter);
+  idleFileIndex_.erase(idleIt);
+}
+
+// Evict the idle entry pointed to by idleIt; return freed bytes or -1 on error.
+ssize_t FileCachePool::evictIdleEntry(IdleFileNameMap::iterator idleIt) {
+  const auto& filename = idleIt->first;
+
+  struct stat st = {};
+  uint64_t fileSize = 0;
+  if (mediaFs_->stat(filename.data(), &st) == 0) {
+    fileSize = st.st_blocks * kDiskBlockSize;
+  }
+
+  if (fileSize > 0) {
+    int err = mediaFs_->truncate(filename.data(), 0);
+    if (err) {
+      LOG_ERRNO_RETURN(0, -1, "truncate(0) failed, name : `", filename);
+    }
+    totalUsed_ -= static_cast<int64_t>(fileSize);
+    if (totalUsed_ < 0) totalUsed_ = 0;
+  }
+  int err = mediaFs_->unlink(filename.data());
+  if (err) {
+    // we still evict fileSize bytes even if unlink fails
+    LOG_ERRNO_RETURN(0, fileSize, "unlink failed, name : `", filename);
+  }
+
+  uint32_t idleLruIter = idleIt->second;
+  idleLru_.remove(idleLruIter);
+  idleFileIndex_.erase(idleIt);
+  return static_cast<ssize_t>(fileSize);
+}
+
+uint64_t FileCachePool::evictIdleWhenFull(uint64_t needEvict) {
+  uint64_t evictSize = 0;
+  while (evictSize < needEvict && !idleLru_.empty() && !exit_) {
+    auto r = evictIdleEntry(idleLru_.back());
+    if (r >= 0) evictSize += static_cast<uint64_t>(r);
+    photon::thread_yield();
+  }
+  return evictSize;
 }
 
 }

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -42,6 +42,8 @@ public:
     static const uint64_t kDiskBlockSize = 512; // stat(2)
     static const uint64_t kDeleteDelayInUs = 1000;
     static const uint32_t kWaterMarkRatio = 90;
+    // max inuse-lru entries before demoting tail to idle-lru (default: 100w)
+    static const uint32_t kDemoteThreshold = 1'000'000;
 
     void Init();
 
@@ -109,6 +111,22 @@ protected:
     LRUContainer lru_;
     // filename -> lruEntry
     FileNameMap fileIndex_;
+
+    uint32_t demoteThreshold_ = kDemoteThreshold;
+
+    // idleFileIndex_ stores filename -> lruContainer's iterator
+    // idleLru_ stores iterators into idleFileIndex_; std::map nodes are stable.
+    typedef map_string_key<uint32_t> IdleFileNameMap;
+    typedef photon::fs::LRU<IdleFileNameMap::iterator, uint32_t> IdleLRUContainer;
+    IdleLRUContainer idleLru_;
+    IdleFileNameMap idleFileIndex_;
+
+    void demoteToIdle(FileNameMap::iterator iter);
+    void promoteFromIdle(IdleFileNameMap::iterator idleIter);
+    uint64_t evictIdleWhenFull(uint64_t needEvictSize);
+    ssize_t evictIdleEntry(IdleFileNameMap::iterator idleIter);
+
+    friend struct FileCachePoolTest;
 };
 
 }

--- a/fs/cache/full_file_cache/quota_pool.cpp
+++ b/fs/cache/full_file_cache/quota_pool.cpp
@@ -195,9 +195,9 @@ int QuotaFilePool::evict(std::string_view filename) {
   int err;
   auto lruEntry = static_cast<QuotaLruEntry*>(fileIter->second.get());
 
-  auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
-  DEFER(cacheStore->release());
   {
+    auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+    DEFER(cacheStore->release());
     photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
     lru.mark_key_cleared(lruEntry->QuotaLruIter);
     err = mediaFs_->truncate(filePath.data(), 0);

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -33,6 +33,8 @@ limitations under the License.
 #include <photon/thread/thread.h>
 #include <photon/common/io-alloc.h>
 #include <photon/fs/cache/cache.h>
+
+#include "../full_file_cache/cache_pool.h"
 #include "random_generator.h"
 
 namespace photon {
@@ -712,6 +714,270 @@ TEST(CachePool, open_same_file) {
       }
     }
   }
+}
+
+// Friend accessor — declared as friend in FileCachePool.
+struct FileCachePoolTest {
+  static void set_demote_threshold(FileCachePool *p, uint32_t limit) {
+    p->demoteThreshold_ = limit;
+  }
+  static size_t inuse_size(FileCachePool *p) { return p->lru_.size(); }
+  static size_t idle_size(FileCachePool *p) { return p->idleLru_.size(); }
+  static bool inuse(FileCachePool *p, std::string_view n) {
+    return p->fileIndex_.find(n) != p->fileIndex_.end();
+  }
+  static bool idle(FileCachePool *p, std::string_view n) {
+    return p->idleFileIndex_.find(n) != p->idleFileIndex_.end();
+  }
+};
+
+// Open through the pool then immediately release.
+static bool openClose(ICachePool* pool, const char* name) {
+  auto s = pool->open(name, O_CREAT | O_RDWR, 0644);
+  bool success = (s != nullptr);
+  if (s) s->release();
+  return success;
+}
+
+TEST(CachePool, test_demote_threshold) {
+  std::string root = "/tmp/ease/cache/test_demote_threshold/";
+  SetupTestDir(root);
+  const size_t demoteThreshold = 10;
+  const size_t fileNum = 100;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_demote_threshold(pool, demoteThreshold);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(100);
+    std::string name = "/f" + std::to_string(i);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+  }
+
+  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
+  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+
+  // first fileNum-demoteThreshold files are in idle
+  for (size_t i = 0; i < fileNum - demoteThreshold; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::idle(pool, name));
+    EXPECT_FALSE(T::inuse(pool, name));
+  }
+  // last demoteThreshold files are in hot
+  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::inuse(pool, name));
+    EXPECT_FALSE(T::idle(pool, name));
+  }
+  // re-open /f0 — must promote to hot
+  ASSERT_TRUE(openClose(pool, "/f0"));
+  EXPECT_TRUE(T::inuse(pool, "/f0"));
+  EXPECT_FALSE(T::idle(pool, "/f0"));
+
+  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
+  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+
+  // random access
+  for (size_t i = 0; i < 100; i++) {
+    int r = rand() % fileNum;
+    std::string name = "/f" + std::to_string(r);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+
+    if (rand() % 3 == 0) {
+      EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+    }
+  }
+}
+
+TEST(CachePool, evict_idle_file) {
+  std::string root = "/tmp/ease/cache/evict_idle_file/";
+  SetupTestDir(root);
+  const size_t demoteThreshold = 10;
+  const size_t fileNum = 100;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_demote_threshold(pool, demoteThreshold);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(100);
+    std::string name = "/f" + std::to_string(i);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+  }
+
+  photon::thread_sleep(1);
+  ASSERT_TRUE(T::idle(pool, "/f0"));
+  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
+  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+
+  ASSERT_EQ(0, pool->evict("/f0"));
+  EXPECT_FALSE(T::idle(pool, "/f0"));
+  EXPECT_FALSE(T::inuse(pool, "/f0"));
+  EXPECT_EQ(T::inuse_size(pool), demoteThreshold);
+  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum - 1);
+
+  std::vector<bool> evicted(fileNum, false);
+  evicted[0] = true;
+  for (size_t i = 0; i < 9; i++) {
+    int index = rand() % fileNum;
+    std::string name = "/f" + std::to_string(index);
+    while (evicted[index] || !T::idle(pool, name)) {
+      index = rand() % fileNum;
+      name = "/f" + std::to_string(index);
+    }
+    ASSERT_EQ(0, pool->evict(name));
+    evicted[index] = true;
+    EXPECT_FALSE(T::idle(pool, name));
+    EXPECT_EQ(T::idle_size(pool), fileNum - demoteThreshold - 2 - i);
+  }
+}
+
+TEST(CachePool, evict_by_size_idle_first) {
+  std::string root = "/tmp/ease/cache/evict_by_size/";
+  SetupTestDir(root);
+  const uint64_t capacityGB = 1;
+  const size_t demoteThreshold = 5;
+  const size_t fileNum = 40;
+  const size_t fileSizeMB = 60;
+  const size_t fileSizeBytes = fileSizeMB * 1024 * 1024;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      capacityGB, 0, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_demote_threshold(pool, demoteThreshold);
+
+  IOVector buffer(*cacheAllocator);
+  buffer.push_back(fileSizeBytes);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(1000);
+    std::string name = "/g" + std::to_string(i);
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    store->release();
+  }
+
+  size_t remaining = T::inuse_size(pool) + T::idle_size(pool);
+  EXPECT_LT(remaining, fileNum);
+  EXPECT_LE(T::inuse_size(pool), (size_t)demoteThreshold);
+
+  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+    std::string name = "/g" + std::to_string(i);
+    EXPECT_TRUE(T::inuse(pool, name)) << name << " should still be in hot";
+    EXPECT_FALSE(T::idle(pool, name)) << name << " must not be in idle";
+  }
+
+  // Write a new file to trigger eviction, the idle file should be evicted first
+  std::string name = "/g" + std::to_string(fileNum);
+  auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, store);
+  store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+  store->release();
+  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+    std::string name = "/g" + std::to_string(i);
+    bool existed = T::inuse(pool, name) || T::idle(pool, name);
+    EXPECT_TRUE(existed) << name << " must still exist";
+  }
+}
+
+static int64_t get_physical_memory_KiB() {
+  FILE *file = fopen("/proc/self/status", "r");
+  if (file == NULL) {
+    return -1;
+  }
+
+  int64_t result = -1;
+  char line[128];
+
+  while (fgets(line, 128, file) != nullptr) {
+    if (strncmp(line, "VmRSS:", 6) == 0) {
+      int len = strlen(line);
+
+      const char *p = line;
+      for (; *p && !std::isdigit(*p); ++p) {
+      }
+
+      line[len - 3] = 0;
+      result = atoll(p);
+      break;
+    }
+  }
+
+  fclose(file);
+  return result;
+}
+
+TEST(CachePool, DISABLED_test_mem_usage) {
+  std::string root = "/tmp/ease/cache/test_mem_usage/";
+  SetupTestDir(root);
+  const uint64_t capacityGB = 1;
+  const size_t fileNum = 10'000'000;
+  const size_t inuse = 1'000'000;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      capacityGB, 0, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+
+  auto before_mem_usage = get_physical_memory_KiB();
+  LOG_INFO("Physical memory usage before: ` KiB.", before_mem_usage);
+
+  const int fileNameLength = 45;
+  for (size_t i = 0; i < fileNum; i++) {
+    std::string name = "/" + std::to_string(i);
+    name += std::string(fileNameLength - name.length(), 'a');
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->release();
+    if (i % 100'000 == 0) {
+      LOG_INFO("Opened ` files. current: ` KiB.", i+1, get_physical_memory_KiB());
+      LOG_INFO("inuse size `, idle size `", T::inuse_size(pool), T::idle_size(pool));
+    }
+  }
+  EXPECT_EQ(inuse, T::inuse_size(pool));
+  EXPECT_EQ(fileNum - inuse, T::idle_size(pool));
+
+  photon::thread_sleep(10);
+  malloc_trim(0);
+  photon::thread_sleep(10);
+
+  auto after_mem_usage = get_physical_memory_KiB();
+  LOG_INFO("Physical memory usage after: ` KiB.", after_mem_usage);
+  auto diff = after_mem_usage - before_mem_usage;
+  LOG_INFO("Physical memory usage diff: ` KiB.", diff);
 }
 
 }


### PR DESCRIPTION
* Add idle LRU for closed cache file to reduce memory usage under large-file-count scenarios:
    * When default LRU exceeds demoteThreshold (default 1M), demote LRU tail entries (if not opened) to idle LRU
    * When file in idle LRU is re-accessed, promote it back to default LRU
    * Memory reduce points for idle LRU:
        * Replace LruEntry (24 bytes) with only lruIter (4 bytes)
        * Remove unused unique_ptr (8 bytes)
    * With 10 million files, memory usage drops about 300 MB
* Currently enabled only in non-quota mode.