### PR TITLE
[Pick][0.8 to 0.9] | compatible with clang 21 (#1187) 

### DIFF
--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -532,6 +532,8 @@ LogBuffer& operator << (LogBuffer& log, const Prologue& pro)
         log.printf(ALogString(pro.addr_func, pro.len_func), ':');
     }
     return log;
+
+    static_assert(24 == sizeof(make_named_value("levels", levels)), "...");
 }
 
 LogBuffer& operator << (LogBuffer& log, ERRNO e) {

--- a/common/alog.h
+++ b/common/alog.h
@@ -542,12 +542,6 @@ inline NamedValue<T> make_named_value(const char (&name)[N], T&& value)
     return NamedValue<T> {ALogStringL(name), std::forward<T>(value)};
 }
 
-template <ssize_t N, ssize_t M>
-inline NamedValue<const char*> make_named_value(const char (&name)[N],
-                                                char (&value)[M]) {
-    return {ALogStringL(name), value};
-}
-
 #define VALUE(x) make_named_value(#x, x)
 
 template <typename T>

--- a/net/http/headers.cpp
+++ b/net/http/headers.cpp
@@ -152,7 +152,7 @@ HeadersBase::KV* HeadersBase::kv_add_sort(KV kv) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
-    memmove(begin - 1, begin, sizeof(KV) * (it - begin));
+    memmove((void*)(begin - 1), begin, sizeof(KV) * (it - begin));
 #ifndef __clang__
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
> compatible with clang 21 (#1187)
Generated by Auto PR, by cherry-pick related commits