### PR TITLE
Add architecture documentation in AGENTS.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+This file contains the coding conventions, build instructions, and common pitfalls that apply across the repository. Detailed architecture and per-module design documentation lives in `doc/docs/` — see the index at the bottom.
+
 ## Coding Principles
 
 ### .h and .cpp files
@@ -54,6 +56,31 @@ Use RAII as long as it is not troublesome.
 - `memset`/`memcpy` remain appropriate for variable-length data and for zeroing structures larger than 8 bytes.
 - Alignment and byte order are the caller's responsibility; on little-endian hosts (x86_64, arm64) this reads/writes little-endian values directly, which matches many network and on-disk wire formats.
 
+### String concatenation
+- When concatenating multiple parts into a string, prefer `estring().appends(a, b, c)` over `std::string(a) + b + c`.
+- `estring::appends` avoids creating intermediate `std::string` temporaries and accepts mixed types (string_view, integers, etc.) without manual conversion.
+- Example: `std::string key = estring().appends(host, ":", port);` not `std::string key = std::string(host) + ":" + std::to_string(port);`
+- For conditional parts, use `estring::make_conditional_cat_list(cond, parts...)` which appends only when `cond` is true:
+  ```cpp
+  estring().appends(
+      path,
+      estring::make_conditional_cat_list(has_query, "?", query));
+  ```
+
+### IStream: `read`/`write` vs `recv`/`send`
+- `read(buf, count)` and `write(buf, count)` guarantee completion of the full `count` bytes unless an error or EOF occurs. They are atomic from the caller's perspective.
+- `recv(buf, count)` and `send(buf, count)` perform a single receive/send operation and may return fewer bytes than requested.
+- When an exact amount must be transferred, prefer `read`/`write`. Use `recv`/`send` only when partial transfer is acceptable.
+
+### Code Modification
+- Separate moves from changes: when moving code, only move. Do not rename, restructure, or optimize at the same time.
+- Understand the original purpose before making changes. The existing layout is not accidental.
+- When modifying or optimizing existing code, respect the original design decisions — data structures, interfaces, implementation patterns, etc. Only change what's necessary.
+
+### Trimming white space(s)
+- Trim trailing white space(s) of every line.
+- Trim excessive new lines at the end of every file.
+
 ## Build & Test
 
 ### Prerequisites
@@ -92,3 +119,78 @@ cmake --build build -j 8
 ```bash
 cd build && ctest
 ```
+
+## Include Paths
+
+The `include/photon/` directory contains symlinks to source headers, mirroring the source tree structure. All headers are included as:
+
+```cpp
+#include <photon/photon.h>
+#include <photon/common/alog.h>
+#include <photon/thread/thread.h>
+#include <photon/net/socket.h>
+```
+
+**Internal includes** (within the same module) may use relative paths: `#include "../alog.h"`. Cross-module includes always use `<photon/module/header.h>`.
+
+The build system sets `include/` as a public include directory for `photon_shared` and `photon_static` targets. Test and example targets link against `photon_shared` to inherit the include path.
+
+## Testing
+
+**Framework:** Google Test (gtest). Tests include `../../test/gtest.h` which wraps `<gtest/gtest.h>` and suppresses sign-compare warnings. Some tests also include `../../test/ci-tools.h` for CI helpers.
+
+**Location:** Each module has a `test/` subdirectory (e.g., `common/test/`, `thread/test/`, `net/http/test/`). Test files are named `test_<feature>.cpp` or `test-<feature>.cpp`.
+
+**CMake pattern:** Each `test/` directory has its own `CMakeLists.txt` following this template:
+
+```cmake
+add_executable(test-<name> <name>.cpp)
+target_link_libraries(test-<name> PRIVATE photon_shared)
+add_test(NAME test-<name> COMMAND $<TARGET_FILE:test-<name>>)
+```
+
+**To add a new test:**
+1. Create `test_foo.cpp` in the appropriate `<module>/test/` directory
+2. Include module headers via relative paths (`"../foo.h"`) and cross-module headers via `<photon/module/header.h>`
+3. Add the three-line CMake block above to that directory's `CMakeLists.txt`
+4. Build and run: `cmake --build build -j 8 && cd build && ctest -R test-foo`
+
+**Test initialization:** Tests that exercise coroutine or I/O features must call `photon::init()` / `photon::fini()` in their `main()` or in a gtest fixture's `SetUp`/`TearDown`.
+
+## Common Pitfalls
+
+**Using `std::mutex` instead of `photon::mutex` in coroutines:** `std::mutex` blocks the OS thread (vCPU), stalling all coroutines on that vCPU. Always use `photon::mutex` (or `photon_std::mutex`) inside photon threads.
+
+**Calling photon APIs before `photon::init()`:** The current OS thread must be initialized as a vCPU before any photon API (thread creation, sync primitives, I/O) can be used. Call `photon::init()` first. If using WorkPool, each worker OS thread is initialized automatically.
+
+**Forgetting `photon::fini()` on exit:** Skips cleanup of ancillary threads (timestamp updater, etc.) and registered `fini_hook` callbacks.
+
+**Blocking syscalls in coroutines:** Direct `sleep()`, `poll()`, `select()`, or blocking `read()`/`write()` on non-photon file descriptors will block the vCPU. Use photon's coroutine-aware I/O or `thread_usleep()` instead.
+
+**Stack overflow:** Default coroutine stack is 8MB. Deep recursion or large stack-allocated buffers may exceed it. Use `thread_create11()` with an explicit `stack_size` parameter for coroutines that need more.
+
+## Conventions
+
+- **Ownership:** `ownership` parameter (typically `bool`) controls whether wrapper objects delete the wrapped object on destruction
+- **Timeout:** All I/O operations accept `Timeout` objects integrating with `photon::now` (microsecond-precision global timestamp)
+- **Error handling:** Functions return -1 or nullptr on error, set `errno`, and log via `LOG_ERROR_RETURN`
+- **Thread safety:** Photon sync primitives (mutex, semaphore, condition_variable) are coroutine-aware; std:: equivalents block the OS thread
+
+## Detailed Documentation
+
+Descriptive architecture and per-module design documentation lives under `doc/docs/` (source for the Docusaurus site). Read these on demand when working on the corresponding area:
+
+| When working on... | Read |
+|--------------------|------|
+| Overall architecture, module relationships | `doc/docs/introduction/photon-architecture.md` |
+| Coroutine runtime, scheduler, sync primitives | `doc/docs/api/thread.md`, `doc/docs/api/lock-and-synchronization.md`, `doc/docs/api/vcpu-and-multicore.md` |
+| Event engines (epoll / io_uring / kqueue), signal handling | `doc/docs/api/vcpu-and-multicore.md` (Event Engines section) |
+| Socket, HTTP client/server, TLS, connection pool | `doc/docs/api/network.md` |
+| Filesystem VFS, local fs, HTTP fs, cache layer | `doc/docs/api/filesystem-and-io.md` |
+| RPC framework, zero-copy serialization | `doc/docs/api/rpc.md` |
+| Logging, string utilities, containers, delegates | `doc/docs/api/common.md` |
+| Redis / OSS / simple_dom (JSON/XML/YAML) | `doc/docs/ecosystem/overview.md` |
+| Delegate / Callback internals | `doc/docs/api/delegate_callback.md` |
+| std-compatible API | `doc/docs/api/std-compatible-api.md` |
+| Building and integrating | `doc/docs/introduction/how-to-build.md`, `doc/docs/introduction/how-to-integrate.md` |
+| Debugging | `doc/docs/miscellaneous/debugging.md` |

--- a/doc/docs/api/common.md
+++ b/doc/docs/api/common.md
@@ -1,0 +1,230 @@
+---
+sidebar_position: 1
+toc_max_heading_level: 4
+---
+
+# Common Utilities
+
+The `common/` module provides foundational utilities used throughout PhotonLibOS: logging, string handling, containers, callable abstractions, I/O vectors, async helpers, checksums, and more.
+
+### Namespace
+
+`photon::`
+
+### Headers
+
+All headers are under `<photon/common/...>`.
+
+## Logging
+
+`<photon/common/alog.h>` — type-safe, compile-time formatted logging system.
+
+### Macros
+
+- Level macros: `LOG_DEBUG`, `LOG_INFO`, `LOG_WARN`, `LOG_ERROR`, `LOG_FATAL`
+- Rate-limiting variants: `LOG_EVERY_T`, `LOG_EVERY_N`, `LOG_FIRST_N`, `LOG_FIRST_N_EVERY_T`
+- Error-return helpers: `LOG_ERROR_RETURN(errno, retval, ...)`, `LOG_ERRNO_RETURN(errno, retval, ...)`
+- Value introspection: `VALUE(x)` prints `x=<value>`, useful for debugging opaque values
+
+### Format strings
+
+alog uses backtick-based format strings processed at compile time, not printf-style runtime parsing.
+
+- Backtick (`` ` ``) is the variable placeholder. Formats are defined by wrappers around the variables, not by the format string itself.
+- Trailing backticks are unnecessary — extra arguments beyond the number of backticks are output automatically.
+
+```cpp
+LOG_WARN("count ` total ", DEC(count).comma(true), DEC(total).comma(true));
+LOG_ERROR("failed, ", VALUE(st));   // no trailing backtick needed
+```
+
+### Formatters
+
+| Wrapper | Output |
+|---------|--------|
+| `HEX(x)` | Hexadecimal |
+| `DEC(x)` | Decimal, with optional `.comma(true)` |
+| `OCT(x)` | Octal |
+| `BIN(x)` | Binary |
+| `FP(x)` | Floating point |
+
+### Backends
+
+`ILogOutput` is the abstract interface. Built-in backends write to file, stderr, stdout, or an async queue. Set via `set_log_output()`.
+
+## String Utilities
+
+### estring
+
+`<photon/common/estring.h>` — `estring` extends `std::string`, `estring_view` extends `std::string_view`.
+
+Adds: trim, case-insensitive compare, numeric conversion, lazy `split()`, and `appends()` for efficient concatenation.
+
+```cpp
+std::string key = estring().appends(host, ":", port);
+
+estring().appends(
+    path,
+    estring::make_conditional_cat_list(has_query, "?", query));
+```
+
+`estring::appends` avoids creating intermediate `std::string` temporaries and accepts mixed types (string_view, integers, etc.) without manual conversion.
+
+### Compile-time strings
+
+`<photon/common/conststr.h>` — compile-time string manipulation: `TString`, `TStrArray`, `DEFINE_ENUM_STR`.
+
+### String builder
+
+`<photon/common/strbuilder.h>` — stack-allocated string builder `strBuilder<N>`.
+
+### String-keyed containers
+
+`<photon/common/string-keyed.h>` — maps and sets keyed by string that avoid constructing a temporary `std::string` on lookup: `unordered_map_string_key`, `map_string_key`, `unordered_map_string_kv`.
+
+## Containers and Data Structures
+
+### Intrusive list
+
+`<photon/common/intrusive_list.h>` — intrusive doubly-linked list with `round_robin_next()` and predicate-based splitting. No per-node heap allocation.
+
+### Ring buffer
+
+`<photon/common/ring.h>`:
+- `RingQueue<T>` — SPSC blocking queue
+- `RingBuffer` — char-specialized ring with `readv`/`writev`
+
+### Lock-free queues
+
+`<photon/common/lockfree_queue.h>` — lock-free MPMC, batch MPMC, and SPSC queues. `RingChannel<QueueType>` adds photon-aware blocking with a configurable yield-then-semaphore strategy. Turn-based slot marking avoids ABA problems.
+
+### Consistent hash
+
+`<photon/common/consistent-hash-map.h>` — vector-based consistent hash ring.
+
+### Sorted span
+
+`<photon/common/ordered_span.h>` — sorted span with binary search insert/lookup.
+
+### TTL containers
+
+`<photon/common/expirecontainer.h>` — keyed containers with auto-expiration driven by a photon timer. `ObjectCache` provides ref-counted `Borrow` RAII access to cached objects.
+
+### Identity pool
+
+`<photon/common/identity-pool.h>` — object pool with constructor/destructor callbacks and autoscaling. Used as the backing store for `ThreadPool`.
+
+## Callable Abstractions
+
+### Delegate
+
+`<photon/common/callback.h>` — `Delegate<R, Ts...>` is a zero-overhead callable wrapper for free functions, member functions, and lambdas. It has no heap allocation and no type erasure.
+
+- `Callback<Ts...>` is an alias for `Delegate<int, Ts...>`.
+- `Closure<ARGS...>` is a self-deleting callback.
+- `TempDelegate` binds to a temporary lambda.
+
+Member functions are dispatched with vtable-aware handling on x86_64 and aarch64.
+
+### Delegates facade
+
+`<photon/common/delegates.h>` — `Delegates<Convs...>` is a type-safe delegate facade with `DEFINE_DELEGATE_FUNCTION` macros for compile-time method dispatch.
+
+### PMF helper
+
+`<photon/common/PMF.h>` — `get_member_function_address()` extracts a raw function pointer from a member function pointer, handling the vtable layout on x86_64 and aarch64.
+
+## I/O and Streams
+
+### IStream
+
+`<photon/common/stream.h>` — abstract `read`/`readv`/`write`/`writev` interface. Includes `ReadAll` RAII helper and function pointer introspection (`_and_read`, `_and_write`) to detect whether the underlying implementation actually performs I/O.
+
+### IMessage
+
+`<photon/common/message.h>` — datagram send/recv over iovecs.
+
+### iovector
+
+`<photon/common/iovector.h>` — `iovector_view` (non-owning) and `iovector` (owning). Rich iovec array manipulation: extract, slice, pipe, internal allocator. Used throughout the RPC and HTTP layers for zero-copy I/O.
+
+### IOAlloc
+
+`<photon/common/io-alloc.h>` — callback-based buffer allocator.
+
+### IMessageChannel
+
+`<photon/common/message-channel.h>` — message passing with `OUT_OF_ORDER`, `PIPELINING`, `ROUND_TRIP` flags.
+
+## Core Utilities
+
+### DEFER and scope helpers
+
+`<photon/common/utility.h>`:
+- `DEFER` — scope-exit cleanup
+- `NewObj<T>` — two-phase construction pattern
+- `likely` / `unlikely` — branch hints
+- alignment and saturating arithmetic helpers
+- `WITH` / `WITH_Release` — scoped resource blocks
+
+### Timeout
+
+`<photon/common/timeout.h>` — `Timeout` is an expiration timer based on `photon::now` (microsecond-precision global timestamp). Query via `expired()`, `timeout_us()`, `timeout_ms()`, `timeout_s()`.
+
+### retval
+
+`<photon/common/retval.h>` — `retval<T>` wraps a return value and captures the current `errno`.
+
+### Range lock
+
+`<photon/common/range-lock.h>` — `RangeLock` provides byte-range locking with conflict detection. `ScopedRangeLock` is the RAII guard.
+
+### Throttle
+
+`<photon/common/throttle.h>` — token bucket rate limiter with priority levels.
+
+### SingleFlight
+
+`<photon/common/singleflight.h>` — request coalescing to prevent cache stampedes.
+
+### RCUPtr
+
+`<photon/common/rcuptr.h>` — `RCUPtr<T>` is a userspace QSBR RCU-protected pointer.
+
+### Generator
+
+`<photon/common/generator.h>` — `Generator<Derived, ValueType>` is a CRTP-based lazy iterator generator.
+
+### EventLoop
+
+`<photon/common/event-loop.h>` — generic event loop with `Wait4Events` / `OnEvents` callbacks.
+
+### Perf counters
+
+`<photon/common/perf_counter.h>` — `REGISTER_PERF` / `REPORT_PERF` macros, with `TOTAL`, `ACCUMULATE`, `AVERAGE` types.
+
+### Hash combiner
+
+`<photon/common/hash_combine.h>` — Boost-style variadic hash combiner.
+
+### UUID
+
+`<photon/common/uuid.h>` and `uuid4.h` — UUID v4 generation, parsing, string conversion.
+
+## Checksums
+
+All checksums live under `<photon/common/checksum/...>`.
+
+| Header | Description |
+|--------|-------------|
+| `crc32c.h` | CRC32C with hardware-acceleration auto-detection (SSE4.2 / ARM CRC). Supports series, combine, trim. |
+| `crc64ecma.h` | CRC64-ECMA with hardware/software auto-selection. |
+| `xxhash.h` | xxHash 32-bit (software). |
+| `digest.h` | OpenSSL EVP-based digest: `sha1`, `sha256`, `sha512`, `md5`, `HMAC_*`. |
+
+## Design Decisions
+
+- **Compile-time format strings.** alog processes backtick-based format strings at compile time rather than parsing them at runtime like printf.
+- **Delegate over `std::function`.** `Delegate` has zero overhead (no heap allocation, no type erasure), supports member functions with vtable-aware dispatch, and explicitly forbids binding to a temporary lambda to reduce lifetime risk.
+- **Intrusive containers.** Intrusive lists and lock-free queues avoid per-node heap allocation and are used pervasively in the scheduler, reset handles, and object pools.
+- **Lock-free queues.** Turn-based slot marking avoids ABA problems. `RingChannel` adds photon-aware blocking with a yield-then-semaphore strategy.

--- a/doc/docs/api/delegate_callback.md
+++ b/doc/docs/api/delegate_callback.md
@@ -32,8 +32,8 @@ argument is a pointer of ```void*``` to distinguish individual callback
 invocations, as usually found in function pointer based callback mechanisms.
 
 Here is an example of a delegate. Suppose we have a delegate type that
-performs some sort of file open operation, and returns a pointer to an
-abstract file object.
+performs some sort of file open operation, and returns a pointer to
+an abstract file object.
 
 ```cpp
 class File;
@@ -92,3 +92,25 @@ ProcessFiles(fileNames, lambda);
 Note that ```Delegate<...>``` explicitly forbids binding to
 a temporary lambda or functor, in order to minimize the risk
 of life-cycle management of the lambda object.
+
+## Related Types
+
+`<photon/common/callback.h>` also defines:
+
+| Type | Description |
+|------|-------------|
+| `Delegate<R, Ts...>` | Zero-overhead callable: free functions, member functions, lambdas |
+| `Callback<Ts...>` | Alias for `Delegate<int, Ts...>` |
+| `Closure<ARGS...>` | Self-deleting callback (for one-shot async operations) |
+| `TempDelegate` | Binds to a temporary lambda |
+
+`<photon/common/delegates.h>` defines `Delegates<Convs...>`, a type-safe delegate facade with `DEFINE_DELEGATE_FUNCTION` macros for compile-time method dispatch.
+
+`<photon/common/PMF.h>` provides `get_member_function_address()`, which extracts a raw function pointer from a member function pointer, handling the vtable layout on x86_64 and aarch64.
+
+## Why Delegate over std::function
+
+- **Zero heap allocation.** A `Delegate` is a pair of pointers (function address + context). It never allocates.
+- **No type erasure.** Dispatch is resolved at compile time for free functions and lambdas, and at construction time (with vtable lookup) for member functions.
+- **Member function awareness.** The implementation understands the difference between plain member functions and virtual member functions on both x86_64 and aarch64, extracting the correct entry point.
+- **Lifetime safety.** Binding to a temporary lambda is explicitly rejected at compile time, avoiding the most common class of `std::function` misuse.

--- a/doc/docs/api/filesystem-and-io.md
+++ b/doc/docs/api/filesystem-and-io.md
@@ -88,3 +88,144 @@ int iouring_close(int fd);
 :::note
 The IO engine must be set appropriately in [Env initialization](./env#init).
 :::
+
+## Core Interfaces
+
+Defined in `<photon/fs/filesystem.h>`.
+
+### IFile (extends IStream)
+
+Positioned I/O interface:
+
+- `pread` / `preadv` / `pwrite` / `pwritev` — positioned read/write
+- `preadv2` / `pwritev2` — with flags (e.g. `RWF_NOWAIT`)
+- `lseek`, `fsync`, `fdatasync`, `fstat`, `ftruncate`, `fallocate`
+- `fiemap` — extent map query (used by the cache layer)
+- `trim`, `zero_range` — discard/zero operations
+- `append` / `appendv` — append with position output
+- `ioctl` / `vioctl` — extensible operations
+
+Member function pointers (`FuncPIO`, `FuncPIOCV`, etc.) are used for dispatch.
+
+### IFileSystem
+
+POSIX-like filesystem:
+
+- `open`, `creat`, `mkdir`, `rmdir`, `symlink`, `readlink`, `link`, `rename`, `unlink`
+- `chmod`, `chown`, `stat`, `lstat`, `access`, `truncate`
+- `statfs`, `statvfs`, `opendir` + `DIR` interface
+- `FileList`: range-based iteration over directory entries
+
+### IFileXAttr / IFileSystemXAttr
+
+Extended attributes: `getxattr`, `setxattr`, `listxattr`, `removexattr`.
+
+## Implementations
+
+### Local filesystem
+
+`<photon/fs/localfs.h>`. Multiple I/O engine backends:
+
+| Engine | Constant | Description |
+|--------|----------|-------------|
+| psync | `ioengine_psync` (0) | Synchronous POSIX I/O |
+| libaio | `ioengine_libaio` (1) | Linux AIO (requires `O_DIRECT`) |
+| posixaio | `ioengine_posixaio` (2) | POSIX AIO |
+| iouring | `ioengine_iouring` (3) | io_uring |
+
+Factory functions:
+
+```cpp
+IFileSystem* new_localfs_adaptor(const char* root_path, int io_engine_type);
+IFile* open_localfile_adaptor(const char* filename, int flags, mode_t mode, int io_engine_type);
+```
+
+### Virtual file
+
+`<photon/fs/virtual-file.h>`. `VirtualFile` manages its own offset and implements `read` / `write` / `readv` / `writev` via `pread` / `pwrite`. Uses `piov_copy` / `piov_nocopy` / `buffered_piov` for iovector handling.
+
+### Composers
+
+| Header | Description |
+|--------|-------------|
+| `forwardfs.h` | `ForwardFile` / `ForwardFS` — decorator pattern: forward all ops to underlay |
+| `subfs.h` | Path prefix remapping (chroot-like view) |
+| `throttled-file.h` | Rate-limited file I/O |
+| `aligned-file.h` | Buffer alignment for direct I/O |
+| `xfile.h` | Linear file (concatenation), stripe file (RAID-0-like) |
+| `range-split.h` | Decompose I/O ranges into aligned sub-ranges |
+
+### HTTP filesystem
+
+`<photon/fs/httpfs/httpfs.h>`.
+
+- `new_httpfs(default_https, conn_timeout, stat_expire)` — HTTP/HTTPS as a filesystem.
+- `new_httpfile()` — single HTTP file with range request support.
+- v2 versions use the native Photon HTTP client instead of libcurl.
+
+### FUSE adaptor
+
+`<photon/fs/fuse_adaptor/>`. Exposes photon filesystems as FUSE mounts. `session_loop.h` / `session_loop.cpp` implement the FUSE session processing.
+
+### extfs
+
+`<photon/fs/extfs/>`. Userspace ext2/ext3/ext4 filesystem: `new_extfs(IFile* underlying_file)`.
+
+## Async Filesystem
+
+`<photon/fs/async_filesystem.h>`.
+
+`IAsyncFile` / `IAsyncFileSystem` / `AsyncDIR`: asynchronous I/O using the `DEFINE_ASYNC` macro pattern. Each operation takes `(done_callback, timeout)`.
+
+Adaptors:
+
+- `new_async_file_adaptors()` — wrap async → sync
+- `new_sync_file_adaptors()` — delegate blocking ops to a thread pool
+- `export_as_async_file` / `fs` / `dir()` — export sync → async
+- `export_as_sync_file` / `fs` / `dir()` — export async → sync
+
+### ExportFS
+
+`<photon/fs/exportfs.h>`. `exportfs_init(thread_pool_capacity)` creates a thread pool for cross-thread filesystem access. Exports sync objects as thread-safe async/sync wrappers for use from external OS threads.
+
+## Cache Layer
+
+`<photon/fs/cache/>`.
+
+### Architecture
+
+```
+ICachedFileSystem → ICachePool → ICacheStore (per-file cache)
+                                      ├── RangeLock (concurrent access)
+                                      ├── fiemap (cached extent query)
+                                      └── refill from source FS
+```
+
+### Key types
+
+| Type | Description |
+|------|-------------|
+| `ICachePool` | Per-filename cache store management: `open()`, `set_quota()`, `evict()`, `sync_pool()` |
+| `ICacheStore` | Per-file cache: `preadv2` / `pwritev2` with automatic miss handling, refill deduplication, `RangeLock` |
+| `IMemCacheStore` / `IMemCachePool` | Memory cache with buffer pinning |
+
+### Cache open flags
+
+`O_WRITE_THROUGH`, `O_WRITE_AROUND`, `O_WRITE_BACK`, `O_CACHE_ONLY`, `O_DIRECT_LOCAL`, `O_MMAP_READ`.
+
+### Implementations
+
+| Implementation | Description |
+|----------------|-------------|
+| `full_file_cache/` | File-backed cache using local FS, `fiemap` for extent queries, LRU eviction |
+| `policy/lru.h` | Array-based LRU (no per-node allocation): `push_front`, `access`, `pop_back` |
+| `ocf_cache/` | Open CAS (Cache Acceleration Software) integration |
+| Persistent cache | Downloads chunks to backing store, never evicts |
+
+## Design Decisions
+
+- **POSIX-like interface.** `IFile` / `IFileSystem` mirror POSIX semantics, making it easy to wrap existing code.
+- **Decorator composition.** `ForwardFile` / `ForwardFS` enable transparent layering: cache → throttle → align → local.
+- **fiemap for cache queries.** The cache layer uses `fiemap` to discover which byte ranges are cached (vs holes), avoiding a separate metadata store.
+- **RangeLock for concurrency.** Prevents concurrent reads of the same byte range — the first caller reads from the source, others wait and read from the cache.
+- **Multiple I/O engines.** The local filesystem supports psync / libaio / posixaio / iouring backends, selected at creation time.

--- a/doc/docs/api/lock-and-synchronization.md
+++ b/doc/docs/api/lock-and-synchronization.md
@@ -115,3 +115,40 @@ public:
     int unlock();
 };
 ```
+
+## All Synchronization Primitives
+
+| Primitive | Notes |
+|-----------|-------|
+| `spinlock` | Exponential backoff |
+| `ticket_spinlock` | FIFO ordering, no starvation |
+| `mutex` | Two-phase: CAS → yield retries → wait queue with `thread_usleep_defer` |
+| `recursive_mutex` | Re-entrant mutex |
+| `seq_mutex` | FIFO mutex |
+| `condition_variable` | Extends `waitq`, supports predicate-based wait |
+| `semaphore` | Counting, with out-of-order resume option |
+| `rwlock` | Traditional reader-writer lock |
+| `qrwlock` | Optimized for read-heavy workloads |
+| `locker<M>` / `SCOPED_LOCK` | RAII lock guard for any lock type |
+
+## Implementation Notes
+
+### mutex
+
+`photon::mutex` uses a two-phase protocol:
+
+1. Fast path: try `CAS` to acquire the lock without yielding.
+2. Contended path: retry a few times with `thread_yield()`.
+3. If still contended: push the current thread onto a wait queue and call `thread_usleep_defer()` to release the spinlock without an extra context switch.
+
+### Defer-based unlock on sleep
+
+`thread_usleep_defer(timeout, defer, arg)` executes the `defer` callback immediately after the context switch. This is what lets `mutex::unlock()` release its internal spinlock while the thread is going to sleep — without an extra round-trip through the scheduler.
+
+### Asymmetric spinlock
+
+The spinlock used inside the scheduler is optimized for the foreground vCPU accessing its own run queue (single atomic store) versus a background vCPU trying to migrate threads in (must check both flags).
+
+### Work stealing
+
+Optional cross-vCPU load balancing, enabled via the flags `VCPU_ENABLE_ACTIVE_WORK_STEALING` and `VCPU_ENABLE_PASSIVE_WORK_STEALING`. Stealers scan other vCPUs' standby queue and run queue.

--- a/doc/docs/api/network.md
+++ b/doc/docs/api/network.md
@@ -258,3 +258,101 @@ Please refer to `net/http/test/client_perf.cpp` and `net/http/test/server_perf.c
 ##### 封装
 
 Similarly, we also encapsulated its fs in `<photon/fs/httpfs/httpfs.h>`, which is called httpfs v2.
+
+## HTTP/1.1 Internals
+
+| Header | Key types |
+|--------|-----------|
+| `message.h` | `Message` (base), `Request` (verb/target/path/query), `Response` (status code). Buffer management, header parsing, chunked/content-length body streams. |
+| `headers.h` | `HeadersBase` — compact header storage using `rstring_view16` (offset + length pairs), sorted for binary search. `Headers` adds chunked/content_length/range helpers. |
+| `body.h` | Body stream factories: `new_body_read_stream()`, `new_chunked_body_read/write_stream()` |
+| `parser.h` | Lightweight parser: `skip_string`, `skip_chars`, `extract_integer`, `extract_until_char` |
+| `url.h` | `URL` — parses `scheme://user:passwd@host:port/path?query#fragment` |
+| `client.h` | `Client` (abstract): `call(Operation*)` with follow redirects, retry, timeout, body_writer delegate. `OperationOnStack<N>` for stack allocation. |
+| `server.h` | `HTTPServer`: `handle_connection()`, pattern-matched `add_handler()`. Built-in: `new_fs_handler()`, `new_proxy_handler()`. |
+
+## HTTP/2
+
+Defined in `<photon/net/http/streams.h>`. Full RFC 9113 / 7541 implementation:
+
+- `FrameHeader` (9 bytes packed): DATA, HEADERS, SETTINGS, PING, GOAWAY, WINDOW_UPDATE, etc.
+- `H2Connection`: `send_preface`, `recv_preface`, `send_settings`, `send_goaway`, stream management.
+- `H2Stream`: value type wrapping connection + stream_id; state machine (Idle → Open → HalfClosed → Closed).
+- `huffman/codec.h`: HPACK Huffman encode/decode.
+
+## WebSocket
+
+`<photon/net/http/websocket.h>`.
+
+`IWebSocketStream`: send_text/binary, recv_frame, ping, close.
+
+- Client-side: `websocket_connect()`
+- Server-side: `server_accept_websocket()` + `new_websocket_handler()`
+
+## Cookie Jar
+
+`ICookieJar`: `get_cookies_from_headers()`, `set_cookies_to_headers()`. `new_simple_cookie_jar()` provides an in-memory storage.
+
+## Security Streams
+
+### TLS
+
+`<photon/net/security-context/tls-stream.h>`. Built on OpenSSL:
+
+- `TLSContext`: cert, key, passphrase, verify mode, ALPN protos.
+- `new_tls_stream(ctx, base, role)`: wrap a socket with TLS.
+- `new_tls_client/server(ctx, base)`: factory wrappers.
+- `tls_stream_set_hostname()`: SNI.
+- `tls_stream_get_alpn_selected()`: negotiated ALPN protocol.
+
+### SASL
+
+`<photon/net/security-context/sasl-stream.h>`. Built on GNU SASL:
+
+- `SaslSession`: property-based configuration.
+- `new_sasl_client/server_session()`: create sessions.
+- `new_sasl_stream()`: wrap a socket with SASL authentication.
+
+## Connection Pool
+
+`<photon/net/socket.h>`. `TCPSocketPool` wraps `ISocketClient`, pools connections by `EndPoint` key.
+
+- Uses `CascadingEventEngine` to detect peer close (`RDHUP`) without blocking the vCPU's main event engine.
+- `Timer` for TTL eviction.
+- `PooledTCPSocketStream` marks a socket as "drop" on error, returns it to the pool on clean close.
+
+Factory: `new_tcp_socket_pool()`.
+
+## Other Components
+
+| Header | Description |
+|--------|-------------|
+| `<photon/net/curl.h>` | RAII libcurl wrapper: GET/HEAD/POST/PUT/DELETE, template-based streams, integrates with photon event loop |
+| `<photon/net/iostream.h>` | `new_iostream(ISocketStream*)`: wrap socket as `std::iostream` |
+| `<photon/net/vdma.h>` | Virtual DMA for zero-copy shared memory networking |
+| `<photon/net/datagram_socket.h>` | `IDatagramSocket`, `UDPSocket`, `UDS_DatagramSocket` |
+
+## Coroutine Integration
+
+Defined in `<photon/net/basic_socket.h>`. The `doio_once` template:
+
+1. Try the syscall.
+2. On `EAGAIN`, call `wait_for_fd_readable()` or `wait_for_fd_writable()`.
+3. The photon thread suspends; the FD is registered with the event engine.
+4. On resume, retry the syscall.
+
+`doio_loop` repeats this until error or EOF.
+
+## Base Classes
+
+`<photon/net/base_socket.h>`:
+
+- `SocketClientBase` / `SocketServerBase`: store pending socket options in `SockOptBuffer` (4KB buffer), applied lazily to avoid multiple `setsockopt` syscalls.
+- `ForwardSocketClient` / `ForwardSocketServer` / `ForwardSocketStream`: decorator pattern forwarding to underlay with optional ownership.
+
+## Design Decisions
+
+- **Abstract interfaces everywhere.** `ISocketStream`, `ISocketClient`, `ISocketServer` enable transparent layering (TLS over TCP, pool over TLS, etc.).
+- **Ownership flag.** Wrappers accept an `ownership` parameter controlling whether the underlay is deleted on destruction.
+- **SockOptBuffer.** Socket options are stored before `connect` / `bind` and applied lazily — avoids multiple `setsockopt` syscalls.
+- **CascadingEventEngine for pools.** The socket pool monitors for `RDHUP` without blocking the vCPU's main event engine.

--- a/doc/docs/api/rpc.md
+++ b/doc/docs/api/rpc.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 9
+toc_max_heading_level: 4
+---
+
+# RPC Framework
+
+The `rpc/` module provides a high-performance RPC framework with zero-copy serialization, connection pooling, and out-of-order async execution. Published in PPoPP'26 as "zBuffer".
+
+### Namespace
+
+`photon::rpc::`
+
+### Headers
+
+`<photon/rpc/rpc.h>`, `<photon/rpc/serialize.h>`, `<photon/rpc/out-of-order-execution.h>`
+
+## Protocol
+
+Defined in `<photon/rpc/rpc.h>`.
+
+### Wire header
+
+Each RPC message begins with a 40-byte header:
+
+| Field | Description |
+|-------|-------------|
+| MAGIC | Constant `0x87de5d02e6ab95c7` |
+| VERSION | Protocol version |
+| size | Total message size |
+| FunctionID | Composite of interface + method |
+| tag | Per-request correlation tag |
+
+### Stub and Skeleton
+
+- **`Stub`** — the RPC client entity. `call<Operation>(req, resp, timeout)` performs a request with zero-copy serialization.
+- **`Skeleton`** — the RPC server entity. `add_function()` registers handlers, `register_service<Operations...>()` registers a batch, `serve(IStream*)` runs the dispatch loop.
+- **`StubPool`** — connection pool with TTL-based expiration and per-call timeout. `get_stub(endpoint)`, `put_stub()`, `acquire()`.
+
+## Serialization
+
+Defined in `<photon/rpc/serialize.h>`. The type system is built on top of `iovector` for zero-copy.
+
+### Field types
+
+| Type | Description |
+|------|-------------|
+| `buffer` | Variable-length byte buffer |
+| `fixed_buffer<T>` | Fixed-size typed buffer |
+| `array<T>` | Variable-length typed array |
+| `string` | Slice-based string (offset + length into iovector) |
+| `slice` | Generic slice reference |
+| `iovec_array` | Array of iovecs |
+| `sorted_map<K,V>` | Binary-search indexed map over serialized data |
+
+### Archives
+
+- `SerializerIOV` — serializes into an iovector.
+- `DeserializerIOV` — deserializes with iovector extraction.
+
+### Message base
+
+`rpc::Message` defines the `serialize_fields()` method plus `add_checksum()` / `validate_checksum()`. `CheckedMessage<Hasher>` adds automatic CRC32C integrity checking.
+
+Field registration uses the `PROCESS_FIELDS(...)` macro together with the `ArchiveBase<Derived>` CRTP, which provides `process_field()` overloads for each supported type.
+
+## Out-of-Order Execution
+
+Defined in `<photon/rpc/out-of-order-execution.h>`. Enables pipelining multiple async operations while presenting a synchronous interface to the caller.
+
+- **`OutOfOrderContext`** — per-operation context with `do_issue`, `do_completion`, `do_collect` callbacks, plus tag, phase, and timeout.
+- `ooo_issue_operation()` — issue an async operation.
+- `ooo_wait_completion()` — wait for completion.
+- `ooo_issue_wait()` — combined issue + wait.
+- `ooo_result_collected()` — signal that the result has been collected.
+- `new_ooo_execution_engine()` — factory for a concurrent out-of-order engine.
+
+## Factory Functions
+
+| Factory | Description |
+|---------|-------------|
+| `new_rpc_stub()` | Create an RPC client stub |
+| `new_stub_pool()` | Create a connection-pooled stub pool |
+| `new_uds_stub_pool()` | Unix Domain Socket stub pool |
+| `new_skeleton()` | Create an RPC server skeleton |
+
+## Design Decisions
+
+- **Zero-copy serialization.** `SerializerIOV` / `DeserializerIOV` work directly on iovector, with no intermediate buffer copies. `sorted_map` performs binary search over serialized data rather than deserializing into `std::map`.
+- **Slice-based strings.** Serialized strings store offset + length into the iovector, not copies, avoiding allocation during deserialization.
+- **CRC32C checksums.** `CheckedMessage` uses hardware-accelerated CRC32C for message integrity.
+- **Out-of-order execution.** Multiple RPC calls can be pipelined on a single connection — issue multiple requests, then collect responses as they arrive.
+- **StubPool.** Reuses connections with TTL-based expiration, reducing TCP handshake overhead.
+
+## Related Modules
+
+- [Network](./network.md) — `ISocketStream` provides the RPC transport, `TCPSocketPool` backs `StubPool`.
+- [Common Utilities](./common.md) — `iovector` for zero-copy serialization, `crc32c` for checksums, `Delegate` for callbacks.

--- a/doc/docs/api/thread.md
+++ b/doc/docs/api/thread.md
@@ -413,3 +413,57 @@ int Timer::cancel();
 int Timer::reset(uint64_t new_timeout = -1);
 int Timer::stop();
 ```
+
+## Runtime Internals
+
+### vCPU queues
+
+Each vCPU maintains three internal queues:
+
+- **RunQ** — intrusive circular doubly-linked list of `READY` threads. Private to the vCPU; no locking for normal operations.
+- **SleepQ** — binary min-heap ordered by `ts_wakeup` (microsecond wakeup time).
+- **StandbyQ** — threads pushed by other vCPUs (cross-vCPU migration), drained into RunQ during `resume_threads()`.
+- **Idle Worker** — a dedicated coroutine that drives the event engine when no photon thread is runnable.
+
+### thread struct
+
+The `thread` struct lives at the **bottom of the stack** (the stack grows upward). Key states: `READY`, `RUNNING`, `SLEEPING`, `DONE`, `STANDBY`.
+
+Stack allocation: minimum 16KB + guard page, page-aligned. Use `use_pooled_stack_allocator()` for better performance when creating many short-lived threads.
+
+### Context switch
+
+Platform-specific assembly (`_photon_switch_context`) saves and restores the stack pointer. `_photon_switch_context_defer` executes a callback on the source thread's stack after saving context — this is what allows mutexes to be unlocked during sleep without an extra context switch.
+
+### Scheduler
+
+- `thread_yield()` — yield to next thread in RunQ.
+- `thread_usleep(timeout)` — sleep for N microseconds (push to SleepQ, switch context).
+- `thread_usleep_defer(timeout, defer, arg)` — sleep + execute defer immediately after switch-out. Critical for mutex unlock-on-sleep.
+- `thread_interrupt(th, errno)` — wake a sleeping thread (sets `error_number`).
+- `thread_shutdown(th, flag)` — mark for shutdown, interrupt if sleeping.
+
+## Channels
+
+Go-style typed channels, defined in `<photon/thread/go.h>`.
+
+- `channel<T>` — available in buffered (lock-free MPMC queue + semaphore) and unbuffered (mutex rendezvous) variants.
+- `select()` — multiplexed channel operations.
+
+## std Compatibility
+
+`<photon/thread/std-compat.h>` provides drop-in replacements that use photon's coroutine-aware primitives:
+
+| Type | Replaces |
+|------|----------|
+| `photon_std::thread` | `std::thread` |
+| `photon_std::mutex` | `std::mutex` |
+| `photon_std::condition_variable` | `std::condition_variable` |
+| `photon_std::promise` / `future` | `std::promise` / `std::future` |
+
+## Design Decisions
+
+- **Per-vCPU private queues.** RunQ and SleepQ are never shared across vCPUs during normal scheduling, avoiding locking overhead.
+- **Asymmetric spinlock.** Optimized for foreground vCPU accessing its own run queue (single atomic store) vs background access (must check both flags).
+- **Defer-based unlock-on-sleep.** `thread_usleep_defer()` releases the mutex spinlock without an extra context switch.
+- **Coroutine at stack bottom.** Assembly can access the thread struct directly from the stack pointer.

--- a/doc/docs/api/vcpu-and-multicore.md
+++ b/doc/docs/api/vcpu-and-multicore.md
@@ -101,3 +101,105 @@ int thread_migrate(photon::thread* th = CURRENT, size_t index = -1UL);
   it will choose the next vCPU in pool (round-robin).
      
 Returns 0 for success, and <0 means failed to migrate.
+
+## Event Engines
+
+Each vCPU has a `MasterEventEngine` that blocks on I/O events and wakes sleeping photon threads via `thread_interrupt()`. Defined in `<photon/io/fd-events.h>`.
+
+### MasterEventEngine
+
+Per-vCPU, drives the idle loop:
+
+- `wait_for_fd(fd, interests, timeout)` — suspend current thread until FD event
+- `wait_and_fire_events(timeout)` — block and fire events by calling `thread_interrupt(thread*, EOK)`
+- `cancel_wait()` — wake the engine (via eventfd or equivalent)
+
+### CascadingEventEngine
+
+For complex multi-FD waits. Does NOT block the vCPU — only the calling photon thread:
+
+- `add_interest(Event)` / `rm_interest(Event)` — manage FD registrations
+- `wait_for_events(data[], count, timeout)` — wait for multiple events
+
+### Event flags
+
+```cpp
+EVENT_READ    = 1
+EVENT_WRITE   = 2
+EVENT_ERROR   = 4
+EDGE_TRIGGERED = 0x4000
+ONE_SHOT       = 0x8000
+```
+
+## Backends
+
+### epoll
+
+Headers: `<photon/io/epoll.cpp>`, `<photon/io/epoll-ng.cpp>`.
+
+- `epoll_create(1)` + eventfd for `cancel_wait`
+- `_inflight_events` vector indexed by fd
+- ONE_SHOT interests with `data=CURRENT` (photon thread pointer)
+- `wait_and_fire_events()`: `epoll_wait()` → `thread_interrupt((thread*)data, EOK)` per event
+- `epoll-ng.cpp` is the edge-triggered variant
+
+### io_uring
+
+Header: `<photon/io/iouring-wrapper.h>`.
+
+The most feature-rich backend:
+
+- SQPoll mode, IOPoll mode, registered files
+- `io_uring_prep_poll_add` / `multishot` for fd events
+- `async_io()` template for: read, write, send, recv, connect, accept, open, mkdir, close, splice, fsync
+- Cancellation via `io_uring_prep_cancel`
+- Kernel version detection (5.11, 5.15, 5.18, 5.19) for feature gating
+- `IouringFixedFileFlag` (bit 32) marks registered FDs
+
+### kqueue
+
+Header: `<photon/io/kqueue.cpp>`. BSD/macOS backend:
+
+- `EVFILT_USER` for self-wakeup (`cancel_wait`)
+- `EV_ONESHOT` for single-event waits
+
+### select
+
+Inline stub. Fallback for platforms without epoll/kqueue.
+
+## Async I/O Backends
+
+### libaio
+
+Header: `<photon/io/aio-wrapper.h>`.
+
+- `libaio_pread` / `preadv` / `pwrite` / `pwritev` — requires `O_DIRECT`, aligned buffers
+- Requires `fd_events_init()` for event notification
+
+### POSIX AIO
+
+- `posixaio_pread` / `pwrite` / `fsync` / `fdatasync`
+
+## Userspace Networking
+
+| Header | Description |
+|--------|-------------|
+| `<photon/io/fstack-dpdk.h>` | F-Stack / DPDK: `fstack_socket` / `connect` / `bind` / `listen` / `accept` / `send` / `recv` / `close` |
+| `<photon/io/spdknvme-wrapper.h>` | SPDK NVMe block device access |
+| `<photon/io/spdkbdev-wrapper.h>` | SPDK generic block device |
+
+## Signal Handling
+
+Header: `<photon/io/signal.h>`.
+
+- `sync_signal_init()` and `sync_signal(signum, handler)` — signal handlers run in a dedicated photon thread
+- `block_all_signal()` blocks all signals except `SIGSTOP` / `SIGKILL`
+
+`<photon/io/reset_handle.h>` defines `ResetHandle`, an intrusive list node with a `reset()` virtual method. `reset_all_handle()` is called during photon reinitialization.
+
+## Design Decisions
+
+- **ONE_SHOT semantics.** All backends use one-shot event registration to avoid thundering herd and ensure each event wakes exactly one thread.
+- **EOK convention.** Events fire with `EOK` (ENXIO, "Event of NeXt I/O"); the interrupted thread checks `error_number` to distinguish event wakeup from timeout.
+- **Thread pointer as event data.** `data=CURRENT` stores the photon thread pointer in the event, enabling direct `thread_interrupt()` without lookup.
+- **Separate Master and Cascading engines.** Master drives the idle loop (blocks the vCPU); Cascading handles per-thread multi-FD waits without blocking others.

--- a/doc/docs/ecosystem/_category_.json
+++ b/doc/docs/ecosystem/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Ecosystem",
+  "position": 5,
+  "link": {
+    "type": "generated-index",
+    "description": "Clients and parsers built on top of Photon."
+  }
+}

--- a/doc/docs/ecosystem/overview.md
+++ b/doc/docs/ecosystem/overview.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 1
+toc_max_heading_level: 4
+---
+
+# Ecosystem
+
+The `ecosystem/` directory contains higher-level clients and parsers built on top of Photon's core modules. These are optional; enable with the `PHOTON_ENABLE_ECOSYSTEM` CMake option.
+
+### Namespace
+
+`photon::`
+
+### Headers
+
+`<photon/ecosystem/...>`
+
+## Redis Client
+
+`<photon/ecosystem/redis.h>` — coroutine-aware Redis client.
+
+- Speaks RESP (Redis Serialization Protocol) directly over `ISocketStream`.
+- Supports strings, hashes, lists, sets, sorted sets, key operations, scripting, pub/sub, and transactions.
+- Uses `Delegate` callbacks for response parsing, avoiding intermediate buffer copies.
+- Connection pooling is provided through the standard socket pool primitives in `net/`.
+
+Source: `ecosystem/redis.h`, `ecosystem/redis.cpp`.
+
+## OSS Client
+
+`<photon/ecosystem/oss.h>` — Alibaba Cloud Object Storage Service client.
+
+- Supports bucket and object operations: put, get, delete, list, multipart upload, copy, metadata.
+- Signs requests with OSS V1/V4 signatures using the `common/checksum` and `common/digest` helpers.
+- Streaming uploads and downloads use `iovector` for zero-copy I/O.
+- XML responses are parsed with `simple_dom`.
+
+Source: `ecosystem/oss.h`, `ecosystem/oss.cpp`, `ecosystem/oss_constants.h`.
+
+## simple_dom
+
+`<photon/ecosystem/simple_dom.h>` — lightweight, allocation-free DOM parser for JSON, XML, and YAML.
+
+- Single tree representation shared across all three formats.
+- `SimpleDOM::Document` parses from a buffer; nodes are accessed via path-like queries.
+- Designed for configuration parsing and small response bodies, not for large streaming documents.
+- Patches for `rapidjson` and `rapidxml` (used as backends) are kept in `ecosystem/patches/`.
+
+Source: `ecosystem/simple_dom.h`, `ecosystem/simple_dom.cpp`, `ecosystem/simple_dom_impl.h`.
+
+## Build
+
+The ecosystem is built only when `PHOTON_ENABLE_ECOSYSTEM=ON`:
+
+```bash
+cmake -B build -D PHOTON_BUILD_TESTING=ON -D PHOTON_ENABLE_ECOSYSTEM=ON
+cmake --build build -j 8
+```
+
+## Related Modules
+
+- [Network](../api/network.md) — `ISocketStream`, HTTP client, and TLS streams used as transport.
+- [Common Utilities](../api/common.md) — `iovector`, `Delegate`, checksums, and `estring` used throughout.
+- [Filesystem and IO](../api/filesystem-and-io.md) — some ecosystem code paths treat remote storage as a filesystem via `fs/httpfs`.

--- a/doc/docs/introduction/photon-architecture.md
+++ b/doc/docs/introduction/photon-architecture.md
@@ -18,3 +18,79 @@ Its components are:
 * A POSIX-like filesystem abstraction and some implementations: local fs, http fs, fuse fs, e2fs, etc.
 * Common utilities: io-vector manipulation, resource pool, object cache, mem allocator, callback delegator,
   pre-compiled logging, lockless ring buffer, defer, range lock, throttle, etc.
+
+## Layered Architecture
+
+```
++--------------------------------------------------------------------+
+|                      Application Code                              |
++--------------------------------------------------------------------+
+|  go() / thread_create11() / thread_create()  |  photon_std::thread |
++--------------------------------------------------------------------+
+|                   photon::thread (coroutine)                       |
+|  Scheduler (RunQ/SleepQ/StandbyQ) | Sync primitives | channel<T>   |
++--------------------------------------------------------------------+
+|                        vCPU (OS Thread)                            |
+|  MasterEventEngine (epoll/io_uring/kqueue) + Idle Worker           |
++--------------------------------------------------------------------+
+|                    WorkPool (multi-vCPU)                           |
+|  std::thread[] + LockfreeMPMCRingQueue for task dispatch           |
++--------------------------------------------------------------------+
+|   fs/ (filesystem)  |  net/ (sockets, HTTP)  |  rpc/ (RPC)         |
++--------------------------------------------------------------------+
+|              common/ (utilities, logging, containers)              |
++--------------------------------------------------------------------+
+```
+
+From top to bottom:
+
+1. **Application code** uses Photon's coroutine primitives (`go`, `thread_create11`, `photon_std::thread`) to express concurrency.
+2. **Coroutine layer** schedules `photon::thread` instances on per-vCPU queues, with sync primitives (`mutex`, `semaphore`, `condition_variable`, `rwlock`) and Go-style `channel<T>`.
+3. **vCPU layer** runs the idle worker coroutine, which drives the `MasterEventEngine` (epoll, io_uring, kqueue, or select) when no photon thread is runnable.
+4. **WorkPool** manages multiple vCPUs and dispatches tasks across them via a lock-free MPMC queue.
+5. **Service modules** (`fs`, `net`, `rpc`) provide filesystem, networking, and RPC abstractions.
+6. **common/** holds cross-cutting utilities: logging, strings, containers, delegates, I/O vectors, checksums.
+
+## Module Summary
+
+| Module | Purpose | Key files |
+|--------|---------|-----------|
+| [thread/](../api/thread.md) | Coroutine runtime, scheduler, sync primitives, channels | `thread.h`, `thread.cpp`, `go.h`, `thread-pool.h`, `workerpool.h` |
+| [io/](../api/vcpu-and-multicore.md#event-engines) | Event engine backends (epoll, io_uring, kqueue), signal handling | `fd-events.h`, `epoll.cpp`, `iouring-wrapper.cpp`, `kqueue.cpp` |
+| [net/](../api/network.md) | Socket abstractions, HTTP client/server, TLS, connection pooling | `socket.h`, `http/client.h`, `http/server.h`, `security-context/tls-stream.h` |
+| [fs/](../api/filesystem-and-io.md) | Filesystem VFS, local fs, HTTP fs, caching layer | `filesystem.h`, `localfs.h`, `cache/cache.h` |
+| [rpc/](../api/rpc.md) | High-performance RPC with zero-copy serialization | `rpc.h`, `serialize.h`, `out-of-order-execution.h` |
+| [common/](../api/common.md) | Logging, string utilities, containers, delegates, async helpers | `alog.h`, `estring.h`, `callback.h`, `iovector.h`, `lockfree_queue.h` |
+| [ecosystem/](../ecosystem/overview.md) | Redis client, OSS client, JSON/XML/YAML parsing | `redis.h`, `oss.h`, `simple_dom.h` |
+
+## Key Design Patterns
+
+**Interface segregation.** Abstract interfaces (`IStream`, `IFile`, `IFileSystem`, `ISocketStream`, `ISocketClient`, `ISocketServer`) separate concerns and enable composition.
+
+**Decorator pattern.** `ForwardFile`, `ForwardFS`, `ForwardSocket*` wrap underlay objects transparently — used for TLS, caching, throttling, and alignment.
+
+**Factory functions.** `new_*_client()`, `new_*_server()`, `new_localfs_adaptor()`, etc. create concrete implementations behind abstract interfaces.
+
+**Strategy pattern.** Pluggable event engines (epoll / io_uring / kqueue) and I/O engines (psync / libaio / iouring) implement the same interface, selected at creation time.
+
+**Delegate callbacks.** `Delegate<R, Ts...>` provides zero-overhead callable wrappers for handlers, body writers, and async completions. See [Delegate and Callback](../api/delegate_callback.md).
+
+**Intrusive collections.** `intrusive_list_node<T>` is used for reset handles, pooled sockets, and scheduler queues to avoid per-node allocation.
+
+## Coroutine and I/O Integration
+
+All I/O integrates with the coroutine system via event-driven suspension:
+
+1. A syscall returns `EAGAIN` → the wrapper calls `wait_for_fd_readable()` or `wait_for_fd_writable()`.
+2. The current photon thread suspends; the FD is registered with the `MasterEventEngine`.
+3. When the event arrives, `thread_interrupt()` moves the thread from the sleep queue to the run queue.
+4. The scheduler resumes the thread, and the syscall is retried.
+
+This pattern appears in `net/basic_socket.h` (the `doio_once` template) and is reused throughout the codebase.
+
+## Conventions
+
+- **Ownership.** Wrapper objects accept an `ownership` parameter (typically `bool`) that controls whether the wrapped object is deleted on destruction.
+- **Timeout.** All I/O operations accept `Timeout` objects integrated with `photon::now` (a microsecond-precision global timestamp).
+- **Error handling.** Functions return `-1` or `nullptr` on error, set `errno`, and log via `LOG_ERROR_RETURN`.
+- **Thread safety.** Photon sync primitives (`mutex`, `semaphore`, `condition_variable`) are coroutine-aware; their `std::` equivalents would block the underlying OS thread.

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current.json
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current.json
@@ -30,5 +30,13 @@
   "sidebar.docSidebar.category.Miscellaneous.link.generated-index.description": {
     "message": "其他工具",
     "description": "The generated-index page description for category Miscellaneous in sidebar docSidebar"
+  },
+  "sidebar.docSidebar.category.Ecosystem": {
+    "message": "生态",
+    "description": "The label for category Ecosystem in sidebar docSidebar"
+  },
+  "sidebar.docSidebar.category.Ecosystem.link.generated-index.description": {
+    "message": "基于 Photon 构建的客户端与解析器",
+    "description": "The generated-index page description for category Ecosystem in sidebar docSidebar"
   }
 }

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/common.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/common.md
@@ -1,0 +1,230 @@
+---
+sidebar_position: 1
+toc_max_heading_level: 4
+---
+
+# 通用工具
+
+`common/` 模块提供 PhotonLibOS 全局使用的基础工具：日志、字符串、容器、可调用对象抽象、I/O 向量、异步辅助设施、校验和等。
+
+### 命名空间
+
+`photon::`
+
+### 头文件
+
+所有头文件均位于 `<photon/common/...>`。
+
+## 日志
+
+`<photon/common/alog.h>` —— 类型安全、编译期格式化的日志系统。
+
+### 宏
+
+- 日志级别宏：`LOG_DEBUG`、`LOG_INFO`、`LOG_WARN`、`LOG_ERROR`、`LOG_FATAL`
+- 限流变体：`LOG_EVERY_T`、`LOG_EVERY_N`、`LOG_FIRST_N`、`LOG_FIRST_N_EVERY_T`
+- 错误返回辅助宏：`LOG_ERROR_RETURN(errno, retval, ...)`、`LOG_ERRNO_RETURN(errno, retval, ...)`
+- 值回显：`VALUE(x)` 输出 `x=<value>`，适合调试不透明的值
+
+### 格式串
+
+alog 使用反引号（`` ` ``）作为变量占位符，由编译器处理，而不是像 printf 那样在运行时解析。
+
+- 格式并不由格式串本身决定，而是由变量外层的包装器决定。
+- 格式串末尾的反引号是多余的 —— 超出反引号数量的参数会自动输出。
+
+```cpp
+LOG_WARN("count ` total ", DEC(count).comma(true), DEC(total).comma(true));
+LOG_ERROR("failed, ", VALUE(st));   // 不需要结尾反引号
+```
+
+### 格式化包装器
+
+| 包装器 | 输出 |
+|--------|------|
+| `HEX(x)` | 十六进制 |
+| `DEC(x)` | 十进制，可选 `.comma(true)` |
+| `OCT(x)` | 八进制 |
+| `BIN(x)` | 二进制 |
+| `FP(x)` | 浮点数 |
+
+### 后端
+
+`ILogOutput` 是抽象接口。内置后端可输出到文件、stderr、stdout 或异步队列，通过 `set_log_output()` 设置。
+
+## 字符串工具
+
+### estring
+
+`<photon/common/estring.h>` —— `estring` 扩展自 `std::string`，`estring_view` 扩展自 `std::string_view`。
+
+额外提供：trim、大小写无关比较、数值转换、惰性 `split()`、高效拼接 `appends()`。
+
+```cpp
+std::string key = estring().appends(host, ":", port);
+
+estring().appends(
+    path,
+    estring::make_conditional_cat_list(has_query, "?", query));
+```
+
+`estring::appends` 不会产生中间的 `std::string` 临时对象，并可混合接受 string_view、整数等多种类型。
+
+### 编译期字符串
+
+`<photon/common/conststr.h>` —— 编译期字符串操作：`TString`、`TStrArray`、`DEFINE_ENUM_STR`。
+
+### 字符串构建器
+
+`<photon/common/strbuilder.h>` —— 栈分配的字符串构建器 `strBuilder<N>`。
+
+### 字符串键容器
+
+`<photon/common/string-keyed.h>` —— 以字符串为键的 map/set，避免在查找时构造临时 `std::string`：`unordered_map_string_key`、`map_string_key`、`unordered_map_string_kv`。
+
+## 容器与数据结构
+
+### 侵入式链表
+
+`<photon/common/intrusive_list.h>` —— 侵入式双向链表，支持 `round_robin_next()` 和按谓词拆分。每个节点无堆分配。
+
+### 环形缓冲区
+
+`<photon/common/ring.h>`：
+- `RingQueue<T>` —— SPSC 阻塞队列
+- `RingBuffer` —— char 特化的环形缓冲区，支持 `readv`/`writev`
+
+### 无锁队列
+
+`<photon/common/lockfree_queue.h>` —— 无锁 MPMC、批量 MPMC、SPSC 队列。`RingChannel<QueueType>` 增加光子协程感知的阻塞，采用可配置的"先 yield 后信号量"策略。基于 turn 的槽位标记避免 ABA 问题。
+
+### 一致性哈希
+
+`<photon/common/consistent-hash-map.h>` —— 基于 vector 的一致性哈希环。
+
+### 有序区间
+
+`<photon/common/ordered_span.h>` —— 有序 span，二分查找插入/查询。
+
+### TTL 容器
+
+`<photon/common/expirecontainer.h>` —— 由光子定时器驱动的自动过期带键容器。`ObjectCache` 提供引用计数的 `Borrow` RAII 访问。
+
+### Identity Pool
+
+`<photon/common/identity-pool.h>` —— 支持构造/析构回调和自动扩缩的对象池，作为 `ThreadPool` 的底层实现。
+
+## 可调用对象抽象
+
+### Delegate
+
+`<photon/common/callback.h>` —— `Delegate<R, Ts...>` 是对自由函数、成员函数、lambda 的零开销可调用包装。无堆分配、无类型擦除。
+
+- `Callback<Ts...>` 是 `Delegate<int, Ts...>` 的别名。
+- `Closure<ARGS...>` 是自删除回调。
+- `TempDelegate` 绑定临时 lambda。
+
+成员函数调用在 x86_64 与 aarch64 上均能正确处理虚表。
+
+### Delegates 门面
+
+`<photon/common/delegates.h>` —— `Delegates<Convs...>` 是类型安全的 delegate 门面，配合 `DEFINE_DELEGATE_FUNCTION` 宏在编译期进行方法分发。
+
+### PMF 辅助
+
+`<photon/common/PMF.h>` —— `get_member_function_address()` 从成员函数指针提取原始函数指针，处理 x86_64 与 aarch64 上的虚表布局。
+
+## I/O 与流
+
+### IStream
+
+`<photon/common/stream.h>` —— 抽象的 `read`/`readv`/`write`/`writev` 接口。提供 `ReadAll` RAII 辅助以及函数指针自省（`_and_read`、`_and_write`）以判断底层是否真正实现 I/O。
+
+### IMessage
+
+`<photon/common/message.h>` —— 基于 iovec 的数据报 send/recv。
+
+### iovector
+
+`<photon/common/iovector.h>` —— `iovector_view`（非拥有）和 `iovector`（拥有）。提供丰富的 iovec 数组操作：extract、slice、pipe、内置分配器。被 RPC 层和 HTTP 层广泛用于零拷贝 I/O。
+
+### IOAlloc
+
+`<photon/common/io-alloc.h>` —— 基于回调的缓冲区分配器。
+
+### IMessageChannel
+
+`<photon/common/message-channel.h>` —— 消息传递，支持 `OUT_OF_ORDER`、`PIPELINING`、`ROUND_TRIP` 标志。
+
+## 核心工具
+
+### DEFER 与作用域辅助
+
+`<photon/common/utility.h>`：
+- `DEFER` —— 作用域退出清理
+- `NewObj<T>` —— 两阶段构造模式
+- `likely` / `unlikely` —— 分支提示
+- 对齐与饱和算术辅助
+- `WITH` / `WITH_Release` —— 作用域资源块
+
+### Timeout
+
+`<photon/common/timeout.h>` —— `Timeout` 是基于 `photon::now`（微秒精度全局时间戳）的过期定时器。通过 `expired()`、`timeout_us()`、`timeout_ms()`、`timeout_s()` 查询。
+
+### retval
+
+`<photon/common/retval.h>` —— `retval<T>` 包装返回值并捕获当前 `errno`。
+
+### Range Lock
+
+`<photon/common/range-lock.h>` —— `RangeLock` 提供字节范围锁并检测冲突。`ScopedRangeLock` 是 RAII 守卫。
+
+### Throttle
+
+`<photon/common/throttle.h>` —— 带优先级的令牌桶限流器。
+
+### SingleFlight
+
+`<photon/common/singleflight.h>` —— 请求合并，防止缓存击穿。
+
+### RCUPtr
+
+`<photon/common/rcuptr.h>` —— `RCUPtr<T>` 是用户态 QSBR RCU 保护指针。
+
+### Generator
+
+`<photon/common/generator.h>` —— `Generator<Derived, ValueType>` 是基于 CRTP 的惰性迭代器生成器。
+
+### EventLoop
+
+`<photon/common/event-loop.h>` —— 通用事件循环，提供 `Wait4Events` / `OnEvents` 回调。
+
+### 性能计数器
+
+`<photon/common/perf_counter.h>` —— `REGISTER_PERF` / `REPORT_PERF` 宏，支持 `TOTAL`、`ACCUMULATE`、`AVERAGE` 类型。
+
+### Hash 组合器
+
+`<photon/common/hash_combine.h>` —— Boost 风格的可变参数 hash 组合器。
+
+### UUID
+
+`<photon/common/uuid.h>` 和 `uuid4.h` —— UUID v4 生成、解析、字符串转换。
+
+## 校验和
+
+所有校验和头文件位于 `<photon/common/checksum/...>`。
+
+| 头文件 | 描述 |
+|--------|------|
+| `crc32c.h` | CRC32C，自动检测硬件加速（SSE4.2 / ARM CRC）。支持 series、combine、trim。 |
+| `crc64ecma.h` | CRC64-ECMA，自动选择硬件/软件实现。 |
+| `xxhash.h` | xxHash 32-bit（纯软件）。 |
+| `digest.h` | 基于 OpenSSL EVP 的摘要：`sha1`、`sha256`、`sha512`、`md5`、`HMAC_*`。 |
+
+## 设计决策
+
+- **编译期格式串。** alog 在编译期处理基于反引号的格式串，而不是像 printf 那样在运行时解析。
+- **Delegate 优于 `std::function`。** `Delegate` 零开销（无堆分配、无类型擦除），支持成员函数并能正确处理虚表分发，且在编译期显式拒绝绑定临时 lambda 以降低生命周期风险。
+- **侵入式容器。** 侵入式链表和无锁队列避免逐节点堆分配，被调度器、reset handle 和对象池广泛使用。
+- **无锁队列。** 基于 turn 的槽位标记避免 ABA 问题。`RingChannel` 增加光子协程感知的阻塞，采用"先 yield 后信号量"策略。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/delegate_callback.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/delegate_callback.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 8
+toc_max_heading_level: 4
+---
+
+# Delegate 与 Callback
+
+Photon 中的 ```Delegate<...>``` 是一种用于高效回调的特定构造，比 ```std::function``` 更高效，同时同样方便。Delegate 是扩展的函数指针，（大多情况下）对自由函数和类成员函数通用。它 ***由两个成员组成***：目标函数的地址（自由函数或类成员函数均可），以及会作为第一个参数传给目标函数的值。对于自由函数，该参数是用户提供的 ```void*``` 类型的任意值；对于类成员函数，该参数则是所涉对象的隐式 ```this``` 指针。创建 Delegate 不涉及内存分配。
+
+它定义在 <photon/common/callback.h>，原型为：
+
+```cpp
+template<typename ResultType, typename...ArgumentTypes>
+struct Delegate;
+```
+
+它定义了一个回调函数，结果类型为 ```ResultType```，参数类型为 ```ArgumentTypes```。目标函数可以是任意类或结构体 ```T``` 的类型为 ```ResultType (T::*)(ArgumentTypes...)``` 的成员函数，也可以是类型为 ```ResultType (*)(void*, ArgumentTypes...)``` 的自由函数。此时第一个参数为 ```void*``` 指针，用来区分不同的回调调用，这在基于函数指针的回调机制中很常见。
+
+下面是一个 Delegate 示例。假设我们有一个 delegate 类型执行某种文件打开操作，并返回一个抽象文件对象的指针。
+
+```cpp
+class File;
+
+using OpenCallback = Delegate<File*, const std::string&, const char*> ;
+```
+
+我们有一个文件处理函数，通过调用 ```OpenCallback``` delegate 打开文件。
+
+```cpp
+void ProcessFiles(vector<string> fileNames, OpenCallback opencb) {
+    for (auto& fileName : fileNames) {
+        auto file = opencb(fileName, "r");  // 调用 delegate
+        // ...
+        delete file;
+    }
+}
+```
+
+作为 ```ProcessFiles()``` 的使用者，我们有多种方式提供打开文件的回调。第一种是类成员函数：
+
+```cpp
+class MyClass {
+    // ...
+public:
+    File* OpenFile_MF(const string& fileName, const char* mode) { ... }
+    //...
+};
+
+MyClass myClass;
+
+ProcessFiles(fileNames, { &myClass, &MyClass::OpenFile_MF });
+```
+
+第二种是自由函数。本例中 void* 的第一个参数是无用的，但在其他场景下可能有用。
+
+```cpp
+File* OpenFile_FF(void*, const string& fileName, const char* mode);
+
+ProcessFiles(fileNames, {nullptr, &OpenFile_FF});
+```
+
+第三种是 lambda 函数。
+
+```cpp
+auto lambda = [&](const string& fileName, const char* mode) {
+    // ...
+};
+
+ProcessFiles(fileNames, lambda);
+```
+
+注意 ```Delegate<...>``` 显式禁止绑定到临时 lambda 或 functor，以降低 lambda 对象生命周期管理上的风险。
+
+## 相关类型
+
+`<photon/common/callback.h>` 还定义了：
+
+| 类型 | 描述 |
+|------|------|
+| `Delegate<R, Ts...>` | 零开销可调用：自由函数、成员函数、lambda |
+| `Callback<Ts...>` | `Delegate<int, Ts...>` 的别名 |
+| `Closure<ARGS...>` | 自删除回调（用于一次性异步操作） |
+| `TempDelegate` | 绑定临时 lambda |
+
+`<photon/common/delegates.h>` 定义 `Delegates<Convs...>`，是类型安全的 delegate 门面，配合 `DEFINE_DELEGATE_FUNCTION` 宏在编译期进行方法分发。
+
+`<photon/common/PMF.h>` 提供 `get_member_function_address()`，从成员函数指针提取原始函数指针，处理 x86_64 与 aarch64 上的虚表布局。
+
+## 为什么选 Delegate 而不是 std::function
+
+- **零堆分配。** `Delegate` 就是一对指针（函数地址 + 上下文），从不分配内存。
+- **无类型擦除。** 自由函数和 lambda 的分发在编译期确定，成员函数则在构造时（伴随虚表查询）确定。
+- **成员函数感知。** 实现在 x86_64 和 aarch64 上都能正确区分普通成员函数与虚成员函数，提取正确的入口点。
+- **生命周期安全。** 在编译期显式拒绝绑定临时 lambda，避免 `std::function` 最常见的一类误用。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/filesystem-and-io.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/filesystem-and-io.md
@@ -86,3 +86,144 @@ int iouring_close(int fd);
 :::note
 io_uring 的事件引擎必须在 [Env](./env#init) 环境里正确初始化
 :::
+
+## 核心接口
+
+定义于 `<photon/fs/filesystem.h>`。
+
+### IFile（扩展自 IStream）
+
+带位置 I/O 接口：
+
+- `pread` / `preadv` / `pwrite` / `pwritev` —— 位置读写
+- `preadv2` / `pwritev2` —— 带标志（如 `RWF_NOWAIT`）
+- `lseek`、`fsync`、`fdatasync`、`fstat`、`ftruncate`、`fallocate`
+- `fiemap` —— extent 查询（被缓存层使用）
+- `trim`、`zero_range` —— 丢弃/清零操作
+- `append` / `appendv` —— 追加并输出位置
+- `ioctl` / `vioctl` —— 可扩展操作
+
+通过成员函数指针（`FuncPIO`、`FuncPIOCV` 等）进行分发。
+
+### IFileSystem
+
+类 POSIX 文件系统：
+
+- `open`、`creat`、`mkdir`、`rmdir`、`symlink`、`readlink`、`link`、`rename`、`unlink`
+- `chmod`、`chown`、`stat`、`lstat`、`access`、`truncate`
+- `statfs`、`statvfs`、`opendir` + `DIR` 接口
+- `FileList`：基于范围的目录项迭代
+
+### IFileXAttr / IFileSystemXAttr
+
+扩展属性：`getxattr`、`setxattr`、`listxattr`、`removexattr`。
+
+## 实现
+
+### 本地文件系统
+
+`<photon/fs/localfs.h>`。多 I/O 引擎后端：
+
+| 引擎 | 常量 | 描述 |
+|------|------|------|
+| psync | `ioengine_psync` (0) | 同步 POSIX I/O |
+| libaio | `ioengine_libaio` (1) | Linux AIO（需要 `O_DIRECT`） |
+| posixaio | `ioengine_posixaio` (2) | POSIX AIO |
+| iouring | `ioengine_iouring` (3) | io_uring |
+
+工厂函数：
+
+```cpp
+IFileSystem* new_localfs_adaptor(const char* root_path, int io_engine_type);
+IFile* open_localfile_adaptor(const char* filename, int flags, mode_t mode, int io_engine_type);
+```
+
+### 虚拟文件
+
+`<photon/fs/virtual-file.h>`。`VirtualFile` 自己管理 offset，并通过 `pread` / `pwrite` 实现 `read` / `write` / `readv` / `writev`。使用 `piov_copy` / `piov_nocopy` / `buffered_piov` 处理 iovector。
+
+### 组合器
+
+| 头文件 | 描述 |
+|--------|------|
+| `forwardfs.h` | `ForwardFile` / `ForwardFS` —— 装饰器模式：把所有操作转发给下层 |
+| `subfs.h` | 路径前缀重映射（类似 chroot 的视图） |
+| `throttled-file.h` | 限流文件 I/O |
+| `aligned-file.h` | 直接 I/O 的缓冲区对齐 |
+| `xfile.h` | 线性文件（拼接）、条带文件（类似 RAID-0） |
+| `range-split.h` | 把 I/O 范围拆分为对齐的子范围 |
+
+### HTTP 文件系统
+
+`<photon/fs/httpfs/httpfs.h>`。
+
+- `new_httpfs(default_https, conn_timeout, stat_expire)` —— 把 HTTP/HTTPS 视为文件系统。
+- `new_httpfile()` —— 单个 HTTP 文件，支持 range 请求。
+- v2 版本使用 Photon 自研的 HTTP 客户端，而不是 libcurl。
+
+### FUSE 适配
+
+`<photon/fs/fuse_adaptor/>`。把 Photon 文件系统暴露为 FUSE 挂载点。`session_loop.h` / `session_loop.cpp` 实现 FUSE 会话处理。
+
+### extfs
+
+`<photon/fs/extfs/>`。用户态 ext2/ext3/ext4 文件系统：`new_extfs(IFile* underlying_file)`。
+
+## 异步文件系统
+
+`<photon/fs/async_filesystem.h>`。
+
+`IAsyncFile` / `IAsyncFileSystem` / `AsyncDIR`：使用 `DEFINE_ASYNC` 宏模式的异步 I/O。每个操作接受 `(done_callback, timeout)`。
+
+适配器：
+
+- `new_async_file_adaptors()` —— 把 async 包装为 sync
+- `new_sync_file_adaptors()` —— 把阻塞操作委托给线程池
+- `export_as_async_file` / `fs` / `dir()` —— 把 sync 导出为 async
+- `export_as_sync_file` / `fs` / `dir()` —— 把 async 导出为 sync
+
+### ExportFS
+
+`<photon/fs/exportfs.h>`。`exportfs_init(thread_pool_capacity)` 创建用于跨线程文件系统访问的线程池。把同步对象导出为线程安全的 async/sync 包装，供外部 OS 线程使用。
+
+## 缓存层
+
+`<photon/fs/cache/>`。
+
+### 架构
+
+```
+ICachedFileSystem → ICachePool → ICacheStore (每文件缓存)
+                                      ├── RangeLock (并发访问)
+                                      ├── fiemap (缓存的 extent 查询)
+                                      └── 从源 FS 回填
+```
+
+### 关键类型
+
+| 类型 | 描述 |
+|------|------|
+| `ICachePool` | 按文件名管理缓存存储：`open()`、`set_quota()`、`evict()`、`sync_pool()` |
+| `ICacheStore` | 每文件缓存：`preadv2` / `pwritev2`，自动处理未命中、回填去重、`RangeLock` |
+| `IMemCacheStore` / `IMemCachePool` | 带缓冲 pin 的内存缓存 |
+
+### 缓存打开标志
+
+`O_WRITE_THROUGH`、`O_WRITE_AROUND`、`O_WRITE_BACK`、`O_CACHE_ONLY`、`O_DIRECT_LOCAL`、`O_MMAP_READ`。
+
+### 实现
+
+| 实现 | 描述 |
+|------|------|
+| `full_file_cache/` | 以本地 FS 为后端的文件缓存，使用 `fiemap` 查询 extent，LRU 驱逐 |
+| `policy/lru.h` | 基于数组的 LRU（无逐节点分配）：`push_front`、`access`、`pop_back` |
+| `ocf_cache/` | Open CAS（Cache Acceleration Software）集成 |
+| 持久化缓存 | 把数据块下载到后端存储，永不驱逐 |
+
+## 设计决策
+
+- **类 POSIX 接口。** `IFile` / `IFileSystem` 镜像 POSIX 语义，便于包装既有代码。
+- **装饰器组合。** `ForwardFile` / `ForwardFS` 支持透明分层：cache → throttle → align → local。
+- **用 fiemap 查询缓存。** 缓存层使用 `fiemap` 探查哪些字节范围已被缓存（对比空洞），避免单独的元数据存储。
+- **RangeLock 提供并发。** 防止对同一字节范围的并发读取 —— 第一个调用者从源读取，其他调用者等待并从缓存读取。
+- **多种 I/O 引擎。** 本地文件系统支持 psync / libaio / posixaio / iouring 后端，在创建时选择。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/lock-and-synchronization.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/lock-and-synchronization.md
@@ -111,3 +111,40 @@ public:
     int unlock();
 };
 ```
+
+## 全部同步原语
+
+| 原语 | 说明 |
+|------|------|
+| `spinlock` | 指数退避 |
+| `ticket_spinlock` | FIFO 顺序，无饥饿 |
+| `mutex` | 两阶段：CAS → yield 重试 → 配合 `thread_usleep_defer` 的等待队列 |
+| `recursive_mutex` | 可重入 mutex |
+| `seq_mutex` | FIFO mutex |
+| `condition_variable` | 扩展 `waitq`，支持基于谓词的等待 |
+| `semaphore` | 计数信号量，支持乱序恢复选项 |
+| `rwlock` | 传统读写锁 |
+| `qrwlock` | 针对读多场景优化 |
+| `locker<M>` / `SCOPED_LOCK` | 任意锁类型的 RAII 守卫 |
+
+## 实现细节
+
+### mutex
+
+`photon::mutex` 使用两阶段协议：
+
+1. 快路径：尝试 `CAS` 获取锁，不让出。
+2. 竞争路径：多次 `thread_yield()` 重试。
+3. 仍竞争：把当前协程推入等待队列，调用 `thread_usleep_defer()`，在不需要额外上下文切换的情况下释放内部 spinlock。
+
+### 基于 defer 的睡眠时解锁
+
+`thread_usleep_defer(timeout, defer, arg)` 在上下文切换后立即执行 `defer` 回调。这正是 `mutex::unlock()` 能在协程进入睡眠时释放内部 spinlock 的原因 —— 不需要经过调度器的额外往返。
+
+### 非对称 spinlock
+
+调度器内部使用的 spinlock 针对两种场景做了优化："前台 vCPU 访问自己的 runq"（单次原子 store）与"后台 vCPU 尝试迁入协程"（必须检查两个 flag）。
+
+### 工作窃取
+
+可选的跨 vCPU 负载平衡，通过 flag `VCPU_ENABLE_ACTIVE_WORK_STEALING` 和 `VCPU_ENABLE_PASSIVE_WORK_STEALING` 启用。窃取者扫描其他 vCPU 的 standby 队列和 run 队列。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/network.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/network.md
@@ -248,3 +248,101 @@ photon::init(INIT_EVENT_DEFAULT, INIT_IO_LIBCURL);
 ##### 封装
 
 同样的，我们在`<photon/fs/httpfs/httpfs.h>`也封装了它的fs，称为httpfs v2。
+
+## HTTP/1.1 内部
+
+| 头文件 | 关键类型 |
+|--------|----------|
+| `message.h` | `Message`（基类）、`Request`（method/target/path/query）、`Response`（状态码）。缓冲管理、头部解析、chunked/content-length 体流。 |
+| `headers.h` | `HeadersBase` —— 紧凑头部存储，使用 `rstring_view16`（offset + length 对），可排序以便二分查找。`Headers` 增加 chunked/content_length/range 辅助。 |
+| `body.h` | 体流工厂：`new_body_read_stream()`、`new_chunked_body_read/write_stream()` |
+| `parser.h` | 轻量解析器：`skip_string`、`skip_chars`、`extract_integer`、`extract_until_char` |
+| `url.h` | `URL` —— 解析 `scheme://user:passwd@host:port/path?query#fragment` |
+| `client.h` | `Client`（抽象）：`call(Operation*)`，支持重定向跟随、重试、超时、body_writer delegate。`OperationOnStack<N>` 用于栈分配。 |
+| `server.h` | `HTTPServer`：`handle_connection()`、模式匹配的 `add_handler()`。内置：`new_fs_handler()`、`new_proxy_handler()`。 |
+
+## HTTP/2
+
+定义于 `<photon/net/http/streams.h>`。完整实现 RFC 9113 / 7541：
+
+- `FrameHeader`（9 字节打包）：DATA、HEADERS、SETTINGS、PING、GOAWAY、WINDOW_UPDATE 等。
+- `H2Connection`：`send_preface`、`recv_preface`、`send_settings`、`send_goaway`、流管理。
+- `H2Stream`：包装 connection + stream_id 的值类型；状态机（Idle → Open → HalfClosed → Closed）。
+- `huffman/codec.h`：HPACK Huffman 编解码。
+
+## WebSocket
+
+`<photon/net/http/websocket.h>`。
+
+`IWebSocketStream`：send_text/binary、recv_frame、ping、close。
+
+- 客户端：`websocket_connect()`
+- 服务端：`server_accept_websocket()` + `new_websocket_handler()`
+
+## Cookie Jar
+
+`ICookieJar`：`get_cookies_from_headers()`、`set_cookies_to_headers()`。`new_simple_cookie_jar()` 提供内存存储。
+
+## 安全流
+
+### TLS
+
+`<photon/net/security-context/tls-stream.h>`。基于 OpenSSL：
+
+- `TLSContext`：证书、密钥、口令、验证模式、ALPN 协议列表。
+- `new_tls_stream(ctx, base, role)`：把 socket 包装为 TLS。
+- `new_tls_client/server(ctx, base)`：工厂包装。
+- `tls_stream_set_hostname()`：SNI。
+- `tls_stream_get_alpn_selected()`：协商得到的 ALPN 协议。
+
+### SASL
+
+`<photon/net/security-context/sasl-stream.h>`。基于 GNU SASL：
+
+- `SaslSession`：基于属性的配置。
+- `new_sasl_client/server_session()`：创建会话。
+- `new_sasl_stream()`：把 socket 包装为 SASL 认证流。
+
+## 连接池
+
+`<photon/net/socket.h>`。`TCPSocketPool` 包装 `ISocketClient`，按 `EndPoint` 为键池化连接。
+
+- 使用 `CascadingEventEngine` 检测对端关闭（`RDHUP`），不阻塞 vCPU 的主事件引擎。
+- `Timer` 用于 TTL 驱逐。
+- `PooledTCPSocketStream` 在出错时把 socket 标记为"drop"，在正常关闭时归还到池。
+
+工厂：`new_tcp_socket_pool()`。
+
+## 其他组件
+
+| 头文件 | 描述 |
+|--------|------|
+| `<photon/net/curl.h>` | RAII libcurl 包装：GET/HEAD/POST/PUT/DELETE，基于模板的流，与光子事件循环集成 |
+| `<photon/net/iostream.h>` | `new_iostream(ISocketStream*)`：把 socket 包装为 `std::iostream` |
+| `<photon/net/vdma.h>` | 用于共享内存零拷贝网络的虚拟 DMA |
+| `<photon/net/datagram_socket.h>` | `IDatagramSocket`、`UDPSocket`、`UDS_DatagramSocket` |
+
+## 协程集成
+
+定义于 `<photon/net/basic_socket.h>`。`doio_once` 模板：
+
+1. 尝试系统调用。
+2. 若返回 `EAGAIN`，调用 `wait_for_fd_readable()` 或 `wait_for_fd_writable()`。
+3. 光子协程挂起，FD 被注册到事件引擎。
+4. 恢复后，重试系统调用。
+
+`doio_loop` 重复此过程直到出错或 EOF。
+
+## 基类
+
+`<photon/net/base_socket.h>`：
+
+- `SocketClientBase` / `SocketServerBase`：把待设置的 socket 选项存入 `SockOptBuffer`（4KB 缓冲），延迟应用以避免多次 `setsockopt` 系统调用。
+- `ForwardSocketClient` / `ForwardSocketServer` / `ForwardSocketStream`：装饰器模式，转发到下层并可选择所有权。
+
+## 设计决策
+
+- **处处抽象接口。** `ISocketStream`、`ISocketClient`、`ISocketServer` 支持透明分层（TLS 叠加 TCP、pool 叠加 TLS 等）。
+- **所有权标志。** 包装接受 `ownership` 参数，控制是否在析构时删除下层。
+- **SockOptBuffer。** socket 选项在 `connect` / `bind` 之前保存，并延迟应用 —— 避免多次 `setsockopt` 系统调用。
+- **连接池使用 CascadingEventEngine。** socket 池检测 `RDHUP` 而不阻塞 vCPU 的主事件引擎。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/rpc.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/rpc.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 9
+toc_max_heading_level: 4
+---
+
+# RPC 框架
+
+`rpc/` 模块提供高性能 RPC 框架，具备零拷贝序列化、连接池和乱序异步执行能力。以 "zBuffer" 为题发表于 PPoPP'26。
+
+### 命名空间
+
+`photon::rpc::`
+
+### 头文件
+
+`<photon/rpc/rpc.h>`、`<photon/rpc/serialize.h>`、`<photon/rpc/out-of-order-execution.h>`
+
+## 协议
+
+定义于 `<photon/rpc/rpc.h>`。
+
+### 报文头
+
+每条 RPC 消息起始于 40 字节头部：
+
+| 字段 | 描述 |
+|------|------|
+| MAGIC | 常数 `0x87de5d02e6ab95c7` |
+| VERSION | 协议版本 |
+| size | 消息总长 |
+| FunctionID | interface + method 的组合 |
+| tag | 每条请求的相关标识 |
+
+### Stub 与 Skeleton
+
+- **`Stub`** —— RPC 客户端实体。`call<Operation>(req, resp, timeout)` 以零拷贝方式发起请求。
+- **`Skeleton`** —— RPC 服务端实体。`add_function()` 注册处理函数，`register_service<Operations...>()` 批量注册，`serve(IStream*)` 运行分发循环。
+- **`StubPool`** —— 带 TTL 过期和单次调用超时的连接池。提供 `get_stub(endpoint)`、`put_stub()`、`acquire()`。
+
+## 序列化
+
+定义于 `<photon/rpc/serialize.h>`。类型系统构建在 `iovector` 之上，实现零拷贝。
+
+### 字段类型
+
+| 类型 | 描述 |
+|------|------|
+| `buffer` | 变长字节缓冲 |
+| `fixed_buffer<T>` | 定长类型化缓冲 |
+| `array<T>` | 变长类型化数组 |
+| `string` | 基于切片的字符串（在 iovector 中的 offset + length） |
+| `slice` | 通用切片引用 |
+| `iovec_array` | iovec 数组 |
+| `sorted_map<K,V>` | 基于序列化数据的二分查找索引 map |
+
+### Archive
+
+- `SerializerIOV` —— 序列化到 iovector。
+- `DeserializerIOV` —— 反序列化并提取为 iovector。
+
+### Message 基类
+
+`rpc::Message` 定义 `serialize_fields()` 方法，以及 `add_checksum()` / `validate_checksum()`。`CheckedMessage<Hasher>` 自动加入 CRC32C 完整性校验。
+
+字段注册使用 `PROCESS_FIELDS(...)` 宏配合 `ArchiveBase<Derived>` CRTP，为每种支持的类型提供 `process_field()` 重载。
+
+## 乱序执行
+
+定义于 `<photon/rpc/out-of-order-execution.h>`。在对外呈现同步接口的同时，支持多个异步操作流水线执行。
+
+- **`OutOfOrderContext`** —— 每个操作的上下文，包含 `do_issue`、`do_completion`、`do_collect` 回调，以及 tag、phase、timeout。
+- `ooo_issue_operation()` —— 发起异步操作。
+- `ooo_wait_completion()` —— 等待完成。
+- `ooo_issue_wait()` —— 组合的 issue + wait。
+- `ooo_result_collected()` —— 标记结果已被消费。
+- `new_ooo_execution_engine()` —— 并发乱序执行引擎工厂。
+
+## 工厂函数
+
+| 工厂 | 描述 |
+|------|------|
+| `new_rpc_stub()` | 创建 RPC 客户端 stub |
+| `new_stub_pool()` | 创建连接池化的 stub pool |
+| `new_uds_stub_pool()` | Unix Domain Socket stub pool |
+| `new_skeleton()` | 创建 RPC 服务端 skeleton |
+
+## 设计决策
+
+- **零拷贝序列化。** `SerializerIOV` / `DeserializerIOV` 直接在 iovector 上工作，无中间缓冲拷贝。`sorted_map` 在序列化数据上进行二分查找，而不是反序列化为 `std::map`。
+- **基于切片的字符串。** 序列化后的字符串保存的是在 iovector 中的 offset + length，而不是副本，从而避免反序列化时的分配。
+- **CRC32C 校验。** `CheckedMessage` 使用硬件加速的 CRC32C 进行消息完整性校验。
+- **乱序执行。** 多个 RPC 调用可以在单连接上流水线化 —— 同时发起多个请求，再按到达顺序收集响应。
+- **StubPool。** 基于 TTL 的连接复用，减少 TCP 握手开销。
+
+## 相关模块
+
+- [网络](./network.md) —— `ISocketStream` 提供 RPC 传输，`TCPSocketPool` 作为 `StubPool` 的底层。
+- [通用工具](./common.md) —— `iovector` 用于零拷贝序列化，`crc32c` 用于校验，`Delegate` 用于回调。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/thread.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/thread.md
@@ -414,3 +414,57 @@ int Timer::cancel();
 int Timer::reset(uint64_t new_timeout = -1);
 int Timer::stop();
 ```
+
+## 运行时内部
+
+### vCPU 队列
+
+每个 vCPU 维护三个内部队列：
+
+- **RunQ** —— `READY` 协程的侵入式循环双向链表。vCPU 私有，正常操作无需加锁。
+- **SleepQ** —— 按 `ts_wakeup`（微秒唤醒时间）排序的二叉最小堆。
+- **StandbyQ** —— 由其他 vCPU 推入的协程（跨 vCPU 迁移），在 `resume_threads()` 期间被合并到 RunQ。
+- **Idle Worker** —— 专用的协程，在没有可运行的光子协程时驱动事件引擎。
+
+### thread 结构体
+
+`thread` 结构体位于 **栈底**（栈向上增长）。主要状态：`READY`、`RUNNING`、`SLEEPING`、`DONE`、`STANDBY`。
+
+栈分配：最小 16KB + guard page，按页对齐。频繁创建短生命周期协程时建议使用 `use_pooled_stack_allocator()` 以获得更好性能。
+
+### 上下文切换
+
+平台相关的汇编（`_photon_switch_context`）保存并恢复栈指针。`_photon_switch_context_defer` 在保存完上下文后，在源协程的栈上执行回调 —— 这正是 mutex 能在睡眠期间释放锁而无需额外上下文切换的原因。
+
+### 调度器
+
+- `thread_yield()` —— 让出给 RunQ 中的下一个协程。
+- `thread_usleep(timeout)` —— 睡眠 N 微秒（推入 SleepQ 并切换上下文）。
+- `thread_usleep_defer(timeout, defer, arg)` —— 睡眠 + 在切出后立即执行 defer。对 mutex 睡眠时解锁至关重要。
+- `thread_interrupt(th, errno)` —— 唤醒睡眠中的协程（设置 `error_number`）。
+- `thread_shutdown(th, flag)` —— 标记为关闭，若在睡眠中则唤醒。
+
+## Channel
+
+Go 风格的带类型 channel，定义在 `<photon/thread/go.h>`。
+
+- `channel<T>` —— 提供带缓冲（无锁 MPMC 队列 + semaphore）和无缓冲（mutex 会合）两种变体。
+- `select()` —— 多路复用 channel 操作。
+
+## std 兼容层
+
+`<photon/thread/std-compat.h>` 提供基于光子协程感知原语的替换品，可直接替换标准库使用：
+
+| 类型 | 替换 |
+|------|------|
+| `photon_std::thread` | `std::thread` |
+| `photon_std::mutex` | `std::mutex` |
+| `photon_std::condition_variable` | `std::condition_variable` |
+| `photon_std::promise` / `future` | `std::promise` / `std::future` |
+
+## 设计决策
+
+- **vCPU 私有队列。** RunQ 和 SleepQ 在正常调度期间从不跨 vCPU 共享，避免锁开销。
+- **非对称 spinlock。** 针对"前台 vCPU 访问自己的 runq"（单次原子 store）和"后台 vCPU 访问"（必须检查两个 flag）分别优化。
+- **基于 defer 的睡眠时解锁。** `thread_usleep_defer()` 在不需要额外上下文切换的情况下释放 mutex 内部的 spinlock。
+- **协程位于栈底。** 汇编可直接通过栈指针访问 thread 结构体。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/vcpu-and-multicore.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/api/vcpu-and-multicore.md
@@ -99,3 +99,105 @@ int WorkPool::thread_migrate(photon::thread* th = CURRENT, size_t index = -1UL);
 - `index` 目标 vCPU 的 index。如果 index 不在 [0, vcpu_num) 范围内，如默认值-1UL，将使用 round-robin 的方式选择下一个 vCPU。
      
 返回0表示成功， 小于0表示失败。
+
+## 事件引擎
+
+每个 vCPU 都有一个 `MasterEventEngine`，它阻塞在 I/O 事件上并通过 `thread_interrupt()` 唤醒睡眠中的光子协程。定义于 `<photon/io/fd-events.h>`。
+
+### MasterEventEngine
+
+每 vCPU 一个，驱动空闲循环：
+
+- `wait_for_fd(fd, interests, timeout)` —— 挂起当前协程直到 FD 事件
+- `wait_and_fire_events(timeout)` —— 阻塞并通过调用 `thread_interrupt(thread*, EOK)` 触发事件
+- `cancel_wait()` —— 唤醒引擎（通过 eventfd 或等价机制）
+
+### CascadingEventEngine
+
+用于复杂的多 FD 等待。不会阻塞 vCPU —— 只阻塞调用它的光子协程：
+
+- `add_interest(Event)` / `rm_interest(Event)` —— 管理 FD 注册
+- `wait_for_events(data[], count, timeout)` —— 等待多个事件
+
+### 事件标志
+
+```cpp
+EVENT_READ    = 1
+EVENT_WRITE   = 2
+EVENT_ERROR   = 4
+EDGE_TRIGGERED = 0x4000
+ONE_SHOT       = 0x8000
+```
+
+## 后端
+
+### epoll
+
+头文件：`<photon/io/epoll.cpp>`、`<photon/io/epoll-ng.cpp>`。
+
+- `epoll_create(1)` + eventfd 用于 `cancel_wait`
+- 按 fd 索引的 `_inflight_events` vector
+- ONE_SHOT interest，`data=CURRENT`（光子协程指针）
+- `wait_and_fire_events()`：`epoll_wait()` → 每个事件都调用 `thread_interrupt((thread*)data, EOK)`
+- `epoll-ng.cpp` 是边沿触发变体
+
+### io_uring
+
+头文件：`<photon/io/iouring-wrapper.h>`。
+
+功能最丰富的后端：
+
+- SQPoll 模式、IOPoll 模式、注册文件
+- `io_uring_prep_poll_add` / `multishot` 用于 fd 事件
+- `async_io()` 模板支持：read、write、send、recv、connect、accept、open、mkdir、close、splice、fsync
+- 通过 `io_uring_prep_cancel` 取消
+- 内核版本检测（5.11、5.15、5.18、5.19）用于特性门控
+- `IouringFixedFileFlag`（第 32 位）标记注册 FD
+
+### kqueue
+
+头文件：`<photon/io/kqueue.cpp>`。BSD/macOS 后端：
+
+- `EVFILT_USER` 用于自唤醒（`cancel_wait`）
+- `EV_ONESHOT` 用于单次事件等待
+
+### select
+
+内联 stub。在没有 epoll/kqueue 的平台上的回退方案。
+
+## 异步 I/O 后端
+
+### libaio
+
+头文件：`<photon/io/aio-wrapper.h>`。
+
+- `libaio_pread` / `preadv` / `pwrite` / `pwritev` —— 需要 `O_DIRECT` 和对齐的缓冲
+- 需要 `fd_events_init()` 进行事件通知
+
+### POSIX AIO
+
+- `posixaio_pread` / `pwrite` / `fsync` / `fdatasync`
+
+## 用户态网络
+
+| 头文件 | 描述 |
+|--------|------|
+| `<photon/io/fstack-dpdk.h>` | F-Stack / DPDK：`fstack_socket` / `connect` / `bind` / `listen` / `accept` / `send` / `recv` / `close` |
+| `<photon/io/spdknvme-wrapper.h>` | SPDK NVMe 块设备访问 |
+| `<photon/io/spdkbdev-wrapper.h>` | SPDK 通用块设备 |
+
+## 信号处理
+
+头文件：`<photon/io/signal.h>`。
+
+- `sync_signal_init()` 和 `sync_signal(signum, handler)` —— 信号处理函数在专用光子协程中运行
+- `block_all_signal()` 阻塞除 `SIGSTOP` / `SIGKILL` 之外的所有信号
+
+`<photon/io/reset_handle.h>` 定义 `ResetHandle`，是带 `reset()` 虚方法的侵入式链表节点。`reset_all_handle()` 在光子重新初始化时被调用。
+
+## 设计决策
+
+- **ONE_SHOT 语义。** 所有后端都使用 one-shot 事件注册，避免惊群并保证每个事件只唤醒一个协程。
+- **EOK 约定。** 事件以 `EOK`（ENXIO，"Event of NeXt I/O"）触发；被唤醒的协程通过检查 `error_number` 区分"事件唤醒"与"超时"。
+- **事件数据即协程指针。** `data=CURRENT` 把光子协程指针存入事件，使 `thread_interrupt()` 可直接调用，无需查表。
+- **Master 与 Cascading 分离。** Master 驱动空闲循环（阻塞 vCPU）；Cascading 处理每协程的多 FD 等待，而不阻塞其他协程。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/ecosystem/_category_.json
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/ecosystem/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "生态",
+  "position": 5,
+  "link": {
+    "type": "generated-index",
+    "description": "基于 Photon 构建的客户端与解析器。"
+  }
+}

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/ecosystem/overview.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/ecosystem/overview.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 1
+toc_max_heading_level: 4
+---
+
+# 生态
+
+`ecosystem/` 目录包含基于 Photon 核心模块构建的更高层客户端与解析器。它们为可选项，通过 CMake 选项 `PHOTON_ENABLE_ECOSYSTEM` 启用。
+
+### 命名空间
+
+`photon::`
+
+### 头文件
+
+`<photon/ecosystem/...>`
+
+## Redis 客户端
+
+`<photon/ecosystem/redis.h>` —— 协程感知的 Redis 客户端。
+
+- 直接在 `ISocketStream` 上实现 RESP（Redis Serialization Protocol）。
+- 支持字符串、哈希、列表、集合、有序集合、键操作、脚本、pub/sub、事务。
+- 使用 `Delegate` 回调进行响应解析，避免中间缓冲拷贝。
+- 连接复用通过 `net/` 中的标准 socket pool 原语提供。
+
+源码：`ecosystem/redis.h`、`ecosystem/redis.cpp`。
+
+## OSS 客户端
+
+`<photon/ecosystem/oss.h>` —— 阿里云对象存储 OSS 客户端。
+
+- 支持 bucket 和 object 操作：put、get、delete、list、multipart upload、copy、metadata。
+- 使用 `common/checksum` 和 `common/digest` 辅助，以 OSS V1/V4 签名对请求进行签名。
+- 流式上传下载使用 `iovector` 实现零拷贝 I/O。
+- XML 响应使用 `simple_dom` 解析。
+
+源码：`ecosystem/oss.h`、`ecosystem/oss.cpp`、`ecosystem/oss_constants.h`。
+
+## simple_dom
+
+`<photon/ecosystem/simple_dom.h>` —— 轻量级、无分配的 JSON、XML、YAML DOM 解析器。
+
+- 三种格式共享同一棵树形表示。
+- `SimpleDOM::Document` 从缓冲区解析，通过路径式查询访问节点。
+- 适合配置解析和较小的响应体，不适合大型流式文档。
+- `rapidjson` 和 `rapidxml`（作为后端使用）的补丁保存在 `ecosystem/patches/`。
+
+源码：`ecosystem/simple_dom.h`、`ecosystem/simple_dom.cpp`、`ecosystem/simple_dom_impl.h`。
+
+## 构建
+
+仅在 `PHOTON_ENABLE_ECOSYSTEM=ON` 时构建生态模块：
+
+```bash
+cmake -B build -D PHOTON_BUILD_TESTING=ON -D PHOTON_ENABLE_ECOSYSTEM=ON
+cmake --build build -j 8
+```
+
+## 相关模块
+
+- [网络](../api/network.md) —— `ISocketStream`、HTTP 客户端、TLS 流，作为传输层使用。
+- [通用工具](../api/common.md) —— `iovector`、`Delegate`、校验和、`estring`，被广泛使用。
+- [文件系统与 I/O](../api/filesystem-and-io.md) —— 部分生态代码通过 `fs/httpfs` 将远端存储视为文件系统。

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/introduction/photon-architecture.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/introduction/photon-architecture.md
@@ -17,3 +17,79 @@ Photon 的主要目标是处理并发与 I/O (包括文件和网络 I/O)
 * 高性能的 RPC client/server 和 HTTP client/server.
 * POSIX 文件系统抽象和实现: local fs, http fs, fuse fs, e2fs, 等等
 * 其他通用库，如 io-vector操作, 资源池, 对象池, 内存分配器, 回调代理，编译期logging模块, 无锁队列, defer, range lock, 限流模块, 等等
+
+## 分层架构
+
+```
++--------------------------------------------------------------------+
+|                      应用代码                                      |
++--------------------------------------------------------------------+
+|  go() / thread_create11() / thread_create()  |  photon_std::thread |
++--------------------------------------------------------------------+
+|                   photon::thread (协程)                            |
+|  调度器 (RunQ/SleepQ/StandbyQ) | 同步原语 | channel<T>             |
++--------------------------------------------------------------------+
+|                        vCPU (OS 线程)                              |
+|  MasterEventEngine (epoll/io_uring/kqueue) + 空闲协程              |
++--------------------------------------------------------------------+
+|                    WorkPool (多 vCPU)                              |
+|  std::thread[] + LockfreeMPMCRingQueue 做任务分发                  |
++--------------------------------------------------------------------+
+|   fs/ (文件系统)  |  net/ (socket、HTTP)  |  rpc/ (RPC)            |
++--------------------------------------------------------------------+
+|              common/ (工具、日志、容器)                             |
++--------------------------------------------------------------------+
+```
+
+自顶向下：
+
+1. **应用代码** 使用 Photon 的协程原语（`go`、`thread_create11`、`photon_std::thread`）表达并发。
+2. **协程层** 在每 vCPU 的队列上调度 `photon::thread`，提供同步原语（`mutex`、`semaphore`、`condition_variable`、`rwlock`）和 Go 风格的 `channel<T>`。
+3. **vCPU 层** 运行空闲协程，在没有可运行光子协程时驱动 `MasterEventEngine`（epoll、io_uring、kqueue 或 select）。
+4. **WorkPool** 管理多个 vCPU 并通过无锁 MPMC 队列分发任务。
+5. **服务模块**（`fs`、`net`、`rpc`）提供文件系统、网络、RPC 抽象。
+6. **common/** 提供跨模块工具：日志、字符串、容器、delegate、I/O 向量、校验和。
+
+## 模块概览
+
+| 模块 | 用途 | 关键文件 |
+|------|------|----------|
+| [thread/](../api/thread.md) | 协程运行时、调度器、同步原语、channel | `thread.h`、`thread.cpp`、`go.h`、`thread-pool.h`、`workerpool.h` |
+| [io/](../api/vcpu-and-multicore.md#事件引擎) | 事件引擎后端（epoll、io_uring、kqueue）、信号处理 | `fd-events.h`、`epoll.cpp`、`iouring-wrapper.cpp`、`kqueue.cpp` |
+| [net/](../api/network.md) | socket 抽象、HTTP client/server、TLS、连接池 | `socket.h`、`http/client.h`、`http/server.h`、`security-context/tls-stream.h` |
+| [fs/](../api/filesystem-and-io.md) | 文件系统 VFS、本地 fs、HTTP fs、缓存层 | `filesystem.h`、`localfs.h`、`cache/cache.h` |
+| [rpc/](../api/rpc.md) | 零拷贝序列化的高性能 RPC | `rpc.h`、`serialize.h`、`out-of-order-execution.h` |
+| [common/](../api/common.md) | 日志、字符串工具、容器、delegate、异步辅助 | `alog.h`、`estring.h`、`callback.h`、`iovector.h`、`lockfree_queue.h` |
+| [ecosystem/](../ecosystem/overview.md) | Redis 客户端、OSS 客户端、JSON/XML/YAML 解析 | `redis.h`、`oss.h`、`simple_dom.h` |
+
+## 关键设计模式
+
+**接口隔离。** 抽象接口（`IStream`、`IFile`、`IFileSystem`、`ISocketStream`、`ISocketClient`、`ISocketServer`）分离关注点，便于组合。
+
+**装饰器模式。** `ForwardFile`、`ForwardFS`、`ForwardSocket*` 透明地包装下层对象 —— 用于 TLS、缓存、限流、对齐。
+
+**工厂函数。** `new_*_client()`、`new_*_server()`、`new_localfs_adaptor()` 等在抽象接口后创建具体实现。
+
+**策略模式。** 可插拔的事件引擎（epoll / io_uring /kqueue）和 I/O 引擎（psync / libaio / iouring）实现同一接口，在创建时选择。
+
+**Delegate 回调。** `Delegate<R, Ts...>` 为 handler、body writer、异步完成回调提供零开销包装。参见 [Delegate 与 Callback](../api/delegate_callback.md)。
+
+**侵入式集合。** `intrusive_list_node<T>` 用于 reset handle、socket 池、调度器队列，避免逐节点分配。
+
+## 协程与 I/O 集成
+
+所有 I/O 都通过"事件驱动的挂起"与协程系统集成：
+
+1. 系统调用返回 `EAGAIN` → 包装层调用 `wait_for_fd_readable()` 或 `wait_for_fd_writable()`。
+2. 当前光子协程挂起，FD 被注册到 `MasterEventEngine`。
+3. 事件到达时，`thread_interrupt()` 把协程从 sleep 队列移到 run 队列。
+4. 调度器恢复协程，重试系统调用。
+
+该模式出现在 `net/basic_socket.h`（`doio_once` 模板）中，并在整个代码库复用。
+
+## 约定
+
+- **所有权。** 包装对象接受 `ownership` 参数（通常是 `bool`），用于控制是否在析构时删除被包装对象。
+- **超时。** 所有 I/O 操作接受与 `photon::now`（微秒精度全局时间戳）集成的 `Timeout` 对象。
+- **错误处理。** 出错时函数返回 `-1` 或 `nullptr`，设置 `errno`，并通过 `LOG_ERROR_RETURN` 记日志。
+- **线程安全。** Photon 的同步原语（`mutex`、`semaphore`、`condition_variable`）是协程感知的；对应的 `std::` 会阻塞底层 OS 线程。


### PR DESCRIPTION
Add comprehensive architecture overview to main AGENTS.md and create module-specific AGENTS.md files for thread/, common/, io/, net/, fs/, and rpc/ directories. Each document covers key components, design decisions, and cross-module references with relative links.

Also add sections for include paths, testing conventions, and common pitfalls to help new development sessions get productive quickly.