### PR TITLE
[Pick][0.8 to 0.9] | [feat.] remove O_RDONLY flag in httpfs_v2 (#1199) 

### DIFF
--- a/fs/httpfs/httpfs_v2.cpp
+++ b/fs/httpfs/httpfs_v2.cpp
@@ -259,7 +259,6 @@ public:
 
 inline IFile* HttpFs_v2::open(const char* pathname, int flags) {
     if (!pathname) LOG_ERROR_RETURN(EINVAL, nullptr, "NULL is not allowed");
-    if (flags != O_RDONLY) return nullptr;
 
     if (pathname[0] == '/') ++pathname;
     estring_view fn(pathname), prefix;


### PR DESCRIPTION
> [feat.] remove O_RDONLY flag in httpfs_v2 (#1199)

O_RDONLY flag in httpfs_v2 shouldn't be set when people try to
upload data chunks to remote HTTP Server (eg. OSS)

Signed-off-by: Yifan Yuan <tuji.yyf@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits