### PR TITLE
Fix fd leak in accept() when setsockopt fails

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -359,6 +359,7 @@ public:
             return nullptr;
         }
         if (m_opts.setsockopt(cfd) != 0) {
+            ::close(cfd);
             return nullptr;
         }
         return create_stream(cfd);


### PR DESCRIPTION
## Summary

Fixes #1247

Close the accepted fd when `setsockopt()` fails in `KernelSocketServer::accept()`, preventing fd leak.

## Changes

| File | Change |
|------|--------|
| `net/kernel_socket.cpp:362` | Added `::close(cfd)` before `return nullptr` |

## Test plan

- [ ] Existing network tests pass
- [ ] Manual: accept + fail setsockopt scenario no longer leaks fd (check /proc/pid/fd count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)