### PR TITLE
add xxhash32 implementation, test, and AGENTS.md coding principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md
+
+## Coding Principles
+
+### .h and .cpp files
+- .h files should include only things that are supposed to be shared with outside. Try best to minimize other things in .h files.
+- For classes defined entirely within a .cpp file (not exposed via header), write all method bodies inline inside the class body. Do not separate declarations and out-of-class definitions. Let all members be public.
+- .cc extension is used for assistant programs that are not included in normal compilation.
+
+### Logging
+- Log lines can be written up to 2x the normal code line width, reducing unnecessary line breaks.
+
+#### Format string
+- Use backtick (`` ` ``) as a variable placeholder inside format strings to separate text from variables. Example: ``LOG_WARN("count ` total ", VALUE(count), VALUE(total)``.
+- Trailing backticks at the end of a format string are unnecessary — extra arguments beyond the number of backticks are output automatically. Example: ``"failed, ", VALUE(st)`` not ``"failed, `", VALUE(st)``.
+- Formats are not actually defined in format-strings, instead they are defined by wrappers of the variables. Example: ``LOG_WARN("count ` total ", DEC(count).comma(true), DEC(total).comma(true)`` will output the integers with commas.
+- Users can define custom output operators for their variables / objects.
+
+#### VALUE() macro
+- ``VALUE(x)`` outputs both the variable name and its value (e.g. ``VALUE(st)`` → ``st=3``), which aids debugging.
+- Never add redundant name prefixes before ``VALUE()`` since it already includes the variable name. Example: use ``"failed, ", VALUE(st)`` not ``"failed, st=", VALUE(st)``.
+- Use judgment on whether ``VALUE()`` is needed: opaque values like status codes benefit from ``VALUE()`` (e.g. ``VALUE(st)``), but context-clear values like loop indices or counts can omit it.
+
+#### LOG_ERROR_RETURN / LOG_ERRNO_RETURN
+- When ``LOG_ERROR`` and ``return`` are used together (possibly with ``errno`` set in between), prefer ``LOG_ERROR_RETURN(errno_val, retval, ...)`` instead.
+- If the log message should also print the current errno, use ``LOG_ERRNO_RETURN(errno_val, retval, ...)``.
+- **Log at every error detection point**: every place that detects an error (sets errno and returns an error code) must use ``LOG_ERROR_RETURN`` to output a log and set errno — no silent error returns.
+- **Exception — simple wrappers don't repeat**: if a function is a thin wrapper that just propagates the return value of a callee which already logged the error, do not log again or re-set errno. Example: `if (sub_func() < 0) return -1;` where `sub_func` already used ``LOG_ERROR_RETURN``.
+- **Abstraction boundary = new log**: when the abstraction level changes (e.g. QAT hardware error → LZ4 compress failure), a new ``LOG_ERROR_RETURN`` is appropriate to re-describe the error at the higher level, and errno may be re-set. If the lower layer already set a meaningful errno, use ``LOG_ERRNO_RETURN`` to output it.
+- **if + LOG_ERROR_RETURN on separate lines**: when an `if` body consists solely of `LOG_ERROR_RETURN` or `LOG_ERRNO_RETURN`, omit braces and put the macro on its own line. Example:
+  ```cpp
+  if (!ptr)
+      LOG_ERROR_RETURN(ENOMEM, -1, "allocation failed");
+  ```
+  Not: `if (!ptr) { LOG_ERROR_RETURN(ENOMEM, -1, "allocation failed"); }`
+
+### RAII
+Use RAII as long as it is not troublesome.
+
+#### DEFER macro usage
+- Use `DEFER` macro for resource cleanup in initialization functions (e.g. `create()` patterns) to avoid repetitive manual cleanup on each error path.
+- Use the `bool ok = false` pattern: each DEFER checks `!ok` before cleaning up; on success set `ok = true` to cancel all deferred cleanups.
+- When multiple consecutive `DEFER` statements serve the same logical purpose, combine them into a single `DEFER({ ... })` block.
+
+#### SCOPED_LOCK
+- Use `SCOPED_LOCK(lock)` instead of manual `lock.lock()`/`lock.unlock()` to ensure the lock is always released, even on early returns or exceptions.
+- Applies to any lock type that `photon::locker` supports (spinlock, mutex, etc.).
+
+### Types
+- Prefer fixed-width integer types (`uint8_t`, `uint16_t`, `uint32_t`, `uint64_t`, and their signed counterparts) over verbose built-in names (`unsigned char`, `unsigned short`, `unsigned int`, `unsigned long`, `unsigned long long`).
+- The only common exceptions are `size_t` for byte counts / array indices (where the width tracks the address space) and `int` for small loop counters or values where a specific width has no semantic meaning.
+- For reading/writing a small fixed number of bytes (1, 2, 4, or 8) at a pointer, prefer a C-style cast over `memcpy`/`memset`/`std::copy`. Example: `*(uint32_t*)dst = value;` to write, `uint32_t v = *(const uint32_t*)src;` to read.
+- This is clearer and produces tighter code than the equivalent `memcpy(&v, src, 4)`, and avoids the verbosity of `*reinterpret_cast<uint32_t*>(dst)` for such a common idiom.
+- `memset`/`memcpy` remain appropriate for variable-length data and for zeroing structures larger than 8 bytes.
+- Alignment and byte order are the caller's responsibility; on little-endian hosts (x86_64, arm64) this reads/writes little-endian values directly, which matches many network and on-disk wire formats.
+
+## Build & Test
+
+### Prerequisites
+
+- Debian/Ubuntu
+```bash
+sudo apt-get install git cmake libssl-dev libcurl4-openssl-dev libaio-dev zlib1g-dev libgtest-dev libgmock-dev libgflags-dev libfuse-dev libgsasl7-dev nasm
+```
+
+- RHEL/CentOS/Fedora
+```bash
+sudo dnf install git cmake openssl-devel libcurl-devel libaio-devel zlib-devel gtest-devel gmock-devel gflags-devel fuse-devel gsasl-devel nasm
+```
+
+- macOS
+```bash
+brew install cmake openssl@1.1 pkg-config gflags googletest gsasl nasm
+```
+
+### Configure
+```bash
+# Linux
+cmake -B build -D PHOTON_BUILD_TESTING=ON -D CMAKE_BUILD_TYPE=MinSizeRel
+
+# macOS
+cmake -B build -D PHOTON_BUILD_TESTING=ON -D CMAKE_BUILD_TYPE=MinSizeRel -D PHOTON_CXX_STANDARD=17 -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1
+```
+
+### Build
+```bash
+cmake --build build -j 8
+# Output: build/output/
+```
+
+### Test
+```bash
+cd build && ctest
+```

--- a/common/checksum/test/CMakeLists.txt
+++ b/common/checksum/test/CMakeLists.txt
@@ -15,3 +15,7 @@ add_executable(test-digest test_digest.cpp)
 target_include_directories(test-digest PRIVATE ${OPENSSL_INCLUDE_DIRS})
 target_link_libraries(test-digest PRIVATE photon_shared)
 add_test(NAME test-digest COMMAND $<TARGET_FILE:test-digest>)
+
+add_executable(test-xxhash test_xxhash.cpp)
+target_link_libraries(test-xxhash PRIVATE photon_shared)
+add_test(NAME test-xxhash COMMAND $<TARGET_FILE:test-xxhash>)

--- a/common/checksum/test/test_xxhash.cpp
+++ b/common/checksum/test/test_xxhash.cpp
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <photon/common/checksum/xxhash.h>
+#include <cstring>
+#include <vector>
+#include "../../../test/gtest.h"
+
+// Reference vectors verified against official xxHash implementation.
+struct TestCase {
+    uint32_t expected;
+    uint32_t seed;
+    const char* input;
+};
+
+static const TestCase cases[] = {
+    {0x02CC5D05u, 0,  ""},
+    {0x0B2CB792u, 1,  ""},
+    {0x550D7456u, 0,  "a"},
+    {0x32D153FFu, 0,  "abc"},
+    {0x63A14D5Fu, 0,  "abcdefghijklmnopqrstuvwxyz"},
+    {0xD5CCFE8Eu, 42, "abcdefghijklmnopqrstuvwxyz"},
+    {0xC2C45B69u, 0,  "0123456789abcdef"},
+    {0xCC79B217u, 0,  "0123456789abcdefg"},
+    {0xEB888D30u, 0,  "0123456789abcdef0123456789abcdef"},
+};
+
+TEST(XxHash32, ReferenceVectors) {
+    for (auto& c : cases) {
+        auto h = xxhash32_sw((const uint8_t*)c.input, strlen(c.input), c.seed);
+        EXPECT_EQ(h, c.expected)
+            << "input=\"" << c.input << "\" seed=" << c.seed;
+    }
+}
+
+TEST(XxHash32, Deterministic) {
+    const char* s = "The quick brown fox jumps over the lazy dog";
+    auto h1 = xxhash32_sw((const uint8_t*)s, 43, 0);
+    auto h2 = xxhash32_sw((const uint8_t*)s, 43, 0);
+    EXPECT_EQ(h1, h2);
+}
+
+TEST(XxHash32, SeedChangesResult) {
+    const char* s = "hello world";
+    auto h0 = xxhash32_sw((const uint8_t*)s, 11, 0);
+    auto h1 = xxhash32_sw((const uint8_t*)s, 11, 1);
+    EXPECT_NE(h0, h1);
+}
+
+TEST(XxHash32, LargeBuffer) {
+    std::vector<uint8_t> buf(1024 * 1024);
+    for (size_t i = 0; i < buf.size(); i++)
+        buf[i] = (uint8_t)(i & 0xFF);
+    auto h = xxhash32_sw(buf.data(), buf.size(), 12345);
+    EXPECT_NE(h, 0u);
+    EXPECT_EQ(xxhash32_sw(buf.data(), buf.size(), 12345), h);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/common/checksum/xxhash.cpp
+++ b/common/checksum/xxhash.cpp
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "xxhash.h"
+
+uint32_t xxhash32_sw(const uint8_t* data, size_t len, uint32_t seed) {
+    constexpr uint32_t PRIME32_1 = 0x9E3779B1;
+    constexpr uint32_t PRIME32_2 = 0x85EBCA77;
+    constexpr uint32_t PRIME32_3 = 0xC2B2AE3D;
+    constexpr uint32_t PRIME32_4 = 0x27D4EB2F;
+    constexpr uint32_t PRIME32_5 = 0x165667B1;
+
+    auto rotl = [](uint32_t v, int s) { return (v << s) | (v >> (32 - s)); };
+    auto round = [&](uint32_t acc, uint32_t val) {
+        acc += val * PRIME32_2;
+        acc = rotl(acc, 13);
+        acc *= PRIME32_1;
+        return acc;
+    };
+    auto read32 = [](const uint8_t* p) -> uint32_t {
+        return (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+               ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    };
+
+    auto* ptr = data;
+    uint32_t h32;
+
+    if (len >= 16) {
+        uint32_t v1 = seed + PRIME32_1 + PRIME32_2;
+        uint32_t v2 = seed + PRIME32_2;
+        uint32_t v3 = seed;
+        uint32_t v4 = seed - PRIME32_1;
+        size_t remaining = len;
+        while (remaining >= 16) {
+            v1 = round(v1, read32(ptr));    ptr += 4;
+            v2 = round(v2, read32(ptr));    ptr += 4;
+            v3 = round(v3, read32(ptr));    ptr += 4;
+            v4 = round(v4, read32(ptr));    ptr += 4;
+            remaining -= 16;
+        }
+        h32 = rotl(v1, 1) + rotl(v2, 7) + rotl(v3, 12) + rotl(v4, 18);
+    } else {
+        h32 = seed + PRIME32_5;
+    }
+
+    h32 += (uint32_t)len;
+
+    size_t remaining = len & 15;
+    while (remaining >= 4) {
+        h32 += read32(ptr) * PRIME32_3;
+        h32 = rotl(h32, 17) * PRIME32_4;
+        ptr += 4;
+        remaining -= 4;
+    }
+    while (remaining >= 1) {
+        h32 += (*ptr) * PRIME32_5;
+        h32 = rotl(h32, 11) * PRIME32_1;
+        ptr += 1;
+        remaining -= 1;
+    }
+
+    h32 ^= h32 >> 15;
+    h32 *= PRIME32_2;
+    h32 ^= h32 >> 13;
+    h32 *= PRIME32_3;
+    h32 ^= h32 >> 16;
+    return h32;
+}

--- a/common/checksum/xxhash.h
+++ b/common/checksum/xxhash.h
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#pragma once
+#include <cstdint>
+#include <cstddef>
+
+uint32_t xxhash32_sw(const uint8_t* data, size_t len, uint32_t seed = 0);

--- a/include/photon/common/checksum/xxhash.h
+++ b/include/photon/common/checksum/xxhash.h
@@ -1,0 +1,1 @@
+../../../../common/checksum/xxhash.h


### PR DESCRIPTION
- Add software xxhash32 implementation (common/checksum/xxhash.h/cpp)
- Add gtest-based xxhash32 test with reference vectors (common/checksum/test/test_xxhash.cpp)
- Add AGENTS.md with coding principles and build/test instructions