### PR TITLE
alog: make LogBuilder destructor noinline to avoid 4KB stack leak

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -443,7 +443,7 @@ struct LogBuilder {
         // so just make sure the other one will not output
         rhs.done = true;
     }
-    ~LogBuilder() __INLINE__ {
+    __attribute__((noinline)) ~LogBuilder() {
         if (!done && level >= logger->log_level) {
             builder(logger->log_output);
             done = true;


### PR DESCRIPTION
## alog: make LogBuilder destructor noinline to prevent 4KB stack inflation

### Problem

When `LogBuilder::~LogBuilder()` is marked `__INLINE__`, the compiler inlines the destructor into every caller. Since the destructor invokes the `noinline, cold` lambda which returns a `STFMTLogBuffer` (containing a 4KB `char buf[LOG_BUFFER_SIZE]`), the return value must be allocated in the **caller's** stack frame (the inlined destructor has no frame of its own).

This means any function that uses `LOG_WARN`, `LOG_ERROR`, etc. unconditionally allocates **4KB+** on the stack — even when the log is never written because the level check fails.

**Example**: a simple function with one `LOG_DEBUG`:

```cpp
int hot_function(int x) {
    LOG_DEBUG("x=`", x);
    return x * 2 + 1;
}
```

With `__INLINE__` destructor (before):
```asm
hot_function(int):
    sub    rsp, 0x1028          ; 4KB+ stack allocation, unconditional
    ...
```

### Fix

Change `~LogBuilder()` from `__INLINE__` to `__attribute__((noinline))`:

```cpp
-    ~LogBuilder() __INLINE__ {
+    __attribute__((noinline)) ~LogBuilder() {
```

### Verification via objdump

Test code compiled with `c++ -std=c++17 -O2`, inspected via `objdump -d -C --no-show-raw-insn`:

#### Before (`__INLINE__` destructor)

```asm
hot_function(int):                        ; even LOG_DEBUG causes 4KB stack
    sub    $0x1000,%rsp                   ; <-- 4096 bytes unconditional!
    orq    $0x0,(%rsp)                    ; stack probe
    sub    $0x38,%rsp                     ; + 56 bytes = 4152 total
    ...
    test   %eax,%eax                      ; level check (inlined destructor)
    je     .skip
    ...
.skip:
    add    $0x1038,%rsp
    ret

hot_function_error(int):                  ; same problem even for the x>=0 fast path
    sub    $0x1000,%rsp                   ; <-- 4KB always allocated
    orq    $0x0,(%rsp)
    sub    $0x38,%rsp
    test   %edi,%edi
    js     .do_log
    add    $0x1,%eax                      ; fast path: still paid 4KB stack cost
    add    $0x1038,%rsp
    ret
```

#### After (`noinline` destructor)

**`.text` section (hot path)** — the caller is compact:

```asm
hot_function(int):
    sub    $0x48,%rsp                     ; <-- only 72 bytes!
    ; construct LogBuilder on stack (a few MOVs, no formatting)
    movl   $0x0,0x10(%rsp)               ; level = ALOG_DEBUG
    movb   $0x0,0x28(%rsp)               ; done = false
    call   ~LogBuilder()                  ; noinline: level check in separate frame
    lea    0x1(%rax,%rax,1),%eax          ; business logic: x*2+1
    add    $0x48,%rsp
    ret

hot_function_error(int):
    sub    $0x48,%rsp                     ; <-- only 72 bytes!
    test   %edi,%edi
    js     .cold_branch                   ; unlikely: x < 0
    add    $0x1,%eax                      ; fast path: x + 1
    add    $0x48,%rsp
    ret
.cold_branch:
    ; construct LogBuilder, call ~LogBuilder
    mov    $0xffffffff,%eax
    jmp    .ret
```

**`LogBuilder::~LogBuilder()`** — level check, early return if not met:

```asm
LogBuilder::~LogBuilder():
    cmp    level, [logger->log_level]
    jbe    .Lreturn             ; fast path: log level not met, return
    ; fall through to cold clone...

LogBuilder::~LogBuilder() [clone .cold]:       ; in .text.unlikely
    call   {lambda}::operator()                ; 4KB buffer allocated here
    call   ILogOutput::write()
    ret
```

**`.text.unlikely` section (cold path)** — all formatting code is isolated:

```asm
{lambda}::operator()(ILogOutput*):
    sub    rsp, 0x1028          ; 4KB buffer allocated in cold path only
    ; Prologue formatting, string formatting, write
    ret
```

###  performance improvement
Below are the maximum latency statistics of a live production project. After optimization, the tail latency has been reduced from 30+ms to 2ms.

<img width="752" height="162" alt="image" src="https://github.com/user-attachments/assets/21f338bc-634a-4e64-9334-c02c490d728d" />

### Impact

- **Stack usage**: Reduces per-function stack consumption by **~4KB** for every function containing a LOG_* call (4152 → 72 bytes, **98.3% reduction**). Critical for coroutine/fiber environments with limited stack sizes.
- **Stack probe elimination**: No more `orq $0x0,(%rsp)` page-touching in the hot path. Eliminates a source of tail latency under memory pressure.
- **icache efficiency**: Log formatting code moves to `.text.unlikely`, keeping the hot path compact and cache-friendly.
- **Branch prediction**: The compiler treats the cold path as unlikely, improving branch prediction accuracy for the common case (log not written).
- **Overhead**: One noinline function call (~1ns) per LOG_* site, negligible compared to the microsecond-scale cost of actual log I/O.
