### PR TITLE
Set dtime to 0xFFFFFFFFu when NO_TIMESTAMP to bypass fsck LOW_DTIME check on e2fsprogs >= 1.46

### DIFF
--- a/fs/extfs/extfs_utils.i
+++ b/fs/extfs/extfs_utils.i
@@ -174,7 +174,10 @@ static int remove_inode(ext2_filsys fs, ext2_ino_t ino) {
 #ifndef NO_TIMESTAMP
         inode.i_dtime = time(0);
 #else
-        inode.i_dtime = 1;
+        // e2fsck >= 1.46 reports LOW_DTIME (orphan-list) when
+        // 0 < i_dtime < s_inodes_count and super timestamps are 0.
+        // Use UINT32_MAX to stay non-zero and skip the check.
+        inode.i_dtime = 0xFFFFFFFFu;
 #endif
     }
 


### PR DESCRIPTION
## Symptom

EXT4 images built with `-DNO_TIMESTAMP` trigger the following on every unlinked inode when checked by e2fsck **>= 1.46.0**:

```
Inode N was part of the orphaned inode list.  IGNORED.
WARNING: Filesystem still has errors  (exit 4)
```

Regression introduced by #1165.

## Root cause

`e2fsck/pass1.c` LOW_DTIME fires when `i_dtime && i_dtime < s_inodes_count`, unless the guard disables it. e2fsprogs v1.46.0 (commit `b403c0c4`) tightened the guard to require `s_wtime` / `s_mtime` to be non-zero. NO_TIMESTAMP builds keep them at 0 for image reproducibility, so the check stays armed and `i_dtime = 1` always trips it.

| e2fsprogs | NO_TIMESTAMP + dtime=1 |
|---|---|
| <= 1.43.5 | passes |
| >= 1.46.0 | reports orphan-list on every unlink |

## Fix

`i_dtime = 1` → `i_dtime = 0xFFFFFFFFu` in the NO_TIMESTAMP branch of `remove_inode`.

## Why a large dtime is safe

Neither e2fsck nor the kernel ext4 driver compares `i_dtime` against any upper bound. It is only used as `next_ino` of the on-disk orphan list, never as a wall-clock timestamp. `0xFFFFFFFFu` keeps dtime non-zero (so the inode is still marked deleted) and `>= s_inodes_count` (so LOW_DTIME does not fire).

## Verification

256 MiB image → write 64 KiB → unlink → upstream e2fsck 1.47.0 `-nfvv`:

| State | exit | report |
|---|---|---|
| Before | 4 | orphan-list error |
| After | 0 | clean |

## References

- #1165
- e2fsprogs v1.46.0 `3fac78e` `576fada`