### PR TITLE
ci: migrate ARM CI from self-hosted to GitHub-hosted runner

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   arm-linux-build-and-test:
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-24.04-arm
 
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
-      options: --cpus 4
+      options: --cpus 4 --privileged
 
     steps:
       - uses: szenius/set-timezone@v2.0
@@ -117,7 +117,7 @@ jobs:
           pkill redis-server
 
   debug-build-from-source:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     container:
       image: almalinux:8
     steps:

--- a/common/checksum/mm_intrin_neon.h
+++ b/common/checksum/mm_intrin_neon.h
@@ -193,7 +193,7 @@ int64_t _mm_extract_epi64_impl(__m128i a) {
 #if defined(__clang__)
 #define PHOTON_NEON_AESCRC_TARGET __attribute__((target("aes,crc")))
 #else
-#define PHOTON_NEON_AESCRC_TARGET
+#define PHOTON_NEON_AESCRC_TARGET __attribute__((target("+crc+crypto")))
 #endif
 
 namespace _sse2neon_detail {


### PR DESCRIPTION
## Changes

- Replace self-hosted ARM runner with GitHub-hosted `ubuntu-24.04-arm` runner for better stability
- Add `--privileged` to container options (consistent with x86_64 CI, required for io_uring tests)
- Migrate `debug-build-from-source` job to `ubuntu-24.04-arm` as well

The self-hosted ARM node has been unstable; GitHub now provides hosted ARM64 runners that can replace it.