### PR TITLE
[Pick][0.7 to 0.8] | copy CI scripts from release/0.8 to 0.7 (#1226) 

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -47,6 +47,7 @@ jobs:
             -D PHOTON_ENABLE_FUSE=ON \
             -D PHOTON_ENABLE_LIBCURL=ON \
             -D PHOTON_ENABLE_EXTFS=ON
+<<<<<<< HEAD
           cmake --build build -j $(nproc) -- VERBOSE=1
 
       - name: Build-Debug-1121-C++20
@@ -77,6 +78,8 @@ jobs:
             -D PHOTON_ENABLE_FUSE=ON \
             -D PHOTON_ENABLE_LIBCURL=ON \
             -D PHOTON_ENABLE_EXTFS=ON
+=======
+>>>>>>> 729a439 (copy CI scripts from release/0.8 to 0.7 (#1226))
           cmake --build build -j $(nproc) -- VERBOSE=1
 
       - name: Test

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -35,10 +35,13 @@ jobs:
         run: |
           export PHOTON_CI_EV_ENGINE=io_uring
           cd build && ctest -E test-lockfree --timeout 3600 -V
+<<<<<<< HEAD
       - name: Test epoll_ng
         run: |
           export PHOTON_CI_EV_ENGINE=epoll_ng
           cd build && ctest -E test-lockfree --timeout 3600 -V
+=======
+>>>>>>> 729a439 (copy CI scripts from release/0.8 to 0.7 (#1226))
 
   gcc921:
     runs-on: ubuntu-latest
@@ -71,10 +74,13 @@ jobs:
         run: |
           export PHOTON_CI_EV_ENGINE=io_uring
           cd build && ctest -E test-lockfree --timeout 3600 -V
+<<<<<<< HEAD
       - name: Test epoll_ng
         run: |
           export PHOTON_CI_EV_ENGINE=epoll_ng
           cd build && ctest -E test-lockfree --timeout 3600 -V
+=======
+>>>>>>> 729a439 (copy CI scripts from release/0.8 to 0.7 (#1226))
 
   gcc1031:
     runs-on: ubuntu-latest
@@ -107,6 +113,7 @@ jobs:
         run: |
           export PHOTON_CI_EV_ENGINE=io_uring
           cd build && ctest -E test-lockfree --timeout 3600 -V
+<<<<<<< HEAD
       - name: Test epoll_ng
         run: |
           export PHOTON_CI_EV_ENGINE=epoll_ng
@@ -197,3 +204,5 @@ jobs:
             -D PHOTON_BUILD_TESTING=ON \
             -D PHOTON_ENABLE_FSTACK_DPDK=ON
           cmake --build build -j $(nproc) -t fstack-dpdk-demo
+=======
+>>>>>>> 729a439 (copy CI scripts from release/0.8 to 0.7 (#1226))


### PR DESCRIPTION
> copy CI scripts from release/0.8 to 0.7 (#1226)

* copy CI scripts from release/0.8

* Since 0.7 is not able to build with C++20 standard, and has no fstack features, remove some related CI tests

---------

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits