### PR TITLE
alog: make LogBuilder destructor noinline to avoid 4KB stack leak

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -442,7 +442,7 @@ struct LogBuilder {
         // so just make sure the other one will not output
         rhs.done = true;
     }
-    ~LogBuilder() __INLINE__ {
+    __attribute__((noinline)) ~LogBuilder() {
         if (!done && level >= logger->log_level) {
             builder(logger->log_output);
             done = true;


### PR DESCRIPTION
## alog: make LogBuilder destructor noinline to prevent 4KB stack inflation

### Problem

When `LogBuilder::~LogBuilder()` is marked `__INLINE__`, the compiler inlines the destructor into every caller. Since the destructor invokes the `noinline, cold` lambda which returns a `STFMTLogBuffer` (containing a 4KB `char buf[LOG_BUFFER_SIZE]`), the return value must be allocated in the **caller's** stack frame (the inlined destructor has no frame of its own).

This means any function that uses `LOG_WARN`, `LOG_ERROR`, etc. unconditionally allocates **4KB+** on the stack — even when the log is never written because the level check fails.

**Example**: a simple function with one `LOG_DEBUG`:

```cpp
int hot_function(int x) {
    LOG_DEBUG("x=`", x);
    return x * 2 + 1;
}
```

With `__INLINE__` destructor (before):
```asm
hot_function(int):
    sub    rsp, 0x1028          ; 4KB+ stack allocation, unconditional
    ...
```

### Fix

Change `~LogBuilder()` from `__INLINE__` to `__attribute__((noinline))`:

```cpp
-    ~LogBuilder() __INLINE__ {
+    __attribute__((noinline)) ~LogBuilder() {
```

### Verification via objdump

Test code compiled with `c++ -std=c++17 -O2`, inspected via `objdump -d -C --no-show-raw-insn`.

**Note on stack probes**: On Ubuntu/Debian, GCC enables `-fstack-clash-protection` by default (via `gcc -dumpspecs`, in `*distro_defaults`). This inserts `orq $0x0,(%rsp)` stack probes that touch memory on every 4KB allocation. On macOS/Clang or other platforms without this default, the `orq` is absent — but the 4KB RSP shift and spatial locality issue remain.

#### Before (`__INLINE__` destructor)

With `-fstack-clash-protection` (Ubuntu/Debian default):
```asm
hot_function(int):                        ; even LOG_DEBUG causes 4KB stack
    sub    $0x1000,%rsp                   ; <-- 4096 bytes unconditional!
    orq    $0x0,(%rsp)                    ; stack probe — touches memory!
    sub    $0x38,%rsp                     ; + 56 bytes = 4152 total
    ...
    test   %eax,%eax                      ; level check (inlined destructor)
    je     .skip
    ...
.skip:
    add    $0x1038,%rsp
    ret
```

Without `-fstack-clash-protection` (macOS/Clang):
```asm
hot_function(int):
    pushq  %rbp
    movq   %rsp, %rbp
    subq   $0x1030, %rsp                  ; 4KB+ allocated, no probe
    movl   default_logger+8(%rip), %eax   ; load log level
    movl   %edi, -0x1024(%rbp)            ; x stored 4KB below frame base!
    testl  %eax, %eax
    je     .cold
    movl   -0x1024(%rbp), %eax            ; load x back from 4KB offset
    leave
    leal   0x1(%rax,%rax), %eax           ; x*2+1
    retq
```

In both cases, the caller's stack frame is 4KB+. Note that even without the stack probe, the parameter `x` is stored at `-0x1024(%rbp)` — 4KB away from the caller's frame, degrading spatial locality.

Another example — a function where only the error branch logs, but the fast path still pays 4KB:

```cpp
int hot_function_error(int x) {
    if (x < 0) {
        LOG_ERROR("negative x=`", x);
        return -1;
    }
    return x + 1;  // fast path: no logging
}
```

```asm
hot_function_error(int):
    subq   $0x1030, %rsp           ; 4KB allocated BEFORE any branch
    test   %edi, %edi
    js     .do_log                  ; x < 0: error path with LOG_ERROR
    add    $0x1, %eax              ; x >= 0: fast path — never logs, but 4KB already on stack
    add    $0x1038, %rsp
    ret
```

The 4KB stack frame is allocated at function entry, unconditionally — even though the `x >= 0` fast path never reaches the LOG_ERROR.

#### After (`noinline` destructor)

**`.text` section (hot path)** — the caller is compact:

```asm
hot_function(int):
    sub    $0x48,%rsp                     ; <-- only 72 bytes!
    ; construct LogBuilder on stack (a few MOVs, no formatting)
    movl   $0x0,0x10(%rsp)               ; level = ALOG_DEBUG
    movb   $0x0,0x28(%rsp)               ; done = false
    call   ~LogBuilder()                  ; noinline: level check in separate frame
    lea    0x1(%rax,%rax,1),%eax          ; business logic: x*2+1
    add    $0x48,%rsp
    ret

hot_function_error(int):
    sub    $0x48,%rsp                     ; <-- only 72 bytes!
    test   %edi,%edi
    js     .cold_branch                   ; unlikely: x < 0
    add    $0x1,%eax                      ; fast path: x + 1, compact stack
    add    $0x48,%rsp
    ret
.cold_branch:
    ; construct LogBuilder, call ~LogBuilder
    mov    $0xffffffff,%eax
    jmp    .ret
```

**`LogBuilder::~LogBuilder()`** — level check, early return if not met:

```asm
LogBuilder::~LogBuilder():
    cmp    level, [logger->log_level]
    jbe    .Lreturn             ; fast path: log level not met, return
    ; fall through to cold clone...

LogBuilder::~LogBuilder() [clone .cold]:       ; in .text.unlikely
    call   {lambda}::operator()                ; 4KB buffer allocated here
    call   ILogOutput::write()
    ret
```

**`.text.unlikely` section (cold path)** — all formatting code is isolated:

```asm
{lambda}::operator()(ILogOutput*):
    sub    rsp, 0x1028          ; 4KB buffer allocated in cold path only
    ; Prologue formatting, string formatting, write
    ret
```

#### Stack frame comparison

| Function | Before (`__INLINE__`) | After (`noinline`) | Reduction |
|----------|----------------------|-------------------|-----------|
| `hot_function` | 0x1038 (4152 bytes) | 0x48 (72 bytes) | **98.3%** |
| `hot_function_error` | 0x1038 (4152 bytes) | 0x48 (72 bytes) | **98.3%** |

### Performance improvement

Below are the maximum latency statistics of a live production project. After optimization, the tail latency has been reduced from 30+ms to 2ms.

<img width="752" height="162" alt="image" src="https://github.com/user-attachments/assets/21f338bc-634a-4e64-9334-c02c490d728d" />

### Impact

- **Stack usage**: Reduces per-function stack consumption by **~4KB** for every function containing a LOG_* call (4152 → 72 bytes, **98.3% reduction**). In coroutine/fiber environments like Photon (default stack 64KB–8MB), each LOG_* site unconditionally reserves 4KB on the caller's stack. A 3-level call chain with 4 LOG_* sites wastes 16KB — 25% of a 64KB coroutine stack — for log buffers that are never used, increasing the risk of stack overflow in deep call chains.
- **Stack spatial locality**: The `sub rsp, 0x1020` shifts the stack pointer down by 4KB. As shown in the objdump above, the parameter `x` is stored at `-0x1024(%rbp)` — 4KB away from the caller's frame. All subsequent callee stack frames end up 4KB further from the caller's data. In a deep call chain, this accumulates: with N LOG_* sites, the actual working data is spread across N×4KB of extra address space, degrading cache line and TLB hit rates for stack accesses.
- **Stack probe on Linux**: On Ubuntu/Debian (and many production Linux environments), GCC enables `-fstack-clash-protection` by default (`gcc -dumpspecs` → `*distro_defaults`). This inserts `orq $0x0,(%rsp)` that touches memory on each 4KB allocation, adding real memory access overhead even when the log is never written.
- **Overhead**: One noinline function call (~1ns) per LOG_* site, negligible compared to the microsecond-scale cost of actual log I/O.
