### PR TITLE
Fix Base64Encode underflow on empty input

### DIFF
--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -129,6 +129,7 @@ void base64_translate_3to4(const char *in, char *out)  {
 }
 
 void Base64Encode(std::string_view in, std::string &out) {
+    if (in.empty()) { out.clear(); return; }
     auto main = in.size() / 3;
     auto remain = in.size() % 3;
     if (0 == remain) {


### PR DESCRIPTION
## Summary
- `Base64Encode` with empty input caused `main--` to underflow a `size_t` from 0 to SIZE_MAX, leading to wild memory access and crash.

## Changes
- `net/utils.cpp`: Add early return `if (in.empty()) { out.clear(); return; }`

## Verification
- [x] Compilation verified (URING ON/OFF)
- [x] Full test suite: no regressions
- [x] 3-reviewer adversarial code review: unanimous APPROVE