### PR TITLE
Fix zerocopy counter increment on sendmsg failure

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -500,6 +500,8 @@ protected:
 
     ssize_t do_sendmsg(int sockfd, const struct msghdr* message, int flags, Timeout timeout) override {
         ssize_t n = photon::net::sendmsg(sockfd, message, flags | ZEROCOPY_FLAG, timeout);
+        if (n < 0)
+            return n;
         m_num_calls++;
         auto ret = zerocopy_confirm(sockfd, m_num_calls - 1, timeout);
         if (ret < 0)


### PR DESCRIPTION
## Summary
- In `do_sendmsg` of the zerocopy socket, `m_num_calls++` happened unconditionally even when `sendmsg` returned an error. This desynchronized the notification counter, causing `zerocopy_confirm()` to hang waiting for a kernel notification that never arrives.

## Changes
- `net/kernel_socket.cpp`: Add `if (n < 0) return n;` before `m_num_calls++`

## Verification
- [x] Compilation verified (URING ON/OFF)
- [x] Full test suite: no regressions
- [x] 3-reviewer adversarial code review: unanimous APPROVE