### PR TITLE
Fix missing setsockopt replay in SMC and fstack-dpdk bind

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -474,6 +474,9 @@ public:
             m_listen_fd = socket(AF_SMC, ver);
             if (m_listen_fd < 0) return -1;
         }
+        if (m_opts.setsockopt(m_listen_fd) != 0) {
+            return -1;
+        }
         int ret = ::bind(m_listen_fd, s.get_sockaddr(), s.get_socklen());
         if (ret < 0)
             LOG_ERRNO_RETURN(0, ret, "failed to bind to ", s.to_endpoint());
@@ -720,6 +723,9 @@ public:
         m_listen_fd = fstack_socket(s.get_sockaddr()->sa_family, SOCK_STREAM, 0);   // already non-blocking and no-delay
         if (m_listen_fd < 0) {
             LOG_ERRNO_RETURN(0, -1, "fail to setup DPDK listen fd");
+        }
+        if (m_opts.setsockopt(m_listen_fd) != 0) {
+            return -1;
         }
         int ret = fstack_bind(m_listen_fd, s.get_sockaddr(), s.get_socklen());
         if (ret < 0)


### PR DESCRIPTION
## Summary

`SMCSocketServer::bind()` and `FstackDpdkSocketServer::bind()` are copies of `KernelSocketServer::bind()` that omit the `m_opts.setsockopt(m_listen_fd)` call. This means socket options (e.g. `SO_REUSEADDR`, `SO_REUSEPORT`) set via `setsockopt()` before `bind()` are silently lost on the listen fd.

This fix adds `m_opts.setsockopt(m_listen_fd)` in both methods, matching the parent class pattern at lines 321-323.

## What changed

- `SMCSocketServer::bind()`: added `m_opts.setsockopt(m_listen_fd)` after socket creation, before `::bind()` — **real bug fix**, options were silently dropped
- `FstackDpdkSocketServer::bind()`: added `m_opts.setsockopt(m_listen_fd)` after socket creation, before `fstack_bind()` — **defensive no-op for pattern consistency** (fstack's `setsockopt()` returns -1 when `m_listen_fd=-1`, never storing options into `m_opts`, so `m_opts` is always empty at bind time)

## What did NOT change

- `KernelSocketServer::bind()` — already correct
- All other subclasses — either inherit the base `bind()` or delegate to it

## Verification

- **Code review**: 4-agent adversarial review, unanimously approved
- **Compilation**: PASS (Debug, URING=OFF)
- **E2E test**: NOT POSSIBLE — SMC requires RDMA/ISM hardware, fstack requires DPDK environment. Neither available in test infra.

## Impact

Most impactful consequence: `SO_REUSEADDR` silently lost on SMC listen socket, causing `EADDRINUSE` on server restart during `TIME_WAIT`.