### PR TITLE
Fix iovector push_back/push_front allocating before capacity check

### DIFF
--- a/common/iovector.h
+++ b/common/iovector.h
@@ -362,6 +362,7 @@ public:
     // note that the buffer may be constituted by multiple iovec elements;
     size_t push_front(size_t bytes)
     {
+        if (iov_begin == 0) return 0;
         auto v = new_iovec(bytes);
         IF_ASSERT_RETURN(v.iov_len, 0);
         if (push_front(v) == bytes)
@@ -387,6 +388,7 @@ public:
     // note that the buffer may constitute multiple iovec elements;
     size_t push_back(size_t bytes)
     {
+        if (iov_end >= capacity) return 0;
         auto v = new_iovec(bytes);
         IF_ASSERT_RETURN(v.iov_len, 0);
         if (push_back(v) == bytes)


### PR DESCRIPTION
## Summary
- Fix `push_back(size_t)` and `push_front(size_t)` in iovector.h calling `new_iovec()` before checking iov capacity
- When iov array is full, allocation succeeds but is never visible in iov array, return value falsely claims success
- Add capacity guards before `new_iovec()`, matching the pattern in `push_back_more()`/`push_front_more()`

Fixes #1297

## Verification
- Code review: adversarial review passed
- Compilation: verified (Debug, URING=OFF)