### PR TITLE
[Pick][0.7 to 0.8] | estring: fix heap-buffer-overflow in _split::find_part (#1217) 

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -241,6 +241,7 @@ public:
         estring_view find_part(const char* begin) const
         {
             auto end = &*str.end();
+            if (begin >= end) return {};
             auto& separator = get_sep_ref(sep);
 
             if (consecutive_merge)


### PR DESCRIPTION
> estring: fix heap-buffer-overflow in _split::find_part (#1217)
Generated by Auto PR, by cherry-pick related commits