### PR TITLE
[Pick][0.7] Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255)

### DIFF
--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -39,3 +39,7 @@ add_test(NAME test-lib-data COMMAND $<TARGET_FILE:test-lib-data>)
 add_executable(test-multi-vcpu-locking test-multi-vcpu-locking.cpp)
 target_link_libraries(test-multi-vcpu-locking PRIVATE photon_shared)
 add_test(NAME test-multi-vcpu-locking COMMAND $<TARGET_FILE:test-multi-vcpu-locking>)
+
+add_executable(test-sleepq-stale-idx test-sleepq-stale-idx.cpp)
+target_link_libraries(test-sleepq-stale-idx PRIVATE photon_shared)
+add_test(NAME test-sleepq-stale-idx COMMAND $<TARGET_FILE:test-sleepq-stale-idx>)

--- a/thread/test/test-sleepq-stale-idx.cpp
+++ b/thread/test/test-sleepq-stale-idx.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <atomic>
+#include <chrono>
+
+#include "../../test/gtest.h"
+#include <photon/common/utility.h>
+#include <photon/photon.h>
+#include <photon/thread/thread.h>
+#include <photon/thread/thread11.h>
+#include <photon/thread/workerpool.h>
+
+TEST(SleepQueue, pop_front_single_sleeper_clears_idx_before_migrate) {
+    ASSERT_EQ(0, photon::init());
+    DEFER(photon::fini());
+
+    photon::WorkPool pool(1, photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE, 0);
+    std::atomic<bool> done{false};
+
+    photon::thread_create11([&] {
+        // Keep this thread as the only sleeper on the source vCPU, so timeout
+        // wakeup must go through SleepQueue::pop_front()'s single-node path.
+        photon::thread_usleep(1000);
+
+        // Re-enter SleepQueue::pop() from another vCPU's standbyq drain. A stale
+        // idx left by pop_front() used to make this pop dereference/corrupt the
+        // target vCPU's sleepq.
+        pool.thread_migrate(photon::CURRENT, 0);
+        done.store(true, std::memory_order_release);
+    });
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!done.load(std::memory_order_acquire)) {
+        photon::thread_yield();
+        ASSERT_LT(std::chrono::steady_clock::now(), deadline);
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -358,6 +358,7 @@ namespace photon
             auto ret = q[0];
             if (q.size() == 1) {
                 q.pop_back();
+                ret->idx = -1;
                 return ret;
             }
             q[0] = q.back();
@@ -370,20 +371,21 @@ namespace photon
 
         int pop(thread *obj)
         {
-            if (obj->idx == -1) return -1;
-            if ((size_t)obj->idx == q.size() - 1){
+            auto id = obj->idx;
+            if (id == -1) return -1;
+            if ((size_t)id == q.size() - 1){
                 q.pop_back();
                 obj->idx = -1;
                 return 0;
             }
 
-            auto id = obj->idx;
             if (q.size() == 1) {
                 assert(id == 0);
                 q.pop_back();
+                obj->idx = -1;
                 return 0;
             }
-            q[obj->idx] = q.back();
+            q[id] = q.back();
             q[id]->idx = id;
             q.pop_back();
             if (!up(id)) down(id);


### PR DESCRIPTION
Cherry-pick of #1255 to `release/0.7`.

## Summary

Fix a SleepQueue stale `idx` bug that could corrupt the sleep heap and cause occasional crashes when a sole sleeping thread times out and is later resumed/migrated through another vCPU path.

## Affected branches

The buggy single-element short-circuit in `SleepQueue::pop_front()` / `pop()` was first introduced into `release/0.7` by commit `2b5e30a` ("FIX on SleepQueue (#1151)"), and similarly into `release/0.8` (`e2d638b`) and `release/0.9` (`02db75f`). `release/0.6` and earlier are not affected.

This PR targets `release/0.7`. Once merged, the auto-pr workflow will cascade the fix to `release/0.8` → `release/0.9` → `main` automatically (main already contains #1255).

## Conflict resolution

Only `thread/test/CMakeLists.txt` had a textual conflict — `release/0.7` does not yet have `test-pooled-stack-allocator` / `test-st-utest` / `test-go-channel`, so only the `test-sleepq-stale-idx` registration was kept. `thread/thread.cpp` and the new test file were applied cleanly.
