### PR TITLE
[Pick][0.8 to 0.9] | [Pick][0.7 to 0.8] | Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)  (#1259) 

### DIFF
--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -46,12 +46,10 @@ add_executable(test-pooled-stack-allocator test-pooled-stack-allocator.cpp)
 target_link_libraries(test-pooled-stack-allocator PRIVATE photon_shared)
 add_test(NAME test-pooled-stack-allocator COMMAND $<TARGET_FILE:test-pooled-stack-allocator>)
 
-<<<<<<< HEAD
 add_executable(test-st-utest st_utest.cpp st_utest_tcp.cpp st_utest_coroutines.cpp)
 target_link_libraries(test-st-utest PRIVATE photon_shared)
 add_test(NAME test-st-utest COMMAND $<TARGET_FILE:test-st-utest>)
-=======
+
 add_executable(test-sleepq-stale-idx test-sleepq-stale-idx.cpp)
 target_link_libraries(test-sleepq-stale-idx PRIVATE photon_shared)
 add_test(NAME test-sleepq-stale-idx COMMAND $<TARGET_FILE:test-sleepq-stale-idx>)
->>>>>>> 4ea3788 ([Pick][0.7 to 0.8] | Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)  (#1259))

--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -46,6 +46,12 @@ add_executable(test-pooled-stack-allocator test-pooled-stack-allocator.cpp)
 target_link_libraries(test-pooled-stack-allocator PRIVATE photon_shared)
 add_test(NAME test-pooled-stack-allocator COMMAND $<TARGET_FILE:test-pooled-stack-allocator>)
 
+<<<<<<< HEAD
 add_executable(test-st-utest st_utest.cpp st_utest_tcp.cpp st_utest_coroutines.cpp)
 target_link_libraries(test-st-utest PRIVATE photon_shared)
 add_test(NAME test-st-utest COMMAND $<TARGET_FILE:test-st-utest>)
+=======
+add_executable(test-sleepq-stale-idx test-sleepq-stale-idx.cpp)
+target_link_libraries(test-sleepq-stale-idx PRIVATE photon_shared)
+add_test(NAME test-sleepq-stale-idx COMMAND $<TARGET_FILE:test-sleepq-stale-idx>)
+>>>>>>> 4ea3788 ([Pick][0.7 to 0.8] | Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)  (#1259))

--- a/thread/test/test-sleepq-stale-idx.cpp
+++ b/thread/test/test-sleepq-stale-idx.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <atomic>
+#include <chrono>
+
+#include "../../test/gtest.h"
+#include <photon/common/utility.h>
+#include <photon/photon.h>
+#include <photon/thread/thread.h>
+#include <photon/thread/thread11.h>
+#include <photon/thread/workerpool.h>
+
+TEST(SleepQueue, pop_front_single_sleeper_clears_idx_before_migrate) {
+    ASSERT_EQ(0, photon::init());
+    DEFER(photon::fini());
+
+    photon::WorkPool pool(1, photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE, 0);
+    std::atomic<bool> done{false};
+
+    photon::thread_create11([&] {
+        // Keep this thread as the only sleeper on the source vCPU, so timeout
+        // wakeup must go through SleepQueue::pop_front()'s single-node path.
+        photon::thread_usleep(1000);
+
+        // Re-enter SleepQueue::pop() from another vCPU's standbyq drain. A stale
+        // idx left by pop_front() used to make this pop dereference/corrupt the
+        // target vCPU's sleepq.
+        pool.thread_migrate(photon::CURRENT, 0);
+        done.store(true, std::memory_order_release);
+    });
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!done.load(std::memory_order_acquire)) {
+        photon::thread_yield();
+        ASSERT_LT(std::chrono::steady_clock::now(), deadline);
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -393,6 +393,7 @@ namespace photon
             auto ret = q[0];
             if (q.size() == 1) {
                 q.pop_back();
+                ret->idx = -1;
                 return ret;
             }
             q[0] = q.back();
@@ -405,20 +406,21 @@ namespace photon
 
         int pop(thread *obj)
         {
-            if (obj->idx == -1) return -1;
-            if ((size_t)obj->idx == q.size() - 1){
+            auto id = obj->idx;
+            if (id == -1) return -1;
+            if ((size_t)id == q.size() - 1){
                 q.pop_back();
                 obj->idx = -1;
                 return 0;
             }
 
-            auto id = obj->idx;
             if (q.size() == 1) {
                 assert(id == 0);
                 q.pop_back();
+                obj->idx = -1;
                 return 0;
             }
-            q[obj->idx] = q.back();
+            q[id] = q.back();
             q[id]->idx = id;
             q.pop_back();
             if (!up(id)) down(id);


### PR DESCRIPTION
> [Pick][0.7 to 0.8] | Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)  (#1259)

* Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)

* Fix Photon SleepQueue stale idx corruption during wakeup and migration

* fix: test

Co-authored-by: Jingyuan <52315061+MJY-HUST@users.noreply.github.com>

* Fix merge conflict

---------

Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Jingyuan <52315061+MJY-HUST@users.noreply.github.com>
Generated by Auto PR, by cherry-pick related commits