### PR TITLE
[Pick][0.9 to main] | [Pick][0.8 to 0.9] | [Pick][0.7 to 0.8] | Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)  (#1259)  (#1273) 

### DIFF
--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -50,10 +50,13 @@ add_executable(test-st-utest st_utest.cpp st_utest_tcp.cpp st_utest_coroutines.c
 target_link_libraries(test-st-utest PRIVATE photon_shared)
 add_test(NAME test-st-utest COMMAND $<TARGET_FILE:test-st-utest>)
 
+<<<<<<< HEAD
 add_executable(test-go-channel test-go-channel.cpp)
 target_link_libraries(test-go-channel PRIVATE photon_shared)
 add_test(NAME test-go-channel COMMAND $<TARGET_FILE:test-go-channel>)
 
+=======
+>>>>>>> 0807140 ([Pick][0.8 to 0.9] | [Pick][0.7 to 0.8] | Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)  (#1259)  (#1273))
 add_executable(test-sleepq-stale-idx test-sleepq-stale-idx.cpp)
 target_link_libraries(test-sleepq-stale-idx PRIVATE photon_shared)
 add_test(NAME test-sleepq-stale-idx COMMAND $<TARGET_FILE:test-sleepq-stale-idx>)


### PR DESCRIPTION
> [Pick][0.8 to 0.9] | [Pick][0.7 to 0.8] | Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)  (#1259)  (#1273)

* [Pick][0.7 to 0.8] | Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)  (#1259)

* Fix Photon SleepQueue stale idx corruption during wakeup and migration (#1255) (#1258)

* Fix Photon SleepQueue stale idx corruption during wakeup and migration

* fix: test

Co-authored-by: Jingyuan <52315061+MJY-HUST@users.noreply.github.com>

* Fix merge conflict

---------

Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Jingyuan <52315061+MJY-HUST@users.noreply.github.com>

* fix conflict

---------

Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Jingyuan <52315061+MJY-HUST@users.noreply.github.com>
Generated by Auto PR, by cherry-pick related commits