### PR TITLE
Fix epoll error-path fallthrough and dead-code UB

### DIFF
--- a/io/epoll-ng.cpp
+++ b/io/epoll-ng.cpp
@@ -117,6 +117,7 @@ public:
                         LOG_ERROR_RETURN(err.no, , "epoll_wait() failed ", err);
                     timeout = sat_sub(timeout, cool_down_ms);
                     cool_down_ms *= 2;
+                    continue;
                 }
                 remains += ret;
                 return;

--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -218,6 +218,7 @@ ok:     entry.interests |= eint;
                     LOG_ERROR_RETURN(err.no, -1, "epoll_wait() failed ", err);
                 timeout = sat_sub(timeout, cool_down_ms);
                 cool_down_ms *= 2;
+                continue;
             }
             return _events_remain = ret;
         }

--- a/io/events_map.h
+++ b/io/events_map.h
@@ -53,6 +53,7 @@ struct EventsMap {
         if (event == EV_KEY::EV_READ) return EV_UNDERLAY::EV_READ;
         if (event == EV_KEY::EV_WRITE) return EV_UNDERLAY::EV_WRITE;
         if (event == EV_KEY::EV_ERR) return EV_UNDERLAY::EV_ERR;
+        return 0;
     }
 };
 


### PR DESCRIPTION
## Summary
- Fix epoll-ng.cpp: add `continue` after error backoff to prevent negative `remains` causing OOB array access
- Fix epoll.cpp: add `continue` to prevent ret=-1 wrapping uint16_t `_events_remain` to 65535, causing massive OOB read on 16-element array
- Fix events_map.h: add default `return 0` in `translate_byval()` to eliminate UB (dead code, no callers)

## Verification
- Code review: adversarial review passed
- Compilation: verified (Debug, URING=ON and OFF)
- E2E test: 48/57 pass on ECS (kernel 6.6, URING=ON), all failures pre-existing