### PR TITLE
feat(cache): introduce three-tier LRU cache (active→inactive→idle)

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -79,11 +79,7 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
     return nullptr;
   }
 
-  // Check idle container first
-  auto idleIt = idleFileIndex_.find(pathname);
-  if (idleIt != idleFileIndex_.end()) {
-    promoteFromIdle(idleIt);
-  }
+  promoteToHot(pathname);
 
   auto find = fileIndex_.find(pathname);
   if (find == fileIndex_.end()) {
@@ -96,15 +92,7 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
     find->second->openCount++;
   }
 
-  // If LRU exceeds the limit, demote the tail (only if not open) to idle
-  while (lru_.size() > demoteThreshold_) {
-    auto tailIt = lru_.back();
-    if (tailIt->second->openCount == 0) {
-      demoteToIdle(tailIt);
-    } else {
-      break;
-    }
-  }
+  demoteToCold();
 
   return new FileCacheStore(this, localFile, refillUnit_, find);
 }
@@ -139,10 +127,13 @@ int FileCachePool::stat(CacheStat* stat, std::string_view pathname) {
 }
 
 int FileCachePool::evict(std::string_view filename) {
-  // Check idle container first
-  auto idleIt = idleFileIndex_.find(filename);
-  if (idleIt != idleFileIndex_.end()) {
-    return evictIdleEntry(idleIt) >= 0 ? 0 : -1;
+  // Check cold tiers first
+  for (auto* tier : coldTiers_) {
+    if (tier->contains(filename)) {
+      auto freed = truncateAndUnlink(filename);
+      tier->remove(filename);
+      return freed >= 0 ? 0 : -1;
+    }
   }
 
   auto fileIter = fileIndex_.find(filename);
@@ -262,10 +253,18 @@ void FileCachePool::eviction() {
 
   isFull_ = true;
 
-  // Phase 1: evict from idle tier first.
-  actualEvict -= evictIdleWhenFull(actualEvict);
+  // Evict from cold tiers first in reverse order
+  for (int i = coldTiers_.size() - 1; i >= 0; i--) {
+    auto* tier = coldTiers_[i];
+    while (actualEvict > 0 && !tier->empty() && !exit_) {
+      auto name = tier->victim();
+      auto freed = truncateAndUnlink(name);
+      tier->remove(name);
+      if (freed >= 0) actualEvict -= freed;
+      photon::thread_yield();
+    }
+  }
 
-  // Phase 2: fall back to LRU eviction when idle tier is exhausted
   while (actualEvict > 0 && !lru_.empty() && !exit_) {
     auto fileIter = lru_.back();
     const auto& fileName = fileIter->first;
@@ -347,34 +346,44 @@ int FileCachePool::insertFile(std::string_view file) {
   }
   auto fileSize = st.st_blocks * kDiskBlockSize;
 
-  if (lru_.size() >= demoteThreshold_) {
-    auto idleLruIt = idleLru_.push_front(idleFileIndex_.end());
-    auto iter = idleFileIndex_.emplace(file, idleLruIt).first;
-    idleLru_.front() = iter;
-  } else {
-    auto lruIter = lru_.push_front(fileIndex_.end());
-    auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
-    auto iter = fileIndex_.emplace(file, std::move(entry)).first;
-    lru_.front() = iter;
-  }
+  auto lruIter = lru_.push_front(fileIndex_.end());
+  auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
+  auto iter = fileIndex_.emplace(file, std::move(entry)).first;
+  lru_.front() = iter;
   totalUsed_ += fileSize;
+
+  demoteToCold();
   return 0;
 }
 
-// Demote a LRU entry (openCount must be 0) to the idle container.
-void FileCachePool::demoteToIdle(FileNameMap::iterator iter) {
-  auto idleLruIt = idleLru_.push_front(idleFileIndex_.end());
-  auto idleIndexIt = idleFileIndex_.emplace(iter->first, idleLruIt).first;
-  idleLru_.front() = idleIndexIt;
+void FileCachePool::demoteToCold() {
+  while (lru_.size() > thresholds_[0]) {
+    auto tailIt = lru_.back();
+    if (tailIt->second->openCount != 0) break;
 
-  lru_.remove(iter->second->lruIter);
-  fileIndex_.erase(iter);
+    coldTiers_[0]->insert(tailIt->first);
+    lru_.remove(tailIt->second->lruIter);
+    fileIndex_.erase(tailIt);
+
+    for (size_t i = 1; i < coldTiers_.size(); i++) {
+      if (coldTiers_[i-1]->size() > thresholds_[i]) {
+        auto key = coldTiers_[i-1]->victim();
+        coldTiers_[i]->insert(key);
+        coldTiers_[i-1]->remove(key);
+      } else break;
+    }
+  }
 }
 
-// Promote an idle entry back to the front of LRU.
-void FileCachePool::promoteFromIdle(IdleFileNameMap::iterator idleIt) {
-  uint32_t idleLruIter = idleIt->second;
-  const auto& filename = idleIt->first;
+void FileCachePool::promoteToHot(std::string_view filename) {
+  bool found = false;
+  for (auto* tier : coldTiers_) {
+    if (tier->contains(filename)) {
+      found = true;
+      tier->remove(filename);
+    }
+  }
+  if (!found) return;
 
   struct stat st = {};
   uint64_t fileSize = 0;
@@ -386,15 +395,9 @@ void FileCachePool::promoteFromIdle(IdleFileNameMap::iterator idleIt) {
   auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
   auto iter = fileIndex_.emplace(filename, std::move(entry)).first;
   lru_.front() = iter;
-
-  idleLru_.remove(idleLruIter);
-  idleFileIndex_.erase(idleIt);
 }
 
-// Evict the idle entry pointed to by idleIt; return freed bytes or -1 on error.
-ssize_t FileCachePool::evictIdleEntry(IdleFileNameMap::iterator idleIt) {
-  const auto& filename = idleIt->first;
-
+ssize_t FileCachePool::truncateAndUnlink(std::string_view filename) {
   struct stat st = {};
   uint64_t fileSize = 0;
   if (mediaFs_->stat(filename.data(), &st) == 0) {
@@ -414,22 +417,49 @@ ssize_t FileCachePool::evictIdleEntry(IdleFileNameMap::iterator idleIt) {
     // we still evict fileSize bytes even if unlink fails
     LOG_ERRNO_RETURN(0, fileSize, "unlink failed, name : `", filename);
   }
-
-  uint32_t idleLruIter = idleIt->second;
-  idleLru_.remove(idleLruIter);
-  idleFileIndex_.erase(idleIt);
   return static_cast<ssize_t>(fileSize);
 }
 
-uint64_t FileCachePool::evictIdleWhenFull(uint64_t needEvict) {
-  uint64_t evictSize = 0;
-  while (evictSize < needEvict && !idleLru_.empty() && !exit_) {
-    auto r = evictIdleEntry(idleLru_.back());
-    if (r >= 0) evictSize += static_cast<uint64_t>(r);
-    photon::thread_yield();
-  }
-  return evictSize;
+// --- InactiveCacheTier ---
+bool InactiveCacheTier::contains(std::string_view name) {
+  return index_.find(name) != index_.end();
 }
+
+void InactiveCacheTier::remove(std::string_view name) {
+  auto it = index_.find(name);
+  if (it == index_.end()) return;
+  lru_.remove(it->second);
+  index_.erase(it);
+}
+
+void InactiveCacheTier::insert(std::string_view name) {
+  auto lruIt = lru_.push_front(index_.end());
+  auto it = index_.emplace(name, lruIt).first;
+  lru_.front() = it;
+}
+
+size_t InactiveCacheTier::size() { return index_.size(); }
+bool InactiveCacheTier::empty() { return lru_.empty(); }
+std::string_view InactiveCacheTier::victim() { return lru_.back()->first; }
+
+// --- IdleCacheTier ---
+bool IdleCacheTier::contains(std::string_view name) {
+  return index_.find(std::string(name)) != index_.end();
+}
+
+void IdleCacheTier::remove(std::string_view name) {
+  auto it = index_.find(std::string(name));
+  if (it == index_.end()) return;
+  index_.erase(it);
+}
+
+void IdleCacheTier::insert(std::string_view name) {
+  index_.emplace(name);
+}
+
+size_t IdleCacheTier::size() { return index_.size(); }
+bool IdleCacheTier::empty() { return index_.empty(); }
+std::string_view IdleCacheTier::victim() { return *index_.begin(); }
 
 }
 }

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <numeric>
 #include <sys/statvfs.h>
 
 #include "cache_store.h"
@@ -356,8 +357,25 @@ int FileCachePool::insertFile(std::string_view file) {
   return 0;
 }
 
+void FileCachePool::adaptThresholds() {
+  uint64_t count = std::accumulate(tierHits_.begin(), tierHits_.end(), 0ULL);
+  for (size_t i = 0; i + 1 < tierHits_.size(); i++) {
+    if (count > 0) {
+      double ratio = static_cast<double>(tierHits_[i]) / count;
+      // High ratio => this tier absorbs the bulk of hits, it has room to shrink.
+      // Low ratio => hits leak to colder tiers, grow it.
+      if (ratio > 0.90) thresholds_[i].adapt(0.80);
+      else if (ratio < 0.50) thresholds_[i].adapt(1.25);
+    }
+    count -= tierHits_[i];
+  }
+
+  promoteCount_ = 0;
+  tierHits_.fill(0);
+}
+
 void FileCachePool::demoteToCold() {
-  while (lru_.size() > thresholds_[0]) {
+  while (lru_.size() > thresholds_[0].value) {
     auto tailIt = lru_.back();
     if (tailIt->second->openCount != 0) break;
 
@@ -366,7 +384,7 @@ void FileCachePool::demoteToCold() {
     fileIndex_.erase(tailIt);
 
     for (size_t i = 1; i < coldTiers_.size(); i++) {
-      if (coldTiers_[i-1]->size() > thresholds_[i]) {
+      if (coldTiers_[i-1]->size() > thresholds_[i].value) {
         auto key = coldTiers_[i-1]->victim();
         coldTiers_[i]->insert(key);
         coldTiers_[i-1]->remove(key);
@@ -376,14 +394,25 @@ void FileCachePool::demoteToCold() {
 }
 
 void FileCachePool::promoteToHot(std::string_view filename) {
+  auto find = fileIndex_.find(filename);
+  if (find != fileIndex_.end()) {
+    tierHits_[0]++;
+    return;
+  }
+
   bool found = false;
-  for (auto* tier : coldTiers_) {
-    if (tier->contains(filename)) {
+  for (size_t i = 0; i < coldTiers_.size(); ++i) {
+    if (coldTiers_[i]->contains(filename)) {
+      tierHits_[i + 1]++;
       found = true;
-      tier->remove(filename);
+      coldTiers_[i]->remove(filename);
+      break;
     }
   }
   if (!found) return;
+
+  promoteCount_++;
+  if (promoteCount_ >= kPromotesPerAdapt) adaptThresholds();
 
   struct stat st = {};
   uint64_t fileSize = 0;

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -157,9 +157,29 @@ protected:
     // Eviction/promote cascades iterate coldTiers_ in order.
     InactiveCacheTier inactiveTier_;
     IdleCacheTier idleTier_;
-    std::vector<ColdCacheTier*> coldTiers_ = {&inactiveTier_, &idleTier_};
-    std::vector<uint32_t> thresholds_ = {1'000'000, 1'000'000'000};
+    std::array<ColdCacheTier*, 2> coldTiers_ = {&inactiveTier_, &idleTier_};
 
+    // Adaptive threshold tuning.
+    struct AdaptiveThreshold {
+        uint32_t min;
+        uint32_t max;
+        uint32_t value;
+
+        AdaptiveThreshold(int min, int max)
+            : min(min), max(max), value(min) {}
+        
+        void adapt(double ratio) {
+            value = std::max(min, std::min(max, static_cast<uint32_t>(value * ratio)));
+        }
+    };
+    std::array<AdaptiveThreshold, 2> thresholds_ = 
+        {AdaptiveThreshold(1'000, 100'000), AdaptiveThreshold(100'000, 100'000'000)};
+
+    static constexpr uint64_t kPromotesPerAdapt = 10'000;
+    uint64_t promoteCount_ = 0;
+    std::array<uint64_t, 3> tierHits_{};
+
+    void adaptThresholds();
     void demoteToCold();
 
     void promoteToHot(std::string_view filename);

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -20,7 +20,6 @@ limitations under the License.
 #include <map>
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <vector>
 #include <photon/thread/thread.h>
 #include <photon/thread/timer.h>
@@ -73,7 +72,7 @@ public:
     std::string_view victim() override;
 
 private:
-    std::unordered_set<std::string> index_;
+    unordered_set_string_key<> index_;
 };
 
 class FileCachePool : public photon::fs::ICachePool {

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -32,6 +32,49 @@ limitations under the License.
 namespace photon {
 namespace fs {
 
+// Abstract base for cold (non-hot) cache tiers.
+class ColdCacheTier {
+public:
+    virtual ~ColdCacheTier() = default;
+    virtual bool contains(std::string_view name) = 0;
+    virtual void remove(std::string_view name) = 0;
+    virtual void insert(std::string_view name) = 0;
+    virtual size_t size() = 0;
+    virtual bool empty() = 0;
+    // The returned view is valid until remove().
+    virtual std::string_view victim() = 0;
+};
+
+class InactiveCacheTier : public ColdCacheTier {
+public:
+    typedef map_string_key<uint32_t> IndexMap;
+    typedef photon::fs::LRU<IndexMap::iterator, uint32_t> LRUContainer;
+
+    bool contains(std::string_view name) override;
+    void remove(std::string_view name) override;
+    void insert(std::string_view name) override;
+    size_t size() override;
+    bool empty() override;
+    std::string_view victim() override;
+
+private:
+    LRUContainer lru_;
+    IndexMap index_;
+};
+
+class IdleCacheTier : public ColdCacheTier {
+public:
+    bool contains(std::string_view name) override;
+    void remove(std::string_view name) override;
+    void insert(std::string_view name) override;
+    size_t size() override;
+    bool empty() override;
+    std::string_view victim() override;
+
+private:
+    std::unordered_set<std::string> index_;
+};
+
 class FileCachePool : public photon::fs::ICachePool {
 public:
     FileCachePool(photon::fs::IFileSystem *mediaFs, uint64_t capacityInGB, uint64_t periodInUs,
@@ -42,8 +85,6 @@ public:
     static const uint64_t kDiskBlockSize = 512; // stat(2)
     static const uint64_t kDeleteDelayInUs = 1000;
     static const uint32_t kWaterMarkRatio = 90;
-    // max inuse-lru entries before demoting tail to idle-lru (default: 100w)
-    static const uint32_t kDemoteThreshold = 1'000'000;
 
     void Init();
 
@@ -112,19 +153,17 @@ protected:
     // filename -> lruEntry
     FileNameMap fileIndex_;
 
-    uint32_t demoteThreshold_ = kDemoteThreshold;
+    // Cold tiers: inactive (LRU-ordered) and idle (unordered).
+    // Eviction/promote cascades iterate coldTiers_ in order.
+    InactiveCacheTier inactiveTier_;
+    IdleCacheTier idleTier_;
+    std::vector<ColdCacheTier*> coldTiers_ = {&inactiveTier_, &idleTier_};
+    std::vector<uint32_t> thresholds_ = {1'000'000, 1'000'000'000};
 
-    // idleFileIndex_ stores filename -> lruContainer's iterator
-    // idleLru_ stores iterators into idleFileIndex_; std::map nodes are stable.
-    typedef map_string_key<uint32_t> IdleFileNameMap;
-    typedef photon::fs::LRU<IdleFileNameMap::iterator, uint32_t> IdleLRUContainer;
-    IdleLRUContainer idleLru_;
-    IdleFileNameMap idleFileIndex_;
+    void demoteToCold();
 
-    void demoteToIdle(FileNameMap::iterator iter);
-    void promoteFromIdle(IdleFileNameMap::iterator idleIter);
-    uint64_t evictIdleWhenFull(uint64_t needEvictSize);
-    ssize_t evictIdleEntry(IdleFileNameMap::iterator idleIter);
+    void promoteToHot(std::string_view filename);
+    ssize_t truncateAndUnlink(std::string_view filename);
 
     friend struct FileCachePoolTest;
 };

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -16,10 +16,11 @@ limitations under the License.
 
 #pragma once
 
+#include <array>
 #include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <photon/thread/thread.h>
 #include <photon/thread/timer.h>

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 
 #include <cstring>
 #include <algorithm>
+#include <set>
 
 #include <photon/common/utility.h>
 #include <photon/photon.h>
@@ -719,15 +720,22 @@ TEST(CachePool, open_same_file) {
 // Friend accessor — declared as friend in FileCachePool.
 struct FileCachePoolTest {
   static void set_demote_threshold(FileCachePool *p, uint32_t limit) {
-    p->demoteThreshold_ = limit;
+    p->thresholds_[0] = limit;
   }
-  static size_t inuse_size(FileCachePool *p) { return p->lru_.size(); }
-  static size_t idle_size(FileCachePool *p) { return p->idleLru_.size(); }
-  static bool inuse(FileCachePool *p, std::string_view n) {
+  static void set_inactive_demote_threshold(FileCachePool *p, uint32_t limit) {
+    p->thresholds_[1] = limit;
+  }
+  static size_t active_size(FileCachePool *p) { return p->lru_.size(); }
+  static size_t inactive_size(FileCachePool *p) { return p->inactiveTier_.size(); }
+  static size_t idle_size(FileCachePool *p) { return p->idleTier_.size(); }
+  static bool active(FileCachePool *p, std::string_view n) {
     return p->fileIndex_.find(n) != p->fileIndex_.end();
   }
+  static bool inactive(FileCachePool *p, std::string_view n) {
+    return p->inactiveTier_.contains(n);
+  }
   static bool idle(FileCachePool *p, std::string_view n) {
-    return p->idleFileIndex_.find(n) != p->idleFileIndex_.end();
+    return p->idleTier_.contains(n);
   }
 };
 
@@ -764,28 +772,28 @@ TEST(CachePool, test_demote_threshold) {
     ASSERT_TRUE(openClose(pool, name.c_str()));
   }
 
-  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
-  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+  EXPECT_LE(T::active_size(pool), demoteThreshold);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
 
-  // first fileNum-demoteThreshold files are in idle
+  // first fileNum-demoteThreshold files are in inactive or idle
   for (size_t i = 0; i < fileNum - demoteThreshold; i++) {
     std::string name = "/f" + std::to_string(i);
-    EXPECT_TRUE(T::idle(pool, name));
-    EXPECT_FALSE(T::inuse(pool, name));
+    EXPECT_TRUE(T::inactive(pool, name) || T::idle(pool, name));
+    EXPECT_FALSE(T::active(pool, name));
   }
-  // last demoteThreshold files are in hot
+  // last demoteThreshold files are in active
   for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
     std::string name = "/f" + std::to_string(i);
-    EXPECT_TRUE(T::inuse(pool, name));
-    EXPECT_FALSE(T::idle(pool, name));
+    EXPECT_TRUE(T::active(pool, name));
+    EXPECT_FALSE(T::inactive(pool, name));
   }
-  // re-open /f0 — must promote to hot
+  // re-open /f0 — must promote to active
   ASSERT_TRUE(openClose(pool, "/f0"));
-  EXPECT_TRUE(T::inuse(pool, "/f0"));
-  EXPECT_FALSE(T::idle(pool, "/f0"));
+  EXPECT_TRUE(T::active(pool, "/f0"));
+  EXPECT_FALSE(T::inactive(pool, "/f0"));
 
-  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
-  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+  EXPECT_LE(T::active_size(pool), demoteThreshold);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
 
   // random access
   for (size_t i = 0; i < 100; i++) {
@@ -794,16 +802,17 @@ TEST(CachePool, test_demote_threshold) {
     ASSERT_TRUE(openClose(pool, name.c_str()));
 
     if (rand() % 3 == 0) {
-      EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+      EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
     }
   }
 }
 
-TEST(CachePool, evict_idle_file) {
-  std::string root = "/tmp/ease/cache/evict_idle_file/";
+TEST(CachePool, three_tier_cascade) {
+  std::string root = "/tmp/ease/cache/three_tier_cascade/";
   SetupTestDir(root);
-  const size_t demoteThreshold = 10;
-  const size_t fileNum = 100;
+  const size_t activeLimit = 5;
+  const size_t inactiveLimit = 10;
+  const size_t fileNum = 30;
 
   auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
   auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
@@ -816,46 +825,113 @@ TEST(CachePool, evict_idle_file) {
 
   auto pool = dynamic_cast<FileCachePool*>(cachePool);
   ASSERT_NE(nullptr, pool);
-  T::set_demote_threshold(pool, demoteThreshold);
+  T::set_demote_threshold(pool, activeLimit);
+  T::set_inactive_demote_threshold(pool, inactiveLimit);
 
+  // Open 30 files sequentially — forces cascade: active → inactive → idle
+  // Sleep between opens must exceed storeCacheTTLUsecs (1ms) so that each
+  // store expires before the next open, allowing demoteToInactive to run.
   for (size_t i = 0; i < fileNum; i++) {
-    photon::thread_usleep(100);
+    photon::thread_usleep(1500);
     std::string name = "/f" + std::to_string(i);
     ASSERT_TRUE(openClose(pool, name.c_str()));
   }
 
-  photon::thread_sleep(1);
+  // --- 1. Verify tier sizes ---
+  EXPECT_LE(T::active_size(pool), activeLimit);
+  EXPECT_LE(T::inactive_size(pool), inactiveLimit);
+  EXPECT_GT(T::idle_size(pool), 0u);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
+
+  // Earliest files in idle, middle in inactive, latest in active
+  size_t expectedIdle = fileNum - activeLimit - inactiveLimit;
+  EXPECT_EQ(T::idle_size(pool), expectedIdle);
+  for (size_t i = 0; i < expectedIdle; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::idle(pool, name)) << name << " should be in idle tier";
+  }
+  for (size_t i = expectedIdle; i < fileNum - activeLimit; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::inactive(pool, name)) << name << " should be in inactive tier";
+  }
+  for (size_t i = fileNum - activeLimit; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::active(pool, name)) << name << " should be in active tier";
+  }
+
+  // --- 2. Promote from idle → active ---
   ASSERT_TRUE(T::idle(pool, "/f0"));
-  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
-  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
-
-  ASSERT_EQ(0, pool->evict("/f0"));
+  ASSERT_TRUE(openClose(pool, "/f0"));
+  EXPECT_TRUE(T::active(pool, "/f0"));
   EXPECT_FALSE(T::idle(pool, "/f0"));
-  EXPECT_FALSE(T::inuse(pool, "/f0"));
-  EXPECT_EQ(T::inuse_size(pool), demoteThreshold);
-  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum - 1);
+  EXPECT_FALSE(T::inactive(pool, "/f0"));
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
 
-  std::vector<bool> evicted(fileNum, false);
-  evicted[0] = true;
-  for (size_t i = 0; i < 9; i++) {
-    int index = rand() % fileNum;
-    std::string name = "/f" + std::to_string(index);
-    while (evicted[index] || !T::idle(pool, name)) {
-      index = rand() % fileNum;
-      name = "/f" + std::to_string(index);
+  // --- 3. Promote from inactive → active ---
+  std::string inactiveName;
+  for (size_t i = 0; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    if (T::inactive(pool, name)) { inactiveName = name; break; }
+  }
+  ASSERT_FALSE(inactiveName.empty());
+  ASSERT_TRUE(openClose(pool, inactiveName.c_str()));
+  EXPECT_TRUE(T::active(pool, inactiveName));
+  EXPECT_FALSE(T::inactive(pool, inactiveName));
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
+
+  // --- 4. Evict from idle ---
+  std::string idleName;
+  for (size_t i = 0; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    if (T::idle(pool, name)) { idleName = name; break; }
+  }
+  ASSERT_FALSE(idleName.empty());
+  size_t idleBefore = T::idle_size(pool);
+  ASSERT_EQ(0, pool->evict(idleName));
+  EXPECT_FALSE(T::idle(pool, idleName));
+  EXPECT_FALSE(T::inactive(pool, idleName));
+  EXPECT_FALSE(T::active(pool, idleName));
+  EXPECT_EQ(T::idle_size(pool), idleBefore - 1);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum - 1);
+
+  // --- 5. Evict from inactive ---
+  inactiveName.clear();
+  for (size_t i = 0; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    if (T::inactive(pool, name)) { inactiveName = name; break; }
+  }
+  ASSERT_FALSE(inactiveName.empty());
+  size_t inactiveBefore = T::inactive_size(pool);
+  ASSERT_EQ(0, pool->evict(inactiveName));
+  EXPECT_FALSE(T::inactive(pool, inactiveName));
+  EXPECT_EQ(T::inactive_size(pool), inactiveBefore - 1);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum - 2);
+
+  // --- 6. Random access preserves invariant ---
+  // Skip evicted files to avoid re-creating cache entries.
+  std::set<std::string> evicted;
+  evicted.insert(idleName);
+  evicted.insert(inactiveName);
+  size_t totalFiles = fileNum - evicted.size();
+  for (size_t i = 0; i < 200; i++) {
+    int r = rand() % fileNum;
+    std::string name = "/f" + std::to_string(r);
+    if (evicted.count(name)) continue;
+    openClose(pool, name.c_str());
+    if (i % 10 == 0) {
+      photon::thread_usleep(1500);
+      size_t total = T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool);
+      EXPECT_EQ(total, totalFiles);
     }
-    ASSERT_EQ(0, pool->evict(name));
-    evicted[index] = true;
-    EXPECT_FALSE(T::idle(pool, name));
-    EXPECT_EQ(T::idle_size(pool), fileNum - demoteThreshold - 2 - i);
   }
 }
 
-TEST(CachePool, evict_by_size_idle_first) {
-  std::string root = "/tmp/ease/cache/evict_by_size/";
+TEST(CachePool, evict_by_size_cold_first) {
+  std::string root = "/tmp/ease/cache/evict_by_size_cold_first/";
   SetupTestDir(root);
   const uint64_t capacityGB = 1;
-  const size_t demoteThreshold = 5;
+  const size_t activeLimit = 5;
+  const size_t inactiveLimit = 10;
   const size_t fileNum = 40;
   const size_t fileSizeMB = 60;
   const size_t fileSizeBytes = fileSizeMB * 1024 * 1024;
@@ -871,13 +947,14 @@ TEST(CachePool, evict_by_size_idle_first) {
 
   auto pool = dynamic_cast<FileCachePool*>(cachePool);
   ASSERT_NE(nullptr, pool);
-  T::set_demote_threshold(pool, demoteThreshold);
+  T::set_demote_threshold(pool, activeLimit);
+  T::set_inactive_demote_threshold(pool, inactiveLimit);
 
   IOVector buffer(*cacheAllocator);
   buffer.push_back(fileSizeBytes);
 
   for (size_t i = 0; i < fileNum; i++) {
-    photon::thread_usleep(1000);
+    photon::thread_usleep(1500);
     std::string name = "/g" + std::to_string(i);
     auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
     ASSERT_NE(nullptr, store);
@@ -885,25 +962,33 @@ TEST(CachePool, evict_by_size_idle_first) {
     store->release();
   }
 
-  size_t remaining = T::inuse_size(pool) + T::idle_size(pool);
-  EXPECT_LT(remaining, fileNum);
-  EXPECT_LE(T::inuse_size(pool), (size_t)demoteThreshold);
+  // After writing 40 x 60MB = 2.4GB with 1GB capacity, eviction should have
+  // kicked in.  Cold tiers (idle first, then inactive) are evicted before active.
+  EXPECT_LE(T::active_size(pool), activeLimit);
+  size_t totalRemaining = T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool);
+  EXPECT_LT(totalRemaining, fileNum);
 
-  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+  // The most recent active files must survive eviction
+  for (size_t i = fileNum - activeLimit; i < fileNum; i++) {
     std::string name = "/g" + std::to_string(i);
-    EXPECT_TRUE(T::inuse(pool, name)) << name << " should still be in hot";
-    EXPECT_FALSE(T::idle(pool, name)) << name << " must not be in idle";
+    EXPECT_TRUE(T::active(pool, name)) << name << " should still be in active";
   }
 
-  // Write a new file to trigger eviction, the idle file should be evicted first
+  // Idle tier should be drained first — if any files remain in cold tiers,
+  // idle should have fewer or equal entries compared to inactive.
+  EXPECT_LE(T::idle_size(pool), T::inactive_size(pool));
+
+  // Write one more file to trigger another round of eviction
   std::string name = "/g" + std::to_string(fileNum);
   auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
   ASSERT_NE(nullptr, store);
   store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
   store->release();
-  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+
+  // Active files must still survive after the extra eviction round
+  for (size_t i = fileNum - activeLimit; i < fileNum; i++) {
     std::string name = "/g" + std::to_string(i);
-    bool existed = T::inuse(pool, name) || T::idle(pool, name);
+    bool existed = T::active(pool, name) || T::inactive(pool, name);
     EXPECT_TRUE(existed) << name << " must still exist";
   }
 }
@@ -940,7 +1025,7 @@ TEST(CachePool, DISABLED_test_mem_usage) {
   SetupTestDir(root);
   const uint64_t capacityGB = 1;
   const size_t fileNum = 10'000'000;
-  const size_t inuse = 1'000'000;
+  const size_t activeNum = 100'000;
 
   auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
   auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
@@ -964,11 +1049,11 @@ TEST(CachePool, DISABLED_test_mem_usage) {
     store->release();
     if (i % 100'000 == 0) {
       LOG_INFO("Opened ` files. current: ` KiB.", i+1, get_physical_memory_KiB());
-      LOG_INFO("inuse size `, idle size `", T::inuse_size(pool), T::idle_size(pool));
+      LOG_INFO("active size `, inactive size `", T::active_size(pool), T::inactive_size(pool));
     }
   }
-  EXPECT_EQ(inuse, T::inuse_size(pool));
-  EXPECT_EQ(fileNum - inuse, T::idle_size(pool));
+  EXPECT_EQ(activeNum, T::active_size(pool));
+  EXPECT_EQ(fileNum - activeNum, T::inactive_size(pool) + T::idle_size(pool));
 
   photon::thread_sleep(10);
   malloc_trim(0);
@@ -986,6 +1071,7 @@ int main(int argc, char** argv) {
   log_output_level = ALOG_ERROR;
   // photon::vcpu_init();
   ::testing::InitGoogleTest(&argc, argv);
+  srand(time(nullptr));
 
   photon::init();
   DEFER(photon::fini());

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -720,10 +720,12 @@ TEST(CachePool, open_same_file) {
 // Friend accessor — declared as friend in FileCachePool.
 struct FileCachePoolTest {
   static void set_demote_threshold(FileCachePool *p, uint32_t limit) {
-    p->thresholds_[0] = limit;
+    p->thresholds_[0].min = limit;
+    p->thresholds_[0].value = limit;
   }
   static void set_inactive_demote_threshold(FileCachePool *p, uint32_t limit) {
-    p->thresholds_[1] = limit;
+    p->thresholds_[1].min = limit;
+    p->thresholds_[1].value = limit;
   }
   static size_t active_size(FileCachePool *p) { return p->lru_.size(); }
   static size_t inactive_size(FileCachePool *p) { return p->inactiveTier_.size(); }


### PR DESCRIPTION
Extend FileCachePool to three-tier cascade (active→inactive→idle) with adaptive threshold, unified under ColdCacheTier base class for cold tier management.

* active: LRU-ordered hot entries currently open or recently accessed
* inactive: LRU-ordered entries currently closed
* idle: unordered cold entries, no LRU ordering, kept only paths in memory