### PR TITLE
Fix Timer thread leak, ~Timer hang, and thread-key constant

### DIFF
--- a/thread/thread-key.cpp
+++ b/thread/thread-key.cpp
@@ -177,7 +177,7 @@ void deallocate_tls(void** tls_) {
                         thread_keys[idx].dtor(data);
                 }
             } else {
-                idx += THREAD_KEY_1STLEVEL_SIZE;
+                idx += THREAD_KEY_2NDLEVEL_SIZE;
             }
         }
         if (!tls->specific_used) {

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1618,7 +1618,6 @@ insert_list:
             if (!timeout)
                 timeout = _default_timeout;
         } while(_repeating);
-        _th = nullptr;
     }
     void* Timer::_stub(void* _this)
     {

--- a/thread/timer.h
+++ b/thread/timer.h
@@ -74,7 +74,6 @@ namespace photon
         ~Timer()
         {
             if (!_th) return;
-            stop();
             _repeating = false;
             if (_waiting)
                 thread_interrupt(_th, ECANCELED);


### PR DESCRIPTION
## What this fixes

Three independent bugs in `thread/`:

1. **Timer thread leak** — `Timer::stub()` set `_th = nullptr` before exiting, so `~Timer()` short-circuited at `if (!_th) return;` and never `thread_join`-ed the joinable stub thread, leaking its stack. Fixed by removing the trailing `_th = nullptr;`.

2. **`~Timer()` hang (Timer.OneShot)** — once `_th` is no longer nulled, `~Timer()` runs its body, whose first statement was `stop()`. For an already-fired one-shot the stub has exited, so `stop()`'s `while (cancel()) _wait_ready.wait_no_lock();` waits on a notification that never comes (lost wakeup) → the `test-thread` / Timer.OneShot 3600s timeout. Fixed by dropping the `stop()` call from `~Timer()`; the destructor's existing `_repeating = false; if (_waiting) thread_interrupt(_th, ECANCELED); thread_join(_th);` already terminates and reaps the stub. (Full root-cause analysis in the thread.)

3. **thread-key destructor skip** — `deallocate_tls` used `THREAD_KEY_1STLEVEL_SIZE` instead of `THREAD_KEY_2NDLEVEL_SIZE` when iterating keys, so some per-key TLS destructors were skipped. Fixed by using the correct constant.

## Net change
3 files, 4 lines: `thread/timer.h` (−1), `thread/thread.cpp` (−1), `thread/thread-key.cpp` (±1).

## Verification
- `test-thread` Timer.OneShot / Reuse / Reapting / Reapting2 — pass.
- Full `test-thread` suite — **56/56 pass** locally (no hang, no regression).
