### PR TITLE
fix(auto-pr): use branch name extraction instead of substring matching for skip logic

### DIFF
--- a/.github/workflows/auto-pr-backport.yml
+++ b/.github/workflows/auto-pr-backport.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   auto-pr:
-    if: ${{ !contains(github.event.head_commit.message, 'auto-pr-') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -23,6 +22,17 @@ jobs:
         git config --global advice.mergeConflict false
         git config --global --add safe.directory "${{ github.workspace }}"
         git config -l
+
+    - name: detect merge source
+      id: detect
+      run: |
+        MERGE_BRANCH=$(git show -s --format=%B ${{ github.event.after }} | grep -oE 'from [^ ]+' | head -n 1 | cut -d' ' -f2) || true
+        echo "MERGE_BRANCH=$MERGE_BRANCH"
+        if echo "$MERGE_BRANCH" | grep -qE '^(auto-pr-[a-f0-9]+-)'; then
+          echo "SKIP=true" >> $GITHUB_OUTPUT
+        else
+          echo "SKIP=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: check branch names
       id: branch_info
@@ -53,14 +63,14 @@ jobs:
 
     - name: create pr branch
       id: create_branch
-      if: steps.branch_info.outputs.HAS_PREV == 'true'
+      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
       run: |
         PRBRANCH=backport-pr-${{github.event.after}}-${{steps.branch_info.outputs.PREV_VERSION}}
         echo "PRBRANCH=$PRBRANCH" >> $GITHUB_OUTPUT
 
     - name: Cherry-pick commits into ${{steps.branch_info.outputs.PREV_BRANCH}}
       id: merge-changes
-      if: steps.branch_info.outputs.HAS_PREV == 'true'
+      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
       run: |
         set -x
         git checkout ${{steps.branch_info.outputs.PREV_BRANCH}}
@@ -85,7 +95,7 @@ jobs:
 
     - uses: actions/github-script@v7
       name: Open backport PR to ${{steps.branch_info.outputs.PREV_BRANCH}}
-      if: steps.branch_info.outputs.HAS_PREV == 'true'
+      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
       env:
           TITLE: ${{steps.merge-changes.outputs.TITLE}}
           MESSAGE: ${{steps.merge-changes.outputs.MESSAGE}}

--- a/.github/workflows/auto-pr-precise.yml
+++ b/.github/workflows/auto-pr-precise.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   auto-pr:
-    if: ${{ !contains(github.event.head_commit.message, 'backport-pr-') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -22,6 +21,17 @@ jobs:
         git config --global advice.mergeConflict false
         git config --global --add safe.directory "${{ github.workspace }}"
         git config -l
+
+    - name: detect merge source
+      id: detect
+      run: |
+        MERGE_BRANCH=$(git show -s --format=%B ${{ github.event.after }} | grep -oE 'from [^ ]+' | head -n 1 | cut -d' ' -f2) || true
+        echo "MERGE_BRANCH=$MERGE_BRANCH"
+        if echo "$MERGE_BRANCH" | grep -qE '^(backport-pr-[a-f0-9]+-)'; then
+          echo "SKIP=true" >> $GITHUB_OUTPUT
+        else
+          echo "SKIP=false" >> $GITHUB_OUTPUT
+        fi
 
     - name: check branch names
       id: branch_info
@@ -48,12 +58,14 @@ jobs:
 
     - name: create pr branch
       id: create_branch
+      if: steps.detect.outputs.SKIP != 'true'
       run: |
         PRBRANCH=auto-pr-${{github.event.after}}-${{steps.branch_info.outputs.NEXT_VERSION}}
         echo "PRBRANCH=$PRBRANCH" >> $GITHUB_OUTPUT
 
     - name: Merge release branch into ${{steps.branch_info.outputs.NEXT_BRANCH}}
       id: merge-changes
+      if: steps.detect.outputs.SKIP != 'true'
       run: |
         set -x
         git checkout ${{steps.branch_info.outputs.NEXT_BRANCH}}
@@ -78,6 +90,7 @@ jobs:
 
     - uses: actions/github-script@v7
       name: Open pick PR to ${{steps.branch_info.outputs.NEXT_BRANCH}}
+      if: steps.detect.outputs.SKIP != 'true'
       env:
           TITLE: ${{steps.merge-changes.outputs.TITLE}}
           MESSAGE: ${{steps.merge-changes.outputs.MESSAGE}}


### PR DESCRIPTION
## Problem

`contains(github.event.head_commit.message, 'auto-pr-')` matches any occurrence of `auto-pr-` in the commit message, not just branch names.

For example, commit message `Add backport auto-pr action with asymmetric anti-loop mechanism (#1301)` contains the substring `auto-pr-` (in "auto-pr action"), causing the backport action to be incorrectly skipped (run [#27190304684](https://github.com/alibaba/PhotonLibOS/actions/runs/27190304684)).

## Fix

Replace the job-level `if: contains()` condition with a `detect merge source` step that:
1. Extracts the merged branch name from the merge commit message via `git show --format=%B | grep 'from <branch>'`
2. Checks if the extracted branch name matches the `auto-pr-<sha>-<target>` or `backport-pr-<sha>-<target>` pattern

This avoids false positives from PR titles or commit descriptions that happen to contain these substrings.

## Skip rules (unchanged)

- **precise**: skip `backport-pr-` merges (backport should not trigger upward cascade)
- **backport**: skip `auto-pr-` merges (pick should not trigger downward backport)