### PR TITLE
Fix iouring eventfd double-close on repeated fini()

### DIFF
--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -64,6 +64,7 @@ public:
                     LOG_ERROR("iouring: failed to unregister cascading event fd ", ERRNO());
             }
             close(m_eventfd);
+            m_eventfd = -1;
         }
         if (m_ring != nullptr) {
             io_uring_queue_exit(m_ring);


### PR DESCRIPTION
## Summary
- In iouring engine `fini()`, `close(m_eventfd)` was called without resetting `m_eventfd` to -1. A second `fini()` call (from destructor, reset, or error path) would double-close the fd, which is UB and could silently close an unrelated fd.

## Changes
- `io/iouring-wrapper.cpp`: Add `m_eventfd = -1;` after `close(m_eventfd)`, matching the existing pattern for `m_ring`

## Verification
- [x] Compilation verified (URING ON/OFF)
- [x] Full test suite: no regressions
- [x] 3-reviewer adversarial code review: unanimous APPROVE