### PR TITLE
[Pick][0.9 to main] | fix(oss): fix memory leak in get_xml_node (#1195) 

### DIFF
--- a/ecosystem/oss.cpp
+++ b/ecosystem/oss.cpp
@@ -57,8 +57,8 @@ using photon::net::http::verbstr;
 
 static SimpleDOM::Node get_xml_node(HTTP_STACK_OP& op) {
   auto length = op.resp.headers.content_length();
-  if (length > XML_LIMIT)
-    LOG_ERROR_RETURN(EINVAL, {}, "xml length limit excceed `", length);
+  if (length > XML_LIMIT || length == 0)
+    LOG_ERROR_RETURN(EINVAL, {}, "xml length invalid `", length);
   auto body_buf = (char*)malloc(length + 1);
   auto rc = op.resp.read(body_buf, length);
   body_buf[length] = '\0';


### PR DESCRIPTION
> fix(oss): fix memory leak in get_xml_node (#1195)
Generated by Auto PR, by cherry-pick related commits