### PR TITLE
Fix SubFile pwritev offset and path buffer overflow

### DIFF
--- a/fs/path.cpp
+++ b/fs/path.cpp
@@ -99,8 +99,7 @@ namespace fs
 
         char path[PATH_MAX];
         if (len >= PATH_MAX - 1) {
-            errno = ENAMETOOLONG;
-            return -1;
+            LOG_ERROR_RETURN(ENAMETOOLONG, -1, "pathname too long");
         }
         if (pathname[0] != '/') {
             *path = '/';

--- a/fs/path.cpp
+++ b/fs/path.cpp
@@ -98,6 +98,10 @@ namespace fs
         if (len == 0) return 0;
 
         char path[PATH_MAX];
+        if (len >= PATH_MAX - 1) {
+            errno = ENAMETOOLONG;
+            return -1;
+        }
         if (pathname[0] != '/') {
             *path = '/';
             memcpy(path + 1, pathname.begin(), len);
@@ -284,6 +288,8 @@ namespace fs
         auto len0 = m_path_len;
         auto len1 = s.length();
         assert(len0 + len1 < sizeof(m_path_buffer) - 1);
+        if (len0 + len1 >= sizeof(m_path_buffer) - 1)
+            return;
         memcpy(m_path_buffer + len0, s.data(), len1 + 1);
         m_path_len = len0 + len1;
     }

--- a/fs/subfs.cpp
+++ b/fs/subfs.cpp
@@ -328,7 +328,7 @@ namespace fs
                 return 0;
             IOVector iovs(iov, iovcnt);
             iovs.shrink_to(m_length - offset);
-            return m_file->pwritev(iovs.iovec(), iovs.iovcnt(), offset);
+            return m_file->pwritev(iovs.iovec(), iovs.iovcnt(), offset + m_offset);
         }
     };
 


### PR DESCRIPTION
## Summary
- Fix SubFile::pwritev passing bare offset instead of offset+m_offset (data corruption on vectored writes to sub-files)
- Fix mkdir_recursive missing PATH_MAX bounds check before memcpy (stack overflow on long paths)
- Fix Walker::path_push_back assert-only bounds check (overflow in release builds)

## Verification
- Code review: adversarial review passed
- Compilation: verified (Debug, URING=OFF)
- E2E test: not feasible (requires specific sub-file and long-path test fixtures)