### PR TITLE
[Pick][0.9 to main] | estring: fix heap-buffer-overflow in _split::find_part (#1217) (#1218) (#1219) 

### DIFF
--- a/common/estring.h
+++ b/common/estring.h
@@ -239,6 +239,7 @@ public:
         estring_view find_part(const char* begin) const
         {
             auto end = &*str.end();
+            if (begin >= end) return {};
             auto& separator = get_sep_ref(sep);
 
             if (consecutive_merge)


### PR DESCRIPTION
> estring: fix heap-buffer-overflow in _split::find_part (#1217) (#1218) (#1219)

Co-authored-by: Bob Chen <beef9999@qq.com>
Generated by Auto PR, by cherry-pick related commits