### PR TITLE
[Pick][0.9 to main] | FIX: http client deal with close delimited response (#1257) (#1260) 

### DIFF
--- a/net/http/body.cpp
+++ b/net/http/body.cpp
@@ -57,10 +57,17 @@ public:
                    m_partial_body_buf((char*)body.data()),
                    m_partial_body_remain(body.size()),
                    m_body_remain(body_remain) {
+        if (body_remain == SIZE_MAX) {
+            // Close-delimited mode: read until peer closes the connection.
+            // Do not use m_body_remain as a counter; m_close_delim drives the
+            // logic in read()/close() instead.
+            m_close_delim = true;
+        }
     }
     ~BodyReadStream() {
     }
     virtual int close() override {
+        if (m_close_delim) return 0;
         auto stream_remain = m_body_remain - m_partial_body_remain;
         if (stream_remain > SKIP_LIMIT) return -1;
         if (stream_remain && !m_stream->skip_read(stream_remain)) return -1;
@@ -69,13 +76,13 @@ public:
 
     virtual ssize_t read(void *buf, size_t count) override {
         ssize_t ret = 0;
-        if (count > m_body_remain) count = m_body_remain;
+        if (!m_close_delim && count > m_body_remain) count = m_body_remain;
         auto read_from_remain = std::min(count, m_partial_body_remain);
         if (read_from_remain > 0) {
             memcpy(buf, m_partial_body_buf, read_from_remain);
             buf = (char*)buf + read_from_remain;
             count -= read_from_remain;
-            m_body_remain -= read_from_remain;
+            if (!m_close_delim) m_body_remain -= read_from_remain;
             m_partial_body_remain -= read_from_remain;
             m_partial_body_buf += read_from_remain;
             ret += read_from_remain;
@@ -84,7 +91,7 @@ public:
             auto r = m_stream->read(buf, count);
             if (r < 0)
                 return r;
-            m_body_remain -= r;
+            if (!m_close_delim) m_body_remain -= r;
             ret += r;
         }
         return ret;
@@ -108,6 +115,7 @@ protected:
     net::ISocketStream *m_stream;
     char* m_partial_body_buf;
     size_t m_partial_body_remain, m_body_remain;
+    bool m_close_delim = false;
 };
 
 class ChunkedBodyReadStream : public BodyReadStream {

--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -268,15 +268,6 @@ size_t Message::body_size() const {
     if (it != headers.end()) return estring_view(it.second()).to_uint64();
     // or calc from Content-Range
     it = headers.find("Content-Range");
-<<<<<<< HEAD
-    if (it == headers.end()) return 0;
-    size_t start, end;
-    if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
-        return end-start+1;
-    }
-    if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
-        return end;
-=======
     if (it != headers.end()) {
         size_t start, end;
         if (sscanf("bytes %lu-%lu", it.second().data(), &start, &end) == 2) {
@@ -286,7 +277,6 @@ size_t Message::body_size() const {
             return end;
         }
         return 0;
->>>>>>> 356aaf3 (FIX: http client deal with close delimited response (#1257) (#1260))
     }
     // No Content-Length and no Content-Range. If the connection will be closed
     // (Connection: close, Trailer, or HTTP/1.0 implicit close) and the response

--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -124,7 +124,9 @@ int Message::append_bytes(uint16_t size) {
         LOG_ERRNO_RETURN(0, -1, "failed to parse headers");
 
     m_abandon = (headers["Connection"] == "close" ||
-                !headers["Trailer"].empty());
+                !headers["Trailer"].empty() ||
+                ((std::string_view{m_buf, m_buf_size} | m_version) == "1.0" &&
+                 headers["Connection"] != "keep-alive"));
     message_status = HEADER_PARSED;
     LOG_DEBUG("header parsed");
     return 0;
@@ -266,6 +268,7 @@ size_t Message::body_size() const {
     if (it != headers.end()) return estring_view(it.second()).to_uint64();
     // or calc from Content-Range
     it = headers.find("Content-Range");
+<<<<<<< HEAD
     if (it == headers.end()) return 0;
     size_t start, end;
     if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
@@ -273,7 +276,23 @@ size_t Message::body_size() const {
     }
     if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
         return end;
+=======
+    if (it != headers.end()) {
+        size_t start, end;
+        if (sscanf("bytes %lu-%lu", it.second().data(), &start, &end) == 2) {
+            return end-start+1;
+        }
+        if (sscanf("bytes */%lu", it.second().data(), &end) == 1) {
+            return end;
+        }
+        return 0;
+>>>>>>> 356aaf3 (FIX: http client deal with close delimited response (#1257) (#1260))
     }
+    // No Content-Length and no Content-Range. If the connection will be closed
+    // (Connection: close, Trailer, or HTTP/1.0 implicit close) and the response
+    // is not chunked, this is RFC 7230 §3.3.3 close-delimited framing: read
+    // body until peer closes the connection.
+    if (m_abandon && !headers.chunked()) return SIZE_MAX;
     return 0;
 }
 

--- a/net/http/message.h
+++ b/net/http/message.h
@@ -147,7 +147,7 @@ protected:
     std::unique_ptr<IStream> m_body_stream;
     net::ISocketStream* m_stream = nullptr;
     bool m_stream_ownership = false;
-    bool m_abandon;
+    bool m_abandon = false;
     bool m_keep_alive = true;
     Verb m_verb = Verb::UNKNOWN;
 

--- a/net/http/server.cpp
+++ b/net/http/server.cpp
@@ -287,7 +287,9 @@ public:
         ret = m_modifier(op.resp, resp);
         if (ret < 0) return ret;
 
-        resp.write_stream((IStream*)(&op.resp));
+        auto wc = resp.write_stream((IStream*)(&op.resp));
+        if (wc < 0)
+            LOG_ERRNO_RETURN(0, -1, "failed to forward upstream response body");
 
         return 0;
     }
@@ -375,8 +377,17 @@ public:
 
     static int default_forward_proxy_modifier(void*, Response &src, Response &dst) {
         dst.set_result(src.status_code());
+        bool src_has_cl = src.headers.find("Content-Length") != src.headers.end();
+        bool src_chunked = src.headers.chunked();
         for (auto kv : src.headers) {
             dst.headers.insert(kv.first, kv.second);
+        }
+        // RFC 7230 §3.3.3: when the upstream response is close-delimited
+        // (no Content-Length and no Transfer-Encoding: chunked), re-frame the
+        // downstream response as chunked so the client can detect EOF without
+        // forcing us to close the downstream connection.
+        if (!src_has_cl && !src_chunked) {
+            dst.headers.insert("Transfer-Encoding", "chunked");
         }
         return 0;
     }

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -1097,6 +1097,181 @@ TEST(http_client, operation_level_proxy_e2e) {
 //     EXPECT_EQ(200, op->status_code);
 // }
 
+// Helpers/tests for issue #1256 -- HTTP/1.0 close-delimited responses
+static std::string g_close_delim_payload;
+static int close_delimited_handler(void*, ISocketStream* sock) {
+    EXPECT_NE(nullptr, sock);
+    // Drain the request (request line + headers ending with \r\n\r\n).
+    char buf[4096];
+    size_t got = 0;
+    while (got < sizeof(buf)) {
+        auto r = sock->recv(buf + got, sizeof(buf) - got);
+        if (r <= 0) break;
+        got += r;
+        if (std::string_view(buf, got).find("\r\n\r\n") != std::string_view::npos) break;
+    }
+    static const char hdr[] =
+        "HTTP/1.0 200 OK\r\nContent-Type: application/octet-stream\r\n\r\n";
+    auto wr = sock->write(hdr, sizeof(hdr) - 1);
+    EXPECT_EQ((ssize_t)(sizeof(hdr) - 1), wr);
+    if (!g_close_delim_payload.empty()) {
+        wr = sock->write(g_close_delim_payload.data(), g_close_delim_payload.size());
+        EXPECT_EQ((ssize_t)g_close_delim_payload.size(), wr);
+    }
+    // Returning lets the server framework close the connection, signalling EOF
+    // to the client (RFC 7230 §3.3.3 close-delimited framing).
+    return 0;
+}
+
+// Same as close_delimited_handler but uses HTTP/1.1 with explicit
+// "Connection: close" instead of HTTP/1.0 implicit close.
+static int close_delimited_http11_handler(void*, ISocketStream* sock) {
+    EXPECT_NE(nullptr, sock);
+    char buf[4096];
+    size_t got = 0;
+    while (got < sizeof(buf)) {
+        auto r = sock->recv(buf + got, sizeof(buf) - got);
+        if (r <= 0) break;
+        got += r;
+        if (std::string_view(buf, got).find("\r\n\r\n") != std::string_view::npos) break;
+    }
+    static const char hdr[] =
+        "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\n"
+        "Connection: close\r\n\r\n";
+    auto wr = sock->write(hdr, sizeof(hdr) - 1);
+    EXPECT_EQ((ssize_t)(sizeof(hdr) - 1), wr);
+    if (!g_close_delim_payload.empty()) {
+        wr = sock->write(g_close_delim_payload.data(), g_close_delim_payload.size());
+        EXPECT_EQ((ssize_t)g_close_delim_payload.size(), wr);
+    }
+    return 0;
+}
+
+TEST(http_client, http10_close_delimited) {
+    g_close_delim_payload.assign(8000, 'A');
+    g_close_delim_payload.append(8000, 'B');
+
+    auto server = new_tcp_socket_server();
+    DEFER(delete server);
+    server->set_handler({nullptr, &close_delimited_handler});
+    EXPECT_EQ(0, server->bind_v4localhost());
+    EXPECT_EQ(0, server->listen(100));
+    server->start_loop();
+    photon::thread_sleep(1);
+
+    auto client = new_http_client();
+    DEFER(delete client);
+    auto op = client->new_operation(Verb::GET, to_url(server, "/cd"));
+    DEFER(client->destroy_operation(op));
+    op->req.headers.content_length(0);
+    int ret = op->call();
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(200, op->resp.status_code());
+
+    std::string out;
+    out.resize(g_close_delim_payload.size() + 1024);
+    size_t total = 0;
+    while (total < out.size()) {
+        auto r = op->resp.read((char*)out.data() + total, out.size() - total);
+        ASSERT_GE(r, 0);
+        if (r == 0) break;
+        total += r;
+    }
+    out.resize(total);
+    EXPECT_EQ(g_close_delim_payload.size(), out.size());
+    EXPECT_EQ(g_close_delim_payload, out);
+}
+
+TEST(http_client, http11_connection_close_no_content_length) {
+    // RFC 7230 §3.3.3: HTTP/1.1 with explicit "Connection: close" and neither
+    // Content-Length nor Transfer-Encoding is also close-delimited.
+    g_close_delim_payload.assign(6000, 'C');
+    g_close_delim_payload.append(6000, 'D');
+
+    auto server = new_tcp_socket_server();
+    DEFER(delete server);
+    server->set_handler({nullptr, &close_delimited_http11_handler});
+    EXPECT_EQ(0, server->bind_v4localhost());
+    EXPECT_EQ(0, server->listen(100));
+    server->start_loop();
+    photon::thread_sleep(1);
+
+    auto client = new_http_client();
+    DEFER(delete client);
+    auto op = client->new_operation(Verb::GET, to_url(server, "/cd11"));
+    DEFER(client->destroy_operation(op));
+    op->req.headers.content_length(0);
+    int ret = op->call();
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(200, op->resp.status_code());
+    EXPECT_EQ("close", op->resp.headers["Connection"]);
+
+    std::string out;
+    out.resize(g_close_delim_payload.size() + 1024);
+    size_t total = 0;
+    while (total < out.size()) {
+        auto r = op->resp.read((char*)out.data() + total, out.size() - total);
+        ASSERT_GE(r, 0);
+        if (r == 0) break;
+        total += r;
+    }
+    out.resize(total);
+    EXPECT_EQ(g_close_delim_payload.size(), out.size());
+    EXPECT_EQ(g_close_delim_payload, out);
+}
+
+TEST(http_server, forward_proxy_close_delimited) {
+    g_close_delim_payload.assign(5000, 'X');
+    g_close_delim_payload.append(5000, 'Y');
+
+    // Upstream: raw TCP server returning HTTP/1.0 close-delimited body.
+    auto upstream = new_tcp_socket_server();
+    DEFER(delete upstream);
+    upstream->set_handler({nullptr, &close_delimited_handler});
+    EXPECT_EQ(0, upstream->bind_v4localhost());
+    EXPECT_EQ(0, upstream->listen(100));
+    upstream->start_loop();
+
+    // Photon forward proxy in front of the upstream.
+    auto proxy_tcp = new_tcp_socket_server();
+    DEFER(delete proxy_tcp);
+    EXPECT_EQ(0, proxy_tcp->bind_v4localhost());
+    EXPECT_EQ(0, proxy_tcp->listen(100));
+    auto proxy_http = new_http_server();
+    DEFER(delete proxy_http);
+    auto proxy_handler = new_default_forward_proxy_handler(30 * 1000 * 1000);
+    proxy_http->add_handler(proxy_handler, true);
+    proxy_tcp->set_handler(proxy_http->get_connection_handler());
+    proxy_tcp->start_loop();
+    photon::thread_sleep(1);
+
+    auto client = new_http_client();
+    DEFER(delete client);
+    auto op = client->new_operation(Verb::GET, to_url(upstream, "/cd"));
+    DEFER(client->destroy_operation(op));
+    op->req.headers.content_length(0);
+    op->set_proxy(to_url(proxy_tcp, "/"));
+    int ret = op->call();
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(200, op->resp.status_code());
+    // The default forward proxy modifier must re-frame close-delimited
+    // upstream responses as Transfer-Encoding: chunked downstream.
+    EXPECT_EQ("chunked", op->resp.headers["Transfer-Encoding"]);
+
+    std::string out;
+    out.resize(g_close_delim_payload.size() + 1024);
+    size_t total = 0;
+    while (total < out.size()) {
+        auto r = op->resp.read((char*)out.data() + total, out.size() - total);
+        ASSERT_GE(r, 0);
+        if (r == 0) break;
+        total += r;
+    }
+    out.resize(total);
+    EXPECT_EQ(g_close_delim_payload.size(), out.size());
+    EXPECT_EQ(g_close_delim_payload, out);
+}
+
 int main(int argc, char** arg) {
     if (photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE))
         return -1;

--- a/net/http/url.cpp
+++ b/net/http/url.cpp
@@ -23,12 +23,6 @@ namespace photon {
 namespace net {
 namespace http {
 
-<<<<<<< HEAD
-bool URL::from_string(std::string_view url_) {
-    estring_view url(url_); // [http[s]://]domain.or.ip[:port][/[path[?query]]]
-    m_url = url.data();     // target := /path?query
-    LOG_DEBUG(VALUE(url));  // target and path both start with '/
-=======
 void URL::fix_target() {
     auto t = (m_url | m_target);
     if (m_target.size() == 0 || t.front() != '/') {
@@ -45,8 +39,11 @@ void URL::fix_target() {
         m_path = rstring_view16(0, m_path.size()+1);
     }
 }
->>>>>>> 356aaf3 (FIX: http client deal with close delimited response (#1257) (#1260))
 
+bool URL::from_string(std::string_view url_) {
+    estring_view url(url_); // [http[s]://]domain.or.ip[:port][/[path[?query]]]
+    m_url = url.data();     // target := /path?query
+    LOG_DEBUG(VALUE(url));  // target and path both start with '/
     free(m_tmp_target);
     m_tmp_target = nullptr;
     DEFER({ // fix the problem that path and target do not start with '/'

--- a/net/http/url.cpp
+++ b/net/http/url.cpp
@@ -23,10 +23,29 @@ namespace photon {
 namespace net {
 namespace http {
 
+<<<<<<< HEAD
 bool URL::from_string(std::string_view url_) {
     estring_view url(url_); // [http[s]://]domain.or.ip[:port][/[path[?query]]]
     m_url = url.data();     // target := /path?query
     LOG_DEBUG(VALUE(url));  // target and path both start with '/
+=======
+void URL::fix_target() {
+    auto t = (m_url | m_target);
+    if (m_target.size() == 0 || t.front() != '/') {
+        // Allocate (size + 2): one extra byte for the leading '/' and one
+        // trailing '\0' so m_tmp_target stays a valid C string. This avoids
+        // a heap-buffer-overflow when something implicitly converts the raw
+        // pointer to std::string_view via the const-char* constructor (which
+        // calls strlen).
+        m_tmp_target = (char*)malloc(m_target.size() + 2);
+        m_tmp_target[0] = '/';
+        memcpy(m_tmp_target + 1, t.data(), t.size());
+        m_tmp_target[m_target.size() + 1] = '\0';
+        m_target = rstring_view16(0, m_target.size()+1);
+        m_path = rstring_view16(0, m_path.size()+1);
+    }
+}
+>>>>>>> 356aaf3 (FIX: http client deal with close delimited response (#1257) (#1260))
 
     free(m_tmp_target);
     m_tmp_target = nullptr;

--- a/net/http/url.h
+++ b/net/http/url.h
@@ -67,6 +67,7 @@ public:
     }
 
     bool from_string(std::string_view url);
+    void fix_target();
     std::string_view query() const { return m_url | m_query; }
 
     std::string_view path() const {


### PR DESCRIPTION
> FIX: http client deal with close delimited response (#1257) (#1260)

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits