### PR TITLE
Fix alog snprintf overflow and iovector slice/iterator bugs

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -308,6 +308,7 @@ protected:
     {
         int ret = ::snprintf(buf.ptr, buf.size, fmt, x);
         if (ret < 0) return;
+        if ((size_t)ret > buf.size) ret = buf.size;
         buf.consume(ret);
     }
 

--- a/common/iovector.cpp
+++ b/common/iovector.cpp
@@ -78,27 +78,33 @@ ssize_t iovector_view::slice(size_t count, off_t offset, iovector_view* /*OUT*/ 
         return -1;
     }
     int cnt = 0;
-    off_t pos = 0;
     auto ptr = iov->iov;
     ssize_t ret = 0;
-    for (auto &p : *this) {
-        if (count && (pos + (off_t)p.iov_len > offset)) {
-            if (offset > pos) {
-                ptr[cnt].iov_base = (char*)p.iov_base + (offset - pos);
-                ptr[cnt].iov_len = p.iov_len - (offset - pos);
-            } else {
-                ptr[cnt].iov_base = p.iov_base;
-                ptr[cnt].iov_len = p.iov_len;
-            }
-            if (count < ptr[cnt].iov_len)
-                ptr[cnt].iov_len = count;
-            pos += p.iov_len;
-            ret += ptr[cnt].iov_len;
-            count -= ptr[cnt].iov_len;
-            cnt ++;
-            if (cnt == iov->iovcnt)
-                break;
+    auto it = begin();
+    auto e = end();
+    // skip iovec elements before offset
+    off_t pos = 0;
+    for (; it != e; ++it) {
+        if (pos + (off_t)it->iov_len > offset)
+            break;
+        pos += it->iov_len;
+    }
+    for (; it != e && count; ++it) {
+        if (offset > pos) {
+            ptr[cnt].iov_base = (char*)it->iov_base + (offset - pos);
+            ptr[cnt].iov_len = it->iov_len - (offset - pos);
+        } else {
+            ptr[cnt].iov_base = it->iov_base;
+            ptr[cnt].iov_len = it->iov_len;
         }
+        if (count < ptr[cnt].iov_len)
+            ptr[cnt].iov_len = count;
+        pos += it->iov_len;
+        ret += ptr[cnt].iov_len;
+        count -= ptr[cnt].iov_len;
+        cnt++;
+        if (cnt == iov->iovcnt)
+            break;
     }
     iov->iovcnt = cnt;
     return ret;
@@ -259,9 +265,13 @@ public:
         assert(_iovcnt);
         assert(n <= _v.iov_len);
         if (n < _v.iov_len) { _v += n; }
-        else { 
-            _v = *++_iov; 
-            _iovcnt--; 
+        else {
+            if (--_iovcnt > 0) {
+                _v = *++_iov;
+            } else {
+                ++_iov;
+                _v = {};
+            }
             assert(_iovcnt == 0 || _v.iov_base);
         }
         return *this;

--- a/common/iovector.cpp
+++ b/common/iovector.cpp
@@ -77,6 +77,10 @@ ssize_t iovector_view::slice(size_t count, off_t offset, iovector_view* /*OUT*/ 
         // empty iov, takes as no useable nested iovec to store the result
         return -1;
     }
+    if (unlikely(count == 0)) {
+        iov->iovcnt = 0;
+        return 0;
+    }
     int cnt = 0;
     auto ptr = iov->iov;
     ssize_t ret = 0;
@@ -89,22 +93,34 @@ ssize_t iovector_view::slice(size_t count, off_t offset, iovector_view* /*OUT*/ 
             break;
         pos += it->iov_len;
     }
-    for (; it != e && count; ++it) {
-        if (offset > pos) {
-            ptr[cnt].iov_base = (char*)it->iov_base + (offset - pos);
-            ptr[cnt].iov_len = it->iov_len - (offset - pos);
-        } else {
-            ptr[cnt].iov_base = it->iov_base;
-            ptr[cnt].iov_len = it->iov_len;
-        }
-        if (count < ptr[cnt].iov_len)
+    // process the first element (may be partial due to offset)
+    if (it != e) {
+        ptr[cnt].iov_base = (char*)it->iov_base + (offset - pos);
+        ptr[cnt].iov_len = it->iov_len - (offset - pos);
+        if (count <= ptr[cnt].iov_len) {
             ptr[cnt].iov_len = count;
-        pos += it->iov_len;
+            ret += count;
+            iov->iovcnt = cnt + 1;
+            return ret;
+        }
         ret += ptr[cnt].iov_len;
         count -= ptr[cnt].iov_len;
         cnt++;
-        if (cnt == iov->iovcnt)
-            break;
+        ++it;
+    }
+    // process remaining full elements
+    for (; it != e && cnt < iov->iovcnt; ++it) {
+        ptr[cnt].iov_base = it->iov_base;
+        ptr[cnt].iov_len = it->iov_len;
+        if (count <= ptr[cnt].iov_len) {
+            ptr[cnt].iov_len = count;
+            ret += count;
+            iov->iovcnt = cnt + 1;
+            return ret;
+        }
+        ret += ptr[cnt].iov_len;
+        count -= ptr[cnt].iov_len;
+        cnt++;
     }
     iov->iovcnt = cnt;
     return ret;


### PR DESCRIPTION
## Summary
- Fix LogFormatter snprintf return value exceeding buf.size on truncation, causing stack buffer overflow
- Fix iovector_view::slice() not advancing cumulative position for skipped elements
- Fix iov_iterator::operator+= reading past array end on last element

## Verification
- Code review: adversarial review passed
- Compilation: verified
- E2E test: test-alog PASS on ECS