### PR TITLE
[Pick][0.8 to 0.9] | Support userinfo in URL and proxy authentication (#1183) 

### DIFF
--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -140,6 +140,20 @@ constexpr static std::bitset<10>
     code_redirect_verb(code3xx(300, 301, 302, 307, 308));
 
 static constexpr size_t kMinimalHeadersSize = 8 * 1024 - 1;
+
+void Client::set_proxy(std::string_view proxy) {
+    m_proxy_url.from_string(proxy);
+    m_proxy = true;
+    auto ui = m_proxy_url.user_passwd();
+    if (!ui.empty()) {
+        std::string encoded;
+        Base64Encode(ui, encoded);
+        m_proxy_auth = "Basic " + encoded;
+    } else {
+        m_proxy_auth.clear();
+    }
+}
+
 enum RoundtripStatus {
     ROUNDTRIP_SUCCESS,
     ROUNDTRIP_FAILED,
@@ -200,7 +214,7 @@ public:
             LOG_ERROR_RETURN(ETIMEDOUT, ROUNDTRIP_FAILED, "connection timedout");
         auto &req = op->req;
         ISocketStream* s;
-        if (m_proxy && !m_proxy_url.empty())
+        if (op->enable_proxy && !m_proxy_url.empty())
             s = get_dialer().dial(m_proxy_url, tmo.timeout());
         else if (!op->uds_path.empty())
             s = get_dialer().dial(op->uds_path, tmo.timeout());
@@ -288,6 +302,8 @@ public:
         op->req.headers.insert("User-Agent", m_user_agent.empty() ? std::string_view(USERAGENT)
                                                                   : std::string_view(m_user_agent));
         op->req.headers.insert("Connection", "keep-alive");
+        if (op->enable_proxy && !m_proxy_auth.empty())
+            op->req.headers.insert("Proxy-Authorization", m_proxy_auth);
         if (m_cookie_jar && m_cookie_jar->set_cookies_to_headers(&op->req) != 0)
             LOG_ERROR_RETURN(0, -1, "set_cookies_to_headers failed");
         Timeout tmo(std::min(op->timeout.timeout(), m_timeout));

--- a/net/http/client.h
+++ b/net/http/client.h
@@ -138,10 +138,7 @@ public:
     // get common headers, to manipulate
     virtual Headers* common_headers() = 0;
 
-    void set_proxy(std::string_view proxy) {
-        m_proxy_url.from_string(proxy);
-        m_proxy = true;
-    }
+    void set_proxy(std::string_view proxy);
     void set_user_agent(std::string_view user_agent) {
         m_user_agent = std::string(user_agent);
     }
@@ -168,6 +165,7 @@ public:
                                           bool secure = false, uint64_t timeout = -1UL) = 0;
 protected:
     StoredURL m_proxy_url;
+    std::string m_proxy_auth;
     std::string m_user_agent;
     uint64_t m_timeout = -1UL;
     bool m_proxy = false;

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -731,6 +731,83 @@ TEST(url, utils) {
     ASSERT_EQ(0, url_unescape(ul2).compare(ul1));
 }
 
+TEST(url, user_passwd) {
+    static const char url0[] = "http://root:password@123.123.1.1:3123/path";
+    URL u0(url0);
+    EXPECT_EQ(u0.user_passwd(), "root:password");
+    EXPECT_EQ(u0.user(), "root");
+    EXPECT_EQ(u0.passwd(), "password");
+    EXPECT_EQ(u0.host(), "123.123.1.1");
+    EXPECT_EQ(u0.port(), 3123);
+    EXPECT_EQ(u0.path(), "/path");
+
+    static const char url1[] = "http://user:pass@example.com";
+    URL u1(url1);
+    EXPECT_EQ(u1.user_passwd(), "user:pass");
+    EXPECT_EQ(u1.user(), "user");
+    EXPECT_EQ(u1.passwd(), "pass");
+    EXPECT_EQ(u1.host(), "example.com");
+    EXPECT_EQ(u1.port(), 80);
+
+    static const char url2[] = "https://admin:s3cret@proxy.host:8080/";
+    URL u2(url2);
+    EXPECT_EQ(u2.user_passwd(), "admin:s3cret");
+    EXPECT_EQ(u2.user(), "admin");
+    EXPECT_EQ(u2.passwd(), "s3cret");
+    EXPECT_EQ(u2.host(), "proxy.host");
+    EXPECT_EQ(u2.port(), 8080);
+    EXPECT_EQ(u2.secure(), true);
+
+    // no user_passwd at all
+    static const char url3[] = "http://example.com:8080/path";
+    URL u3(url3);
+    EXPECT_EQ(u3.user_passwd(), "");
+    EXPECT_EQ(u3.user(), "");
+    EXPECT_EQ(u3.passwd(), "");
+    EXPECT_EQ(u3.host(), "example.com");
+    EXPECT_EQ(u3.port(), 8080);
+
+    // user only, no colon, no password
+    static const char url5[] = "http://onlyuser@example.com:8080/path";
+    URL u5(url5);
+    EXPECT_EQ(u5.user_passwd(), "onlyuser");
+    EXPECT_EQ(u5.user(), "onlyuser");
+    EXPECT_EQ(u5.passwd(), "");
+    EXPECT_EQ(u5.host(), "example.com");
+
+    // user with colon but empty password: user:@host
+    static const char url6[] = "http://user:@example.com:8080/path";
+    URL u6(url6);
+    EXPECT_EQ(u6.user_passwd(), "user:");
+    EXPECT_EQ(u6.user(), "user");
+    EXPECT_EQ(u6.passwd(), "");
+    EXPECT_EQ(u6.host(), "example.com");
+    EXPECT_EQ(u6.port(), 8080);
+
+    // @ in query string should not be treated as delimiter
+    static const char url4[] = "http://example.com/path?email=a@b.com";
+    URL u4(url4);
+    EXPECT_EQ(u4.user_passwd(), "");
+    EXPECT_EQ(u4.host(), "example.com");
+    EXPECT_EQ(u4.query(), "email=a@b.com");
+}
+
+TEST(http_client, set_proxy_with_auth) {
+    auto client = new_http_client();
+    DEFER(delete client);
+    client->set_proxy("http://root:password@123.123.1.1:3123");
+    EXPECT_TRUE(client->has_proxy());
+    auto proxy = client->get_proxy();
+    EXPECT_EQ(proxy->host(), "123.123.1.1");
+    EXPECT_EQ(proxy->port(), 3123);
+
+    // set_proxy without userinfo should clear auth
+    client->set_proxy("http://10.0.0.1:8080");
+    EXPECT_TRUE(client->has_proxy());
+    EXPECT_EQ(client->get_proxy()->host(), "10.0.0.1");
+    EXPECT_EQ(client->get_proxy()->port(), 8080);
+}
+
 // Only for manual test
 // TEST(http_client, proxy) {
 //     auto client = new_http_client();

--- a/net/http/url.cpp
+++ b/net/http/url.cpp
@@ -50,6 +50,25 @@ void URL::from_string(std::string_view url) {
         pos += p + 3;
         url.remove_prefix(p + 3);
     }
+    // parse user:passwd (RFC 3986 Section 3.2.1): user:passwd@host
+    auto at = url.find('@');
+    auto slash = url.find('/');
+    if (at != url.npos && (slash == url.npos || at < slash)) {
+        auto userinfo = url.substr(0, at);
+        auto colon = userinfo.find(':');
+        if (colon != userinfo.npos) {
+            m_user = rstring_view16(pos, colon);
+            m_passwd = rstring_view16(pos + colon + 1, at - colon - 1);
+        } else {
+            m_user = rstring_view16(pos, at);
+            m_passwd = rstring_view16(pos + at, 0);
+        }
+        pos += at + 1;
+        url.remove_prefix(at + 1);
+    } else {
+        m_user = rstring_view16(0, 0);
+        m_passwd = rstring_view16(0, 0);
+    }
     p = url.find_first_of(":/?");
     if (p == url.npos) p = url.size();
     m_host = rstring_view16(pos, p);

--- a/net/http/url.h
+++ b/net/http/url.h
@@ -46,6 +46,8 @@ protected:
     rstring_view16 m_query;
     rstring_view16 m_target;
     rstring_view16 m_fragment;
+    rstring_view16 m_user;
+    rstring_view16 m_passwd;
     uint16_t m_port = 0;
     bool m_secure;
     char *m_tmp_target = nullptr;
@@ -86,6 +88,12 @@ public:
     uint16_t port() const { return m_port; }
     bool secure() const { return m_secure; }
     bool empty() const { return !m_url; }
+    std::string_view user() const { return m_url | m_user; }
+    std::string_view passwd() const { return m_url | m_passwd; }
+    std::string_view user_passwd() const {
+        uint16_t len = m_passwd.offset() + m_passwd.size() - m_user.offset();
+        return {m_url + m_user.offset(), len};
+    }
 };
 class StoredURL : public URL {
 public:


### PR DESCRIPTION
> Support userinfo in URL and proxy authentication (#1183)

* support user:passwd in URL

Signed-off-by: zhuangbowei.zbw <zhuangbowei.zbw@alibaba-inc.com>

* support proxy auth via user:passwd in HTTP client

Signed-off-by: zhuangbowei.zbw <zhuangbowei.zbw@alibaba-inc.com>

---------

Signed-off-by: zhuangbowei.zbw <zhuangbowei.zbw@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits