### PR TITLE
[Pick][0.8 to 0.9] | Set dtime to 0xFFFFFFFFu when NO_TIMESTAMP to bypass fsck LOW_DTIME check on e2fsprogs >= 1.46 (#1240) (#1242) 

### DIFF
--- a/fs/extfs/extfs_utils.i
+++ b/fs/extfs/extfs_utils.i
@@ -174,7 +174,10 @@ static int remove_inode(ext2_filsys fs, ext2_ino_t ino) {
 #ifndef NO_TIMESTAMP
         inode.i_dtime = time(0);
 #else
-        inode.i_dtime = 1;
+        // e2fsck >= 1.46 reports LOW_DTIME (orphan-list) when
+        // 0 < i_dtime < s_inodes_count and super timestamps are 0.
+        // Use UINT32_MAX to stay non-zero and skip the check.
+        inode.i_dtime = 0xFFFFFFFFu;
 #endif
     }
 


### PR DESCRIPTION
> Set dtime to 0xFFFFFFFFu when NO_TIMESTAMP to bypass fsck LOW_DTIME check on e2fsprogs >= 1.46 (#1240) (#1242)

Signed-off-by: zhuangbowei.zbw <zhuangbowei.zbw@alibaba-inc.com>
Co-authored-by: ZAwei <zhuangbowei.zbw@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits