### PR TITLE
[Backport][main to 0.9] | fix+feat(auto-pr-backport): correct cut field index, and add workflow_dispatch trigger (#1305) 

### DIFF
--- a/.github/workflows/auto-pr-backport.yml
+++ b/.github/workflows/auto-pr-backport.yml
@@ -1,0 +1,156 @@
+name: Backport Auto PR
+
+on:
+  push:
+    branches:
+      - 'release/*'
+      - 'main'
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA on main or a release/* branch to backport to the previous version (single commit only)'
+        required: true
+
+jobs:
+  auto-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.AUTOPR_SECRET }}
+
+    - name: set git config
+      run: |
+        git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global advice.mergeConflict false
+        git config --global --add safe.directory "${{ github.workspace }}"
+        git config -l
+
+    - name: resolve inputs
+      id: inputs
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          COMMIT="${{ inputs.commit_sha }}"
+          if ! git cat-file -e "${COMMIT}^{commit}" 2>/dev/null; then
+            echo "::error::commit ${COMMIT} not found"
+            exit 1
+          fi
+          # Resolve to full SHA so downstream branch names are stable
+          COMMIT=$(git rev-parse "$COMMIT")
+          # Pick the highest containing branch as source: main > release/<latest> > ... > release/<oldest>
+          CONTAINING=$(git branch -r --contains "$COMMIT" | sed 's|^[ ]*||' | grep -E '^origin/(release/|main$)' | sed 's|^origin/||')
+          if echo "$CONTAINING" | grep -qx 'main'; then
+            SOURCE_BRANCH="main"
+          else
+            SOURCE_BRANCH=$(echo "$CONTAINING" | grep '^release/' | sort -V | tail -n 1)
+          fi
+          if [ -z "$SOURCE_BRANCH" ]; then
+            echo "::error::commit ${COMMIT} is not on main or any release/* branch"
+            exit 1
+          fi
+          RANGE_START="$COMMIT"
+        else
+          COMMIT="${{ github.event.after }}"
+          RANGE_START="${{ github.event.commits[0].id }}"
+          SOURCE_BRANCH=$(echo $GITHUB_REF | sed 's|refs/heads/||')
+        fi
+        echo "COMMIT=$COMMIT" >> $GITHUB_OUTPUT
+        echo "RANGE_START=$RANGE_START" >> $GITHUB_OUTPUT
+        echo "SOURCE_BRANCH=$SOURCE_BRANCH" >> $GITHUB_OUTPUT
+        echo "resolved: COMMIT=$COMMIT RANGE_START=$RANGE_START SOURCE_BRANCH=$SOURCE_BRANCH"
+
+    - name: detect merge source
+      id: detect
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # Manual trigger: user explicitly requested it, never skip
+          echo "SKIP=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        MERGE_BRANCH=$(git show -s --format=%B ${{ steps.inputs.outputs.COMMIT }} | grep -oE 'from [^ ]+' | head -n 1 | cut -d' ' -f2) || true
+        echo "MERGE_BRANCH=$MERGE_BRANCH"
+        if echo "$MERGE_BRANCH" | grep -qE '^(auto-pr-[a-f0-9]+-)'; then
+          echo "SKIP=true" >> $GITHUB_OUTPUT
+        else
+          echo "SKIP=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: check branch names
+      id: branch_info
+      run: |
+        RELEASE_VERSIONS=$(git branch -r | grep 'origin/release/' | cut -d '/' -f 3 | sort -V)
+        CURRENT_BRANCH="${{ steps.inputs.outputs.SOURCE_BRANCH }}"
+        if [ "$CURRENT_BRANCH" = "main" ]; then
+          # Source on main: backport to the highest release version
+          PREV_VERSION=$(echo "$RELEASE_VERSIONS" | tail -n 1)
+          CURRENT_VERSION="main"
+        else
+          CURRENT_VERSION=$(echo "$CURRENT_BRANCH" | rev | cut -d '/' -f 1 | rev)
+          # Find the previous (lower) version
+          PREV_VERSION=$(echo "$RELEASE_VERSIONS" | grep -w $CURRENT_VERSION -B 1 | head -n 1)
+        fi
+        if [ -z "$PREV_VERSION" ] || [ "$PREV_VERSION" = "$CURRENT_VERSION" ]; then
+          echo "No lower release version found, skipping backport PR"
+          echo "HAS_PREV=false" >> $GITHUB_OUTPUT
+        else
+          echo "HAS_PREV=true" >> $GITHUB_OUTPUT
+          PREV_BRANCH="release/$PREV_VERSION"
+          set -x
+          echo "PREV_VERSION=$PREV_VERSION" >> $GITHUB_OUTPUT
+          echo "PREV_BRANCH=$PREV_BRANCH" >> $GITHUB_OUTPUT
+        fi
+        echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        echo "CURRENT_BRANCH=$CURRENT_BRANCH" >> $GITHUB_OUTPUT
+
+    - name: create pr branch
+      id: create_branch
+      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
+      run: |
+        PRBRANCH=backport-pr-${{steps.inputs.outputs.COMMIT}}-${{steps.branch_info.outputs.PREV_VERSION}}
+        echo "PRBRANCH=$PRBRANCH" >> $GITHUB_OUTPUT
+
+    - name: Cherry-pick commits into ${{steps.branch_info.outputs.PREV_BRANCH}}
+      id: merge-changes
+      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
+      run: |
+        set -x
+        git checkout ${{steps.branch_info.outputs.PREV_BRANCH}}
+        git checkout -b ${{steps.create_branch.outputs.PRBRANCH}}
+        RANGE_START=${{ steps.inputs.outputs.RANGE_START }}
+        COMMIT=${{ steps.inputs.outputs.COMMIT }}
+        echo "TITLE<<__AUTOPR_EOF" >> $GITHUB_OUTPUT
+        git log --format="| %s" ${RANGE_START}~..${COMMIT} | tr '\n' ' ' >> $GITHUB_OUTPUT
+        echo "" >> $GITHUB_OUTPUT
+        echo "__AUTOPR_EOF" >> $GITHUB_OUTPUT
+        echo "MESSAGE<<__AUTOPR_EOF" >> $GITHUB_OUTPUT
+        git log --format="> %B" ${RANGE_START}~..${COMMIT} >> $GITHUB_OUTPUT
+        echo "__AUTOPR_EOF" >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
+        REVS=$(git rev-list --reverse ${RANGE_START}~..${COMMIT})
+        for rev in "$REVS"; do
+          if ! git cherry-pick ${rev} ; then
+            git add -u
+            git -c core.editor=true cherry-pick --continue
+          fi
+        done
+        git push -d origin ${{steps.create_branch.outputs.PRBRANCH}} || true
+        git push -u origin ${{steps.create_branch.outputs.PRBRANCH}}
+
+    - uses: actions/github-script@v7
+      name: Open backport PR to ${{steps.branch_info.outputs.PREV_BRANCH}}
+      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
+      env:
+          TITLE: ${{steps.merge-changes.outputs.TITLE}}
+          MESSAGE: ${{steps.merge-changes.outputs.MESSAGE}}
+      with:
+        github-token: ${{ secrets.AUTOPR_SECRET }}
+        script: |
+          await github.rest.pulls.create({
+            ...context.repo,
+            title: `[Backport][${{steps.branch_info.outputs.CURRENT_VERSION}} to ${{steps.branch_info.outputs.PREV_VERSION}}] ` + process.env.TITLE,
+            head: `${{steps.create_branch.outputs.PRBRANCH}}`,
+            base: `${{steps.branch_info.outputs.PREV_BRANCH}}`,
+            body: process.env.MESSAGE + `\nGenerated by Backport Auto PR, by cherry-pick related commits.\n\nPlease review and decide whether to merge or close this backport PR.`,
+          });


### PR DESCRIPTION
> fix+feat(auto-pr-backport): correct cut field index, and add workflow_dispatch trigger (#1305)

* fix(auto-pr-backport): correct cut field index for release version parsing

`git branch -r` outputs entries like `  origin/release/0.7` (with two
leading spaces). Splitting on `/` yields 3 fields: `  origin`, `release`,
`0.7`. The previous `cut -f 4` produced an empty string, leaving
`RELEASE_VERSIONS` empty and triggering 'No lower release version found'
on every push to main.

Align with auto-pr-precise.yml which correctly uses `cut -f 3`.

This fix was originally part of PR #1303 but was dropped during squash
merge.

* feat(auto-pr-backport): support manual trigger for a single commit

Adds a `workflow_dispatch` trigger with a `commit_sha` input so the
backport workflow can be re-run on demand for a previously merged
commit (e.g. when the original push was masked by a now-fixed bug, or
when an earlier backport PR was closed and needs to be regenerated).

Behavior:
- `push` to main / release/* keeps the existing semantics unchanged.
- `workflow_dispatch` accepts one commit SHA. The workflow:
  - validates the commit exists,
  - resolves it to a full SHA (so the PR branch name is stable),
  - infers the source branch as the highest containing branch
    (main > release/<latest> > ... > release/<oldest>),
  - skips the anti-loop `auto-pr-` detection (manual trigger is
    always honored),
  - cherry-picks just that single commit (no commit range).

The PR branch follows the same naming pattern
`backport-pr-<sha>-<prev_version>` so the existing auto-delete
workflow continues to clean it up after merge.
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.