### PR TITLE
Fix sendfile_n treating short pread as hard error

### DIFF
--- a/net/basic_socket.cpp
+++ b/net/basic_socket.cpp
@@ -225,11 +225,11 @@ ssize_t sendfile_n(ISocketStream* out_stream,
         size_t s = sizeof(buf);
         if (s > count) s = count;
         ssize_t n_read = ::pread(in_fd, buf, s, offset);
-        if (n_read != (ssize_t) s)
+        if (n_read <= 0)
             LOG_ERRNO_RETURN(0, (ssize_t)-1, "failed to read fd ", in_fd);
         offset += n_read;
-        ssize_t n_write = out_stream->write(buf, s);
-        if (n_write != (ssize_t) s)
+        ssize_t n_write = out_stream->write(buf, n_read);
+        if (n_write != n_read)
             LOG_ERRNO_RETURN(0, (ssize_t)-1, "failed to write to stream ", out_stream);
         return n_write;
     };


### PR DESCRIPTION
## Summary
- In `sendfile_n` (ISocketStream overload), a short `pread` return (normal near EOF) was treated as a hard error. Also wrote uninitialized buffer bytes and compared write count against the wrong value.

## Changes
- `net/basic_socket.cpp`: (1) Check `n_read <= 0` instead of `n_read != s`, (2) write `n_read` bytes not `s`, (3) compare `n_write` against `n_read`

## Verification
- [x] Compilation verified (URING ON/OFF)
- [x] Full test suite: no regressions
- [x] 3-reviewer adversarial code review: unanimous APPROVE