### PR TITLE
Fix IdentityPoolBase::do_scale reading shared state outside lock

### DIFF
--- a/common/identity-pool.cpp
+++ b/common/identity-pool.cpp
@@ -56,9 +56,9 @@ void IdentityPoolBase::put(void* obj)
 
 uint64_t IdentityPoolBase::do_scale()
 {
+    SCOPED_LOCK(m_mtx);
     auto des_n = (min_size_in_interval + 1) / 2;
     assert(des_n <= m_size);
-    SCOPED_LOCK(m_mtx);
     while (m_size > 0 && des_n-- > 0) {
         auto x = --m_size;
         m_mtx.unlock();


### PR DESCRIPTION
## Summary
- Move `SCOPED_LOCK(m_mtx)` above reads of `min_size_in_interval` and `m_size` in `do_scale()`
- Previously these shared variables were read before acquiring the lock, racing with concurrent `get()`/`put()`

Fixes #1293

## Verification
- Code review: adversarial review passed
- Compilation: verified (Debug, URING=OFF)