### PR TITLE
feat(oss): support custom headers on all OSS SDK requests

### DIFF
--- a/ecosystem/oss.cpp
+++ b/ecosystem/oss.cpp
@@ -393,6 +393,7 @@ class OssClientImpl : public Client {
                           photon::net::http::Headers& headers,
                           const StringKV& query_params = {},
                           bool invalidate_cache = false);
+  void inject_custom_headers(photon::net::http::Headers& headers);
   int sign_and_call(HTTP_STACK_OP& op, photon::net::http::Verb verb,
                     const OssUrl& oss_url, const StringKV& query_params = {},
                     bool invalidate_cache = false);
@@ -443,6 +444,16 @@ OssClient::OssClient(const ClientOptions& options, Authenticator* authenticator)
   m_client->set_user_agent(m_oss_options.user_agent);
   if (!m_oss_options.proxy.empty()) m_client->set_proxy(m_oss_options.proxy);
 
+  auto& ch = m_oss_options.custom_headers;
+  for (auto it = ch.begin(); it != ch.end();) {
+    std::transform(it->first.begin(), it->first.end(), it->first.begin(), ::tolower);
+    // reserved for authenticator;
+    if (it->first == "authorization" || it->first == "date")
+      it = ch.erase(it);
+    else
+      ++it;
+  }
+
   if (!options.bind_ips.empty()) {
     std::vector<photon::net::IPAddr> ip_vec;
     auto ips = estring_view(options.bind_ips).split(',');
@@ -486,7 +497,15 @@ int OssClient::append_auth_headers(photon::net::http::Verb v, const OssUrl& oss_
   params.object = oss_url.object();
   params.invalidate_cache = invalidate_cache;
 
+  // inject custom headers before sign so x-oss-* headers participate in signing
+  inject_custom_headers(headers);
   return m_authenticator->sign(headers, params);
+}
+
+void OssClient::inject_custom_headers(photon::net::http::Headers& headers) {
+  for (const auto& kv : m_oss_options.custom_headers) {
+    headers.insert(kv.first, kv.second);
+  }
 }
 
 int OssClient::sign_and_call(HTTP_STACK_OP& op, photon::net::http::Verb verb,

--- a/ecosystem/oss.h
+++ b/ecosystem/oss.h
@@ -52,6 +52,7 @@ struct ClientOptions {
   // For QPSLimit case, the policy is different. We will retry more
   // times until we have waited the "request time out" period.
   uint64_t retry_base_interval_us = 100'000;
+  std::vector<std::pair<std::string, std::string>> custom_headers;
 };
 
 struct ObjectMeta {

--- a/ecosystem/test/CMakeLists.txt
+++ b/ecosystem/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test-ecosystem test.cpp test_simple_dom.cpp test_redis.cpp)
+add_executable(test-ecosystem test.cpp test_simple_dom.cpp test_redis.cpp test_oss_custom_headers.cpp)
 target_link_libraries(test-ecosystem PRIVATE photon_shared)
 add_test(NAME test-ecosystem COMMAND $<TARGET_FILE:test-ecosystem>)
 

--- a/ecosystem/test/test_oss.cpp
+++ b/ecosystem/test/test_oss.cpp
@@ -46,6 +46,11 @@ class BasicAuthOssTest : public ::testing::Test {
     // v4 signature with non-empty region, otherwise v1 signature.
     opts_.region = FLAGS_region;
 
+    if (random_suffix % 2) {
+      opts_.custom_headers = {{"x-custom-trace-id", "test-run-" + std::to_string(random_suffix)},
+                              {"x-oss-custom-client", "photon-test"}};
+    }
+
     CreateOssClient(opts_);
   }
 

--- a/ecosystem/test/test_oss_custom_headers.cpp
+++ b/ecosystem/test/test_oss_custom_headers.cpp
@@ -1,0 +1,170 @@
+#include <gtest/gtest.h>
+#include <photon/common/alog.h>
+#include <photon/common/estring.h>
+#include <photon/net/http/server.h>
+#include <photon/net/socket.h>
+#include <photon/photon.h>
+
+#include <photon/thread/thread.h>
+
+#include <map>
+#include <string>
+
+#include "../oss.h"
+
+using namespace photon::objstore;
+using namespace photon::net;
+using namespace photon::net::http;
+
+static std::map<std::string, std::string> g_captured_headers;
+static photon::mutex g_mutex;
+
+static int capture_handler(void*, Request& req, Response& resp,
+                           std::string_view) {
+  {
+    SCOPED_LOCK(g_mutex);
+    g_captured_headers.clear();
+    for (auto kv : req.headers) {
+      g_captured_headers[std::string(kv.first)] = std::string(kv.second);
+    }
+  }
+  char body[] = "x";
+  resp.set_result(200);
+  resp.headers.content_length(1);
+  resp.headers.insert("Content-Range", "bytes 0-0/1");
+  resp.write(body, 1);
+  return 0;
+}
+
+class NoopAuthenticator : public Authenticator {
+ public:
+  int sign(Headers& headers, const SignParameters& params) override {
+    return 0;
+  }
+  void set_credentials(CredentialParameters&& credentials) override {}
+};
+
+class FakeAuthenticator : public Authenticator {
+ public:
+  int sign(Headers& headers, const SignParameters& params) override {
+    headers.insert("Authorization", "OSS fake-ak:fake-sig");
+    headers.insert("Date", "Tue, 10 Jun 2026 00:00:00 GMT");
+    return 0;
+  }
+  void set_credentials(CredentialParameters&& credentials) override {}
+};
+
+class OssCustomHeaderTest : public ::testing::Test {
+ protected:
+  ISocketServer* tcp_server = nullptr;
+  HTTPServer* http_server = nullptr;
+
+  void SetUp() override {
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+    tcp_server = new_tcp_socket_server();
+    tcp_server->timeout(1000UL * 1000);
+    tcp_server->bind_v4localhost();
+    tcp_server->listen();
+    http_server = new_http_server();
+    http_server->add_handler({nullptr, &capture_handler});
+    tcp_server->set_handler(http_server->get_connection_handler());
+    tcp_server->start_loop();
+  }
+
+  void TearDown() override {
+    delete http_server;
+    delete tcp_server;
+    photon::fini();
+  }
+
+  ClientOptions make_opts() {
+    ClientOptions opts;
+    opts.endpoint = "oss-test.example.com";
+    opts.bucket = "test-bucket";
+    opts.proxy = estring().appends("http://127.0.0.1:",
+                                   tcp_server->getsockname().port);
+    opts.retry_times = 0;
+    return opts;
+  }
+};
+
+TEST_F(OssCustomHeaderTest, custom_headers_are_sent) {
+  auto opts = make_opts();
+  opts.custom_headers = {{"x-custom-trace-id", "abc123"}};
+
+  auto client = new_oss_client(opts, new NoopAuthenticator());
+  ASSERT_NE(client, nullptr);
+  DEFER(delete client);
+
+  ObjectHeaderMeta meta;
+  client->head_object("test-obj", meta);
+
+  SCOPED_LOCK(g_mutex);
+  ASSERT_NE(g_captured_headers.find("x-custom-trace-id"),
+            g_captured_headers.end());
+  EXPECT_EQ(g_captured_headers["x-custom-trace-id"], "abc123");
+}
+
+TEST_F(OssCustomHeaderTest, keys_are_lowercased) {
+  auto opts = make_opts();
+  opts.custom_headers = {{"X-CUSTOM-UPPER", "val"}};
+
+  auto client = new_oss_client(opts, new NoopAuthenticator());
+  ASSERT_NE(client, nullptr);
+  DEFER(delete client);
+
+  ObjectHeaderMeta meta;
+  client->head_object("test-obj", meta);
+
+  SCOPED_LOCK(g_mutex);
+  EXPECT_EQ(g_captured_headers.count("X-CUSTOM-UPPER"), 0u);
+  ASSERT_NE(g_captured_headers.find("x-custom-upper"),
+            g_captured_headers.end());
+  EXPECT_EQ(g_captured_headers["x-custom-upper"], "val");
+}
+
+TEST_F(OssCustomHeaderTest, sdk_headers_override_custom) {
+  auto opts = make_opts();
+  opts.custom_headers = {{"x-oss-range-behavior", "custom-value"}};
+
+  auto client = new_oss_client(opts, new NoopAuthenticator());
+  ASSERT_NE(client, nullptr);
+  DEFER(delete client);
+
+  char buf[1];
+  iovec iov{buf, 1};
+  client->get_object_range("test-obj", &iov, 1, 0);
+
+  SCOPED_LOCK(g_mutex);
+  auto it = g_captured_headers.find("x-oss-range-behavior");
+  ASSERT_NE(it, g_captured_headers.end());
+  EXPECT_EQ(it->second, "standard");
+}
+
+TEST_F(OssCustomHeaderTest, case_insensitive_insert_prevents_override) {
+  auto opts = make_opts();
+  opts.custom_headers = {{"X-OSS-RANGE-BEHAVIOR", "custom-value"},
+                         {"authoriZation", "custom-auth"},
+                         {"dAte", "custom-date"}};
+
+  auto client = new_oss_client(opts, new FakeAuthenticator());
+  ASSERT_NE(client, nullptr);
+  DEFER(delete client);
+
+  char buf[1];
+  iovec iov{buf, 1};
+  client->get_object_range("test-obj", &iov, 1, 0);
+
+  SCOPED_LOCK(g_mutex);
+  auto it = g_captured_headers.find("x-oss-range-behavior");
+  ASSERT_NE(it, g_captured_headers.end());
+  EXPECT_EQ(it->second, "standard");
+
+  auto auth_it = g_captured_headers.find("Authorization");
+  ASSERT_NE(auth_it, g_captured_headers.end());
+  EXPECT_EQ(auth_it->second, "OSS fake-ak:fake-sig");
+
+  auto date_it = g_captured_headers.find("Date");
+  ASSERT_NE(date_it, g_captured_headers.end());
+  EXPECT_EQ(date_it->second, "Tue, 10 Jun 2026 00:00:00 GMT");
+}


### PR DESCRIPTION
Allow users to configure custom header key-value pairs in ClientOptions that are automatically attached to every request. Keys are lowercased once at construction time. SDK-internal headers take precedence over custom headers via first-writer-wins insert semantics.

The customized headers can be used with bucket policy later.