### PR TITLE
Fix FUSE splice fd leak and httpfs prefix matching

### DIFF
--- a/fs/fuse_adaptor/session_loop.cpp
+++ b/fs/fuse_adaptor/session_loop.cpp
@@ -56,11 +56,9 @@ struct fuse_pipe {
     int pipefd[2] = {-1, -1};
     ssize_t flush() {
         int nuldev_fd = open("/dev/null", O_WRONLY);
-        if (nuldev_fd < 0) {
-            LOG_ERROR("fuse-adaptor failed to open null device: `", strerror(errno));
-            return -1;
-        }
-
+        if (nuldev_fd < 0)
+            LOG_ERRNO_RETURN(0, -1, "fuse-adaptor failed to open null device");
+        DEFER(close(nuldev_fd));
         return splice(pipefd[0], NULL, nuldev_fd, NULL, size, SPLICE_F_MOVE);
     }
 

--- a/fs/httpfs/httpfs.cpp
+++ b/fs/httpfs/httpfs.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include "../../net/curl.h"
 #include <photon/thread/thread.h>
 #include <photon/common/string-keyed.h>
+#include <photon/common/estring.h>
 #include <photon/common/string_view.h>
 #include <photon/common/timeout.h>
 #include <photon/common/utility.h>
@@ -275,21 +276,13 @@ public:
     }
 };
 
-static bool strciprefix(char const* a, char const* b) {
-    for (;; a++, b++) {
-        int d = tolower((unsigned char)*a) - tolower((unsigned char)*b);
-        if (d != 0 || !*a) return d;
-    }
-    return !*b;
-}
-
 IFile* HttpFs::open(const char* pathname, int flags) {
     std::string url;
-    std::string_view fn(pathname);
+    estring_view fn(pathname);
     // ignore prefix '/'
     if (fn.front() == '/') fn = fn.substr(1);
-    if (!strciprefix(fn.data(), HTTP_PREFIX) &&
-        !strciprefix(fn.data(), HTTPS_PREFIX)) {
+    if (!fn.istarts_with(HTTP_PREFIX) &&
+        !fn.istarts_with(HTTPS_PREFIX)) {
         url = default_https ? HTTPS_PREFIX : HTTP_PREFIX;
         url += '/';
     }


### PR DESCRIPTION
## Summary
- Fix fuse_pipe::flush leaking /dev/null fd on every call
- Fix strciprefix implementing strcmp instead of prefix check

## Verification
- Code review: adversarial review passed
- Compilation: verified
- E2E test: not feasible (requires FUSE mount)