### PR TITLE
Add maximum RPC request size to prevent OOM from wire

### DIFF
--- a/rpc/rpc.cpp
+++ b/rpc/rpc.cpp
@@ -188,6 +188,8 @@ namespace rpc {
         return new StubImpl(stream, ownership);
     }
 
+    static constexpr uint32_t MAX_RPC_MESSAGE_SIZE = 64 * 1024 * 1024; // 64MB
+
     class SkeletonImpl final: public Skeleton
     {
     public:
@@ -272,6 +274,8 @@ namespace rpc {
                     LOG_ERROR_RETURN(ENOSYS, -1, "unable to find function service for ID ", header.function.function);
 
                 func = it->second;
+                if (header.size > MAX_RPC_MESSAGE_SIZE)
+                    LOG_ERROR_RETURN(EMSGSIZE, -1, "RPC message too large: ", header.size);
                 ret = request.push_back(header.size);
                 if (ret != header.size) {
                     LOG_ERRNO_RETURN(ENOMEM, -1, "Failed to allocate iov");


### PR DESCRIPTION
## Summary
- RPC skeleton reads `header.size` (uint32_t from wire) and allocates without upper bound
- Attacker can send crafted header causing up to ~2GB allocation → OOM
- Add `MAX_RPC_MESSAGE_SIZE` constant (64MB) and check before allocation

## Verification
- Code review: adversarial review passed
- Compilation: verified (Debug, URING=OFF)
- E2E test: not feasible (requires RPC server fixture with crafted input)