### PR TITLE
Fix cache UAF, infinite recursion, and null pointer issues

### DIFF
--- a/fs/cache/cached_fs.cpp
+++ b/fs/cache/cached_fs.cpp
@@ -371,6 +371,7 @@ public:
     int vioctl(int request, va_list args) override {
         IFile *src_rwfile = nullptr;
         if (cache_store_->get_src_file(&src_rwfile, O_RDWR) != 0) return -1;
+        if (!src_rwfile) LOG_ERROR_RETURN(0, -1, "source rw file is null");
         return src_rwfile->vioctl(request, args);
     }
 

--- a/fs/cache/full_file_cache/quota_pool.cpp
+++ b/fs/cache/full_file_cache/quota_pool.cpp
@@ -138,6 +138,9 @@ void QuotaFilePool::updateDirQuota(FileIterator iter, size_t quota) {
 
 int QuotaFilePool::set_quota(std::string_view pathname, size_t quota) {
   auto pos = getQuotaCtrlPos(pathname.data());
+  if (!pos) {
+    LOG_ERROR_RETURN(EINVAL, -1, "pathname don't contain dir name:`", pathname)
+  }
   std::string dirName(pathname.data() + 1, pos);
   auto find = dirInfos_.find(dirName.c_str());
   if (dirInfos_.end() == find) {
@@ -160,6 +163,9 @@ int QuotaFilePool::stat(CacheStat* stat, std::string_view pathname) {
     stat->used_size /= refillUnit_;
   } else if ('/' == pathname.back()) {
     auto pos = getQuotaCtrlPos(pathname.data());
+    if (!pos) {
+      LOG_ERROR_RETURN(EINVAL, -1, "pathname don't contain dir name:`", pathname)
+    }
     std::string dirName(pathname.data() + 1, pos);
     auto find = dirInfos_.find(dirName.c_str());
     if (find != dirInfos_.end()) {
@@ -180,6 +186,9 @@ int QuotaFilePool::stat(CacheStat* stat, std::string_view pathname) {
 
 int QuotaFilePool::evict(std::string_view filename) {
   auto pos = getQuotaCtrlPos(filename.data());
+  if (!pos) {
+    LOG_ERROR_RETURN(EINVAL, -1, "pathname don't contain dir name:`", filename)
+  }
   std::string dirName(filename.data() + 1, pos);
   auto find = dirInfos_.find(dirName.c_str());
   if (dirInfos_.end() == find) {

--- a/fs/cache/persistent_cache/persistent_cache.cpp
+++ b/fs/cache/persistent_cache/persistent_cache.cpp
@@ -123,7 +123,7 @@ public:
         return new PersistentCacheFile(src_file, pathname, this);
     }
     IFile *open(const char *pathname, int flags, mode_t mode) {
-        return open(pathname, flags, 0644);
+        return open(pathname, flags);
     }
 
     UNIMPLEMENTED(int stat(const char *pathname, struct stat *buf) override);

--- a/fs/cache/pool_store.h
+++ b/fs/cache/pool_store.h
@@ -214,9 +214,9 @@ namespace fs
         }
 
         std::string_view get_src_name() { return src_name_; }
-        void set_src_name(std::string_view pathname) { src_name_ = pathname.data(); }
+        void set_src_name(std::string_view pathname) { src_name_.assign(pathname.data(), pathname.size()); }
         std::string_view get_store_key() { return store_key_; }
-        void set_store_key(std::string_view pathname) { store_key_ = pathname.data(); }
+        void set_store_key(std::string_view pathname) { store_key_.assign(pathname.data(), pathname.size()); }
         void set_pool(ICachePool* pool) { pool_ = pool; }
         void set_cached_size(off_t cached_size, int flags = 0);
         off_t get_actual_size() { return actual_size_; }

--- a/fs/cache/store.cpp
+++ b/fs/cache/store.cpp
@@ -191,8 +191,9 @@ void* ICacheStore::async_refill(void* args) {
 
     ctx->store->pool_->m_refilling.fetch_sub(1, std::memory_order_relaxed);
     ctx->store->range_lock_.unlock(ctx->refill_off, ctx->refill_size);
+    auto vcpu = static_cast<photon::vcpu_base*>(ctx->store->pool_->m_vcpu);
     ctx->store->release();
-    photon::thread_migrate(photon::CURRENT, static_cast<photon::vcpu_base*>(ctx->store->pool_->m_vcpu));
+    photon::thread_migrate(photon::CURRENT, vcpu);
     delete ctx;
     return nullptr;
 }


### PR DESCRIPTION
## Summary
- Fix use-after-free in async_refill: save vcpu pointer before release() which may delete the store object
- Fix infinite recursion in PersistentCacheFs::open 3-arg overload calling itself
- Fix null pointer dereference in CachedFile::vioctl when source filesystem is absent
- Fix undefined behavior from nullptr in quota_pool set_quota/evict/stat
- Fix string_view size ignored in pool_store set_src_name/set_store_key

## Verification
- Code review: adversarial review passed
- Compilation: verified (Debug, URING=OFF)
- E2E test: not feasible (requires cache layer test fixtures)