### PR TITLE
fix(cache): cap actualEvict by totalUsed_ to prevent eviction deadloop

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -255,12 +255,20 @@ void FileCachePool::eviction() {
     evictByCache = totalUsed_ - waterMark_;
   }
 
-  auto actualEvict = static_cast<int64_t>(std::max(evictByCache, evictByDisk));
+  auto actualEvict = std::min(
+    static_cast<int64_t>(std::max(evictByCache, evictByDisk)),
+    totalUsed_
+  );
+
   if (actualEvict <= 0) {
     return;
   }
 
   isFull_ = true;
+
+  if (!lru_.empty() && !exit_) {
+    LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
+  }
 
   // Phase 1: evict from idle tier first.
   actualEvict -= evictIdleWhenFull(actualEvict);


### PR DESCRIPTION
## Problem

FileCachePool::eviction() computes the eviction target as:

    actualEvict = max(evictByCache, evictByDisk)

evictByDisk is derived from the whole-disk free space, which is not under the cache pool's control.  When other processes occupy the disk, evictByDisk can exceed totalUsed_ — the total bytes the pool actually owns.  After truncating every cache file to zero, actualEvict is still positive while the LRU holds only entries with openCount > 0 and size == 0.  These entries are moved to the LRU head on every iteration without reducing actualEvict, causing an infinite loop.

Concrete example:

  diskAvailInBytes_ = 150 MB  (configured minimum free space)
  disk free         =  50 MB  (occupied by other processes)
  evictByDisk       = 100 MB
  totalUsed_        =  30 MB  (all cache pool owns)

  actualEvict starts at 100 MB.  After clearing all 30 MB of cache,
  actualEvict = 70 MB > 0, but the LRU has no more evictable entries.

## Fix

Cap actualEvict to at most totalUsed_ before entering the loop:

    actualEvict = min(max(evictByCache, evictByDisk), totalUsed_)

The cache pool cannot free more than it owns.  With this bound, after all truncations complete, actualEvict ≤ 0 and the loop exits normally.

A diagnostic log line is added at loop entry to aid future analysis.

## Verification

Reproduced with a 200 MB ext4 loop device as the cache directory. 120 MB is pre-occupied by a noise file, leaving ~50 MB free against a 150 MB diskAvailInBytes_ threshold.  Three cache files are kept open (openCount > 0) to hold path-B entries in the LRU after truncation.  Without the fix eviction() never returns; with the fix it exits in O(n) iterations.