### PR TITLE
Fix UDP recv waiting on writable instead of readable

### DIFF
--- a/net/datagram_socket.cpp
+++ b/net/datagram_socket.cpp
@@ -105,7 +105,7 @@ public:
             .msg_flags = 0,
         };
         auto ret = DOIO_ONCE(::recvmsg(fd, &hdr, MSG_DONTWAIT | flags),
-                         wait_for_fd_writable(fd));
+                         wait_for_fd_readable(fd));
         if (addrlen) *addrlen = hdr.msg_namelen;
         return ret;
     }


### PR DESCRIPTION
## Summary
- `do_recv` in DatagramSocketClientUDPBase used `wait_for_fd_writable` instead of `wait_for_fd_readable` for `recvmsg`, causing the coroutine to wait for the wrong I/O readiness event.

## Changes
- `net/datagram_socket.cpp`: `wait_for_fd_writable` → `wait_for_fd_readable` in DOIO_ONCE for recvmsg

## Verification
- [x] Compilation verified (URING ON/OFF)
- [x] Full test suite: no regressions
- [x] 3-reviewer adversarial code review: unanimous APPROVE