### PR TITLE
Fix lockfree queue init and ObjectCache move/lock bugs

### DIFF
--- a/common/expirecontainer.cpp
+++ b/common/expirecontainer.cpp
@@ -159,7 +159,12 @@ void* ObjectCacheBase::ref_release(ItemPtr item, bool recycle, bool destroy) {
 // the argument `key` plays the roles of (type-erased) key
 void* ObjectCacheBase::release(const Item& key_item, bool recycle,
                                bool destroy) {
-    auto item = ExpireContainerBase::TypedIterator<Item>(Base::find(key_item));
-    if (item == end()) return nullptr;
-    return ref_release(*item, recycle, destroy);
+    ItemPtr item;
+    {
+        SCOPED_LOCK(_lock);
+        auto it = ExpireContainerBase::TypedIterator<Item>(Base::__find_prelock(key_item));
+        if (it == end()) return nullptr;
+        item = *it;
+    }
+    return ref_release(item, recycle, destroy);
 }

--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -317,8 +317,8 @@ protected:
     using Base::idx;
     using Base::tail;  // write_tail
 
-    alignas(CPUCacheLine::SIZE) std::atomic<size_t> write_head;
-    alignas(CPUCacheLine::SIZE) std::atomic<size_t> read_tail;
+    alignas(CPUCacheLine::SIZE) std::atomic<size_t> write_head{0};
+    alignas(CPUCacheLine::SIZE) std::atomic<size_t> read_tail{0};
 
     T slots[Base::SLOTS_NUM];
     explicit LockfreeBatchMPMCRingQueue(size_t c) : Base(c) {}

--- a/common/objectcachev2.h
+++ b/common/objectcachev2.h
@@ -151,11 +151,38 @@ public:
             _box->acquire();
         }
 
-        Borrow(Borrow&& rhs) : _reader(nullptr) { *this = std::move(rhs); }
+        Borrow(Borrow&& rhs) : _reader(nullptr) {
+            _oc = rhs._oc;
+            _box = rhs._box;
+            _reader = std::move(rhs._reader);
+            _recycle = rhs._recycle;
+            rhs._oc = nullptr;
+            rhs._box = nullptr;
+        }
 
-        Borrow& operator=(Borrow&& rhs) = default;
+        Borrow& operator=(Borrow&& rhs) {
+            if (this != &rhs) {
+                if (_box) {
+                    if (_recycle) _box->reset();
+                    _box->release();
+                    if (_box->rc == 0) {
+                        SCOPED_LOCK(_oc->maplock);
+                        _oc->lru_list.pop(_box);
+                        _oc->lru_list.push_back(_box);
+                    }
+                }
+                _oc = rhs._oc;
+                _box = rhs._box;
+                _reader = std::move(rhs._reader);
+                _recycle = rhs._recycle;
+                rhs._oc = nullptr;
+                rhs._box = nullptr;
+            }
+            return *this;
+        }
 
         ~Borrow() {
+            if (!_box) return;
             if (_recycle) {
                 _box->reset();
             }


### PR DESCRIPTION
## Summary
- Fix LockfreeBatchMPMCRingQueue write_head/read_tail uninitialized (add {0})
- Fix ObjectCacheV2::Borrow default move causing double-release (explicit move ops with source nullification and old-state release including LRU list requeue)
- Fix ObjectCacheBase::release() iterator used after lock release (hold lock across find and dereference)

## Verification
- Code review: adversarial review passed (3 independent reviewers)
- Compilation: verified
- E2E test: test-objcache PASS on ECS