### PR TITLE
Fix critical bugs in work-stealing and thread-pool

### DIFF
--- a/thread/thread-pool.cpp
+++ b/thread/thread-pool.cpp
@@ -27,7 +27,7 @@ namespace photon
     }
 
     void set_bypass_threadpool(bool flag) {
-        __bypass_threadpool = true;
+        __bypass_threadpool = flag;
     }
 
     TPControl* ThreadPoolBase::thread_create_ex(thread_entry start, void* arg, bool joinable)

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -2029,7 +2029,7 @@ insert_list:
             th->vcpu->nthreads--;
             th->vcpu = v;
             v->nthreads++;
-        } while (q.front()->allow_work_stealing());
+        } while (!q.empty() && q.front()->allow_work_stealing());
         return stolen.eject_whole();
     }
     inline __attribute__((always_inline))
@@ -2046,8 +2046,11 @@ insert_list:
         scoped_rwlock _(vcpu_t::vcpu_list_rwlock, RLOCK);
         auto u = vcpu->next();
         while (u != vcpu) {
-            if (0 == (u->flags & VCPU_ENABLE_PASSIVE_WORK_STEALING))
+            if (0 == (u->flags & VCPU_ENABLE_PASSIVE_WORK_STEALING)) {
+                SCOPED_LOCK(vcpu_t::vcpu_list_lock);
+                u = u->next();
                 continue;
+            }
             thread* th;
             if ((th = ws_scan_standbyq(vcpu, u)) || (th = ws_scan_runq(vcpu, u))) {
                 vcpu->idle_worker->insert_list_tail(th);


### PR DESCRIPTION
## Summary

Fixes #1245

- Fix infinite loop in `try_work_stealing()`: advance iterator before `continue`
- Fix null deref in `ws_scan_standbyq()`: check `q.empty()` before accessing `q.front()`
- Fix `set_bypass_threadpool(bool flag)`: use `flag` parameter instead of hardcoded `true`

## Changes

| File | What changed | What was NOT changed |
|------|-------------|---------------------|
| `thread/thread.cpp` | Added `SCOPED_LOCK + u=u->next()` in the passive-check skip path; added `!q.empty()` guard in do-while condition | No changes to lock ordering, scheduling logic, or thread lifecycle |
| `thread/thread-pool.cpp` | Changed `= true` to `= flag` | No changes to thread pool capacity, creation, or join logic |

## Verification

- Adversarial code review by independent agents confirmed all three fixes are correct
- No new lock ordering issues introduced (RLOCK -> spinlock ordering preserved)
- No behavioral change for existing callers (no code currently calls `set_bypass_threadpool(false)`)

## Test plan

- [ ] Existing work-stealing tests pass
- [ ] Multi-vCPU test with mixed flags (active-only + passive-only + none) does not hang
- [ ] `ctest` full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)