### PR TITLE
Fix fstack server missing destructor and m_opts shadow

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -712,6 +712,14 @@ class FstackDpdkSocketServer : public KernelSocketServer {
 public:
     using KernelSocketServer::KernelSocketServer;
 
+    ~FstackDpdkSocketServer() override {
+        terminate();
+        if (m_listen_fd < 0) return;
+        fstack_shutdown(m_listen_fd, static_cast<int>(ShutdownHow::ReadWrite));
+        fstack_close(m_listen_fd);
+        m_listen_fd = -1;
+    }
+
     int bind(const EndPoint& ep) override {
         if (m_listen_fd >= 0)
             LOG_ERROR_RETURN(EALREADY, -1, "already bound");
@@ -747,6 +755,20 @@ public:
         return m_opts.get_opt(level, option_name, option_value, option_len);
     }
 
+    ISocketStream* accept(EndPoint* remote_endpoint = nullptr) override {
+        int cfd = remote_endpoint ? do_accept(*remote_endpoint) : do_accept();
+        if (cfd < 0) {
+            return nullptr;
+        }
+        for (auto& opt : m_opts) {
+            if (fstack_setsockopt(cfd, opt.level, opt.opt_name, opt.opt_val, opt.opt_len) != 0) {
+                LOG_ERRNO_RETURN(EINVAL, nullptr, "Failed to setsockopt ",
+                                 VALUE(opt.level), VALUE(opt.opt_name), VALUE(opt.opt_val));
+            }
+        }
+        return create_stream(cfd);
+    }
+
 protected:
     KernelSocketStream* create_stream(int fd) override {
         return new FstackDpdkSocketStream(fd);
@@ -755,22 +777,6 @@ protected:
     int do_accept(struct sockaddr* addr, socklen_t* addrlen) override {
         return fstack_accept(m_listen_fd, addr, addrlen, m_timeout);
     }
-
-private:
-    class FstackSockOptBuffer : public SockOptBuffer {
-    public:
-        int setsockopt(int fd) override {
-            for (auto& opt : *this) {
-                if (fstack_setsockopt(fd, opt.level, opt.opt_name, opt.opt_val, opt.opt_len) != 0) {
-                    LOG_ERRNO_RETURN(EINVAL, -1, "Failed to setsockopt ",
-                                     VALUE(opt.level), VALUE(opt.opt_name), VALUE(opt.opt_val));
-                }
-            }
-            return 0;
-        }
-    };
-
-    FstackSockOptBuffer m_opts;
 };
 
 #endif // ENABLE_FSTACK_DPDK


### PR DESCRIPTION
## Summary
- Add destructor override using fstack_shutdown/fstack_close instead of inherited ::close
- Remove private FstackSockOptBuffer m_opts that shadowed base class m_opts
- Add accept() override to apply socket options via fstack_setsockopt

## Verification
- Code review: adversarial review passed
- Compilation: verified
- E2E test: not feasible (requires DPDK environment)