### PR TITLE
Fix Photon SleepQueue stale idx corruption during wakeup and migration

### DIFF
--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -53,3 +53,7 @@ add_test(NAME test-st-utest COMMAND $<TARGET_FILE:test-st-utest>)
 add_executable(test-go-channel test-go-channel.cpp)
 target_link_libraries(test-go-channel PRIVATE photon_shared)
 add_test(NAME test-go-channel COMMAND $<TARGET_FILE:test-go-channel>)
+
+add_executable(test-sleepq-stale-idx test-sleepq-stale-idx.cpp)
+target_link_libraries(test-sleepq-stale-idx PRIVATE photon_shared)
+add_test(NAME test-sleepq-stale-idx COMMAND $<TARGET_FILE:test-sleepq-stale-idx>)

--- a/thread/test/test-sleepq-stale-idx.cpp
+++ b/thread/test/test-sleepq-stale-idx.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <atomic>
+#include <chrono>
+
+#include "../../test/gtest.h"
+#include <photon/common/utility.h>
+#include <photon/photon.h>
+#include <photon/thread/thread.h>
+#include <photon/thread/thread11.h>
+#include <photon/thread/workerpool.h>
+
+TEST(SleepQueue, pop_front_single_sleeper_clears_idx_before_migrate) {
+    ASSERT_EQ(0, photon::init(photon::INIT_EVENT_EPOLL, photon::INIT_IO_NONE));
+    DEFER(photon::fini());
+
+    photon::WorkPool pool(1, photon::INIT_EVENT_EPOLL, photon::INIT_IO_NONE, 0);
+    std::atomic<bool> done{false};
+
+    photon::thread_create11([&] {
+        // Keep this thread as the only sleeper on the source vCPU, so timeout
+        // wakeup must go through SleepQueue::pop_front()'s single-node path.
+        photon::thread_usleep(1000);
+
+        // Re-enter SleepQueue::pop() from another vCPU's standbyq drain. A stale
+        // idx left by pop_front() used to make this pop dereference/corrupt the
+        // target vCPU's sleepq.
+        pool.thread_migrate(photon::CURRENT, 0);
+        done.store(true, std::memory_order_release);
+    });
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!done.load(std::memory_order_acquire)) {
+        photon::thread_yield();
+        ASSERT_LT(std::chrono::steady_clock::now(), deadline);
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/thread/test/test-sleepq-stale-idx.cpp
+++ b/thread/test/test-sleepq-stale-idx.cpp
@@ -25,10 +25,10 @@ limitations under the License.
 #include <photon/thread/workerpool.h>
 
 TEST(SleepQueue, pop_front_single_sleeper_clears_idx_before_migrate) {
-    ASSERT_EQ(0, photon::init(photon::INIT_EVENT_EPOLL, photon::INIT_IO_NONE));
+    ASSERT_EQ(0, photon::init());
     DEFER(photon::fini());
 
-    photon::WorkPool pool(1, photon::INIT_EVENT_EPOLL, photon::INIT_IO_NONE, 0);
+    photon::WorkPool pool(1, photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE, 0);
     std::atomic<bool> done{false};
 
     photon::thread_create11([&] {

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -391,6 +391,7 @@ namespace photon
             auto ret = q[0];
             if (q.size() == 1) {
                 q.pop_back();
+                ret->idx = -1;
                 return ret;
             }
             q[0] = q.back();
@@ -403,20 +404,21 @@ namespace photon
 
         int pop(thread *obj)
         {
-            if (obj->idx == -1) return -1;
-            if ((size_t)obj->idx == q.size() - 1){
+            auto id = obj->idx;
+            if (id == -1) return -1;
+            if ((size_t)id == q.size() - 1){
                 q.pop_back();
                 obj->idx = -1;
                 return 0;
             }
 
-            auto id = obj->idx;
             if (q.size() == 1) {
                 assert(id == 0);
                 q.pop_back();
+                obj->idx = -1;
                 return 0;
             }
-            q[obj->idx] = q.back();
+            q[id] = q.back();
             q[id]->idx = id;
             q.pop_back();
             if (!up(id)) down(id);


### PR DESCRIPTION
## Summary

  Fix a `SleepQueue` stale `idx` bug in Photon that could corrupt the sleep heap and cause occasional crashes

  ## Background

  Occasional crashes when using the workerpool in v0.9.4.. The core stack pointed to Photon scheduler internals:

  ```text
  photon::thread::operator<
  photon::SleepQueue::down
  photon::SleepQueue::pop
  photon::resume_threads_inlined
  photon::idler
```
or
```text
  photon::SleepQueue::pop_front
  photon::resume_threads_inlined
  photon::idler
```

  This indicated that SleepQueue could contain corrupted or invalid thread entries, eventually crashing while adjusting the heap or comparing thread::ts_wakeup.

  ## Root Cause

  SleepQueue uses thread::idx as a reverse index into its internal heap:

  thread is in sleepq     => idx >= 0 && q[idx] == thread
  thread is not in sleepq => idx == -1

  The original SleepQueue::pop_front() missed this invariant in the single-element case:

  ```cpp
  if (q.size() == 1) {
      q.pop_back();
      return ret;
  }
```

  As a result, when the only sleeping thread timed out, it was removed from sleepq, but its idx still remained 0.

  A failure scenario:

  1. A vCPU has exactly one sleeping thread T.
  2. T times out.
  3. idler() wakes it through sleepq.pop_front().
  4. T is removed from sleepq, but T->idx is still 0.
  5. T is later migrated or resumed through another vCPU path.
  6. The target vCPU drains standbyq in resume_threads_inlined() and calls sleepq.pop(T).
  7. sleepq.pop(T) trusts the stale idx, causing invalid access, wrong heap deletion, or heap corruption.
  8. A later SleepQueue::down() / thread::operator<() may dereference a bad thread pointer and crash.

  ## Fix

  1. Clear idx in the single-element pop_front() path:
  ```cpp
  ret->idx = -1;
```

  2. Clear obj->idx consistently in the single-element pop() path as well.

  ## Test

  Added a regression test:

  PhotonLibOS/thread/test/test-sleepq-stale-idx.cpp

  The test builds the minimal failure scenario:

  1. Create one Photon thread as the only sleeper on the source vCPU.
  2. Let it time out, forcing SleepQueue::pop_front() to take the single-element path.
  3. Migrate the same thread to a WorkPool vCPU.
  4. Let the target vCPU drain standbyq and call sleepq.pop(th).
  5. Verify that the scheduler does not crash or hang.

Co-Authored-By: Codex gpt-5.5