### PR TITLE
Fix OOB access in event engines when fd is 0

### DIFF
--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -121,7 +121,7 @@ public:
         if (unlikely(!e.interests))
             return 0;
         if (unlikely((size_t)e.fd >= _inflight_events.size()))
-            _inflight_events.resize(e.fd * 2);
+            _inflight_events.resize(e.fd * 2 + 2);
 
         e.interests &= EVENT_RWEO;
         auto& entry = _inflight_events[e.fd];

--- a/io/kqueue.cpp
+++ b/io/kqueue.cpp
@@ -160,7 +160,7 @@ public:
         if (e.fd < 0)
             LOG_ERROR_RETURN(EINVAL, -1, "invalid file descriptor ", e.fd);
         if ((size_t)e.fd >= _inflight_events.size())
-            _inflight_events.resize(e.fd * 2);
+            _inflight_events.resize(e.fd * 2 + 2);
         auto& entry = _inflight_events[e.fd];
         if (e.interests & entry.interests) {
             if (((e.interests & entry.interests & EVENT_READ) &&


### PR DESCRIPTION
## Summary
- In `add_interest()`, `_inflight_events.resize(e.fd * 2)` produces `resize(0)` when fd is 0, then `_inflight_events[0]` is an out-of-bounds access. Affects both epoll and kqueue engines.

## Changes
- `io/epoll.cpp`: `resize(e.fd * 2)` → `resize(e.fd * 2 + 2)`
- `io/kqueue.cpp`: Same fix

## Verification
- [x] Compilation verified (URING ON/OFF)
- [x] Full test suite: no regressions (cascading_timeout flakiness verified as pre-existing via n=25 A/B, Fisher p=0.56)
- [x] 3-reviewer adversarial code review: unanimous APPROVE