### PR TITLE
Fix swapped sscanf arguments in Content-Range parsing

### DIFF
--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -268,10 +268,10 @@ size_t Message::body_size() const {
     it = headers.find("Content-Range");
     if (it == headers.end()) return 0;
     size_t start, end;
-    if (sscanf("bytes %lu-%lu", it.second().data(), &start, &end) == 2) {
+    if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
         return end-start+1;
     }
-    if (sscanf("bytes */%lu", it.second().data(), &end) == 1) {
+    if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
         return end;
     }
     return 0;


### PR DESCRIPTION
## Summary
- In HTTP Content-Range header parsing, `sscanf` arguments were swapped: the format string was passed as input and the input as format. This made Content-Range parsing always fail silently.

## Changes
- `net/http/message.cpp`: Swap sscanf arguments to correct order at lines 271 and 274

## Verification
- [x] Compilation verified (URING ON/OFF)
- [x] Full test suite: no regressions
- [x] 3-reviewer adversarial code review: unanimous APPROVE