### PR TITLE
Fix WorkPool get_vcpu_in_pool data race on vcpus vector

### DIFF
--- a/thread/workerpool.cpp
+++ b/thread/workerpool.cpp
@@ -151,6 +151,7 @@ public:
     }
 
     photon::vcpu_base *get_vcpu_in_pool(size_t index) {
+        SCOPED_LOCK(worker_lock);
         auto size = vcpus.size();
         if (index >= size) {
             index = vcpu_index++ % size;


### PR DESCRIPTION
## Summary
- Add `SCOPED_LOCK(worker_lock)` to `get_vcpu_in_pool()` to protect reads of `vcpus` vector
- Without the lock, concurrent `add_vcpu()`/`remove_vcpu()` can invalidate the vector during read

Fixes #1296

## Verification
- Code review: adversarial review passed
- Compilation: verified (Debug, URING=OFF)