### PR TITLE
feat(thread): make WorkPool ring size configurable at construction

### DIFF
--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -720,5 +720,125 @@ public:
     }
 };
 
+// FlexRingChannel: composition-based wrapper for FlexQueue types.
+// Unlike RingChannel (which inherits from QueueType), FlexRingChannel holds
+// a pointer to a dynamically-allocated FlexQueue. This avoids the memory
+// layout conflict where RingChannel's members (semaphore, idler, etc.) would
+// overlap with the zero-length slots[] array in the base queue class.
+//
+// Usage:
+//   using FlexRing = FlexLockfreeMPMCRingQueue<Delegate<void>>;
+//   auto* ch = FlexRingChannel<FlexRing>::create(1024);
+//   ch->send(task);
+//   auto task = ch->recv();
+//   FlexRingChannel<FlexRing>::destroy(ch);
+template <typename FlexQueueType>
+class FlexRingChannel {
+    FlexQueueType* queue;
+    photon::semaphore     queue_sem;
+    std::atomic<uint64_t> idler{0};    // # consumers in idle/wait
+    std::atomic<uint64_t> pending{0};  // mirror of queue_sem.m_count
+    uint64_t default_yield_turn = 1024;
+    uint64_t default_yield_usec = 1024;
+
+    using T = decltype(std::declval<FlexQueueType>().recv());
+
+    FlexRingChannel(FlexQueueType* q, uint64_t yield_turn, uint64_t yield_usec)
+        : queue(q), default_yield_turn(yield_turn),
+          default_yield_usec(yield_usec) {}
+
+public:
+    ~FlexRingChannel() = default;
+
+    FlexRingChannel(const FlexRingChannel&) = delete;
+    FlexRingChannel& operator=(const FlexRingChannel&) = delete;
+
+    static FlexRingChannel* create(size_t capacity,
+                                   uint64_t max_yield_turn = 1024,
+                                   uint64_t max_yield_usec = 1024) {
+        auto q = FlexQueueType::create(capacity);
+        if (!q) return nullptr;
+        return new FlexRingChannel(q, max_yield_turn, max_yield_usec);
+    }
+
+    static void destroy(FlexRingChannel* ch) {
+        if (!ch) return;
+        FlexQueueType::destroy(ch->queue);
+        delete ch;
+    }
+
+    template <typename Pause = ThreadPause>
+    void send(const T& x) {
+        queue->template send<Pause>(x);
+        // Dekker barrier: ensure the prior push is ordered before the
+        // following idler load, paired with the seq_cst RMW on `idler`
+        // in recv().
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        auto cur_idler = idler.load(std::memory_order_seq_cst);
+        if (cur_idler == 0) return;
+
+        // Cap pending (== m_count) at cur_idler so a long burst can never
+        // accumulate stale wake-up tokens.
+        auto p = pending.load(std::memory_order_acquire);
+        for (;;) {
+            if (p >= cur_idler) {
+                auto fresh = idler.load(std::memory_order_relaxed);
+                if (fresh <= cur_idler) return;
+                cur_idler = fresh;
+                continue;
+            }
+            if (pending.compare_exchange_weak(p, p + 1,
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+                queue_sem.signal(1);
+                return;
+            }
+        }
+    }
+
+    T recv(uint64_t max_yield_turn, uint64_t max_yield_usec) {
+        T x;
+        if (queue->pop(x)) return x;
+        // yield once if failed, so photon::now will be updated
+        photon::thread_yield();
+        // seq_cst on idler is the other half of the Dekker barrier (see send).
+        idler.fetch_add(1, std::memory_order_seq_cst);
+        DEFER(idler.fetch_sub(1, std::memory_order_seq_cst));
+        Timeout yield_timeout(max_yield_usec);
+        uint64_t yield_turn = max_yield_turn;
+        while (!queue->pop(x)) {
+            if (yield_turn > 0 && !yield_timeout.expired()) {
+                yield_turn--;
+                photon::thread_yield();
+            } else {
+                // wait for 100ms
+                int r = queue_sem.wait(1, 100UL * 1000);
+                // r == 0 means we actually consumed one m_count token; mirror
+                // it on `pending`. r < 0 (timeout/interrupt) does not touch
+                // m_count, so we must not touch `pending` either.
+                if (r == 0)
+                    pending.fetch_sub(1, std::memory_order_acq_rel);
+                // reset yield mark and set into busy wait
+                yield_turn = max_yield_turn;
+                yield_timeout.timeout(max_yield_usec);
+            }
+        }
+        return x;
+    }
+
+    T recv() { return recv(default_yield_turn, default_yield_usec); }
+
+    bool empty() const { return queue->empty(); }
+    bool full() const { return queue->full(); }
+    size_t read_available() const { return queue->read_available(); }
+    size_t write_available() const { return queue->write_available(); }
+
+    // Diagnostic accessor: returns the current count of in-flight wake-up
+    // tokens (mirrors `queue_sem.m_count`).
+    uint64_t notification_pending() const {
+        return pending.load(std::memory_order_acquire);
+    }
+};
+
 }  // namespace common
 }  // namespace photon

--- a/common/test/test_lockfree.cpp
+++ b/common/test/test_lockfree.cpp
@@ -258,6 +258,73 @@ TEST(lockfree_queue, test_queue) {
     test_queue_batch<WithLock, WithLock>("FlexPhotonSPSCQueue+Batch", cuqueue);
 }
 
+TEST(FlexRingChannel, basic) {
+    using FlexRing = FlexLockfreeMPMCRingQueue<int>;
+    using Channel = photon::common::FlexRingChannel<FlexRing>;
+
+    auto* ch = Channel::create(16);
+    ASSERT_NE(ch, nullptr);
+    DEFER(Channel::destroy(ch));
+
+    EXPECT_TRUE(ch->empty());
+    EXPECT_FALSE(ch->full());
+    EXPECT_EQ(ch->read_available(), 0u);
+
+    for (int i = 1; i <= 10; i++) {
+        ch->send(i);
+    }
+    EXPECT_FALSE(ch->empty());
+    EXPECT_EQ(ch->read_available(), 10u);
+
+    for (int i = 1; i <= 10; i++) {
+        int val = ch->recv();
+        EXPECT_EQ(val, i);
+    }
+    EXPECT_TRUE(ch->empty());
+    EXPECT_EQ(ch->read_available(), 0u);
+}
+
+TEST(FlexRingChannel, mpmc) {
+    using FlexRing = FlexLockfreeMPMCRingQueue<int>;
+    using Channel = photon::common::FlexRingChannel<FlexRing>;
+
+    auto* ch = Channel::create(2048);
+    ASSERT_NE(ch, nullptr);
+    DEFER(Channel::destroy(ch));
+
+    constexpr int num_items = 1000;
+    std::atomic<int> sum{0};
+    std::atomic<bool> producer_done{false};
+
+    // Producer thread (std::thread)
+    std::thread producer([&] {
+        for (int i = 1; i <= num_items; i++) {
+            ch->send<ThreadPause>(i);
+        }
+        producer_done.store(true);
+    });
+
+    // Consumer thread (photon thread)
+    auto consumer = photon::thread_create([](void* arg) -> void* {
+        auto* args = (std::pair<Channel*, std::atomic<int>*>*)arg;
+        auto* ch = args->first;
+        auto* sum = args->second;
+        for (int i = 0; i < 1000; i++) {
+            int val = ch->recv();
+            sum->fetch_add(val);
+        }
+        delete args;
+        return nullptr;
+    }, new std::pair<Channel*, std::atomic<int>*>(ch, &sum));
+    photon::thread_enable_join(consumer);
+
+    producer.join();
+    photon::thread_join((photon::join_handle*)consumer);
+
+    int expected = num_items * (num_items + 1) / 2;
+    EXPECT_EQ(sum.load(), expected);
+}
+
 int main(int argc, char **arg) {
     if (!photon::is_using_default_engine()) return 0;
     ::testing::InitGoogleTest(&argc, arg);
@@ -265,5 +332,7 @@ int main(int argc, char **arg) {
     DEFER(luqueue.destroy(&luqueue));
     DEFER(lubqueue.destroy(&lubqueue));
     DEFER(cuqueue.destroy(&cuqueue));
+    photon::vcpu_init();
+    DEFER(photon::vcpu_fini());
     return RUN_ALL_TESTS();
 }

--- a/thread/test/test-pool.cpp
+++ b/thread/test/test-pool.cpp
@@ -300,6 +300,64 @@ TEST(workpool, async_work_lambda_threadpool_append) {
     LOG_INFO("DONE");
 }
 
+TEST(workpool, custom_ring_size) {
+    // Small ring (will be rounded up to power of 2)
+    {
+        WorkPool wp(2, 0, 0, 0, 4);
+        semaphore sem;
+        std::atomic<int> counter{0};
+        for (int i = 0; i < 16; i++) {
+            wp.async_call(new auto([&sem, &counter] {
+                counter.fetch_add(1, std::memory_order_relaxed);
+                sem.signal(1);
+            }));
+        }
+        sem.wait(16);
+        EXPECT_EQ(counter.load(), 16);
+    }
+    // Non-power-of-two ring size
+    {
+        WorkPool wp(2, 0, 0, 0, 1000);
+        semaphore sem;
+        std::atomic<int> counter{0};
+        for (int i = 0; i < 64; i++) {
+            wp.async_call(new auto([&sem, &counter] {
+                counter.fetch_add(1, std::memory_order_relaxed);
+                sem.signal(1);
+            }));
+        }
+        sem.wait(64);
+        EXPECT_EQ(counter.load(), 64);
+    }
+    // Large ring size
+    {
+        WorkPool wp(2, 0, 0, -1, 256 * 1024);
+        EXPECT_EQ(wp.get_vcpu_num(), 2);
+        semaphore sem;
+        std::atomic<int> counter{0};
+        for (int i = 0; i < 64; i++) {
+            wp.async_call(new auto([&sem, &counter] {
+                counter.fetch_add(1, std::memory_order_relaxed);
+                sem.signal(1);
+            }));
+        }
+        sem.wait(64);
+        EXPECT_EQ(counter.load(), 64);
+    }
+}
+
+TEST(workpool, ring_size_with_call) {
+    // Verify synchronous call works with custom ring size
+    WorkPool wp(2, 0, 0, 0, 32);
+    std::atomic<int> sum{0};
+    for (int i = 0; i < 20; i++) {
+        wp.call([&sum, i] {
+            sum.fetch_add(i);
+        });
+    }
+    EXPECT_EQ(sum.load(), 190);  // 0+1+...+19
+}
+
 int main(int argc, char** arg)
 {
     if (!is_using_default_engine()) return 0;

--- a/thread/workerpool.cpp
+++ b/thread/workerpool.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <photon/thread/thread.h>
 
 #include <algorithm>
+#include <cassert>
 #include <future>
 #include <random>
 #include <thread>
@@ -31,20 +32,24 @@ namespace photon {
 
 class WorkPool::impl {
 public:
-    static constexpr uint32_t RING_SIZE = 65536;
     static constexpr uint64_t QUEUE_YIELD_COUNT = 256;
     static constexpr uint64_t QUEUE_YIELD_US = 1024;
+
+    using FlexRing = FlexLockfreeMPMCRingQueue<Delegate<void>>;
+    using FlexRingChannel = common::FlexRingChannel<FlexRing>;
 
     photon::spinlock worker_lock;
     std::vector<std::thread> owned_std_threads;
     std::vector<photon::vcpu_base *> vcpus;
     std::atomic<uint64_t> vcpu_index{0};
-    photon::common::RingChannel<
-        LockfreeMPMCRingQueue<Delegate<void>, RING_SIZE>>
-        ring;
+    FlexRingChannel* ring;
     int mode;
 
-    impl(size_t vcpu_num, int ev_engine, int io_engine, int mode) : mode(mode) {
+    impl(size_t vcpu_num, int ev_engine, int io_engine, int mode, size_t ring_size)
+        : mode(mode) {
+        assert(ring_size > 0 && "workpool ring_size must be > 0");
+        ring = FlexRingChannel::create(ring_size, QUEUE_YIELD_COUNT, QUEUE_YIELD_US);
+        if (!ring) abort();
         vcpus.reserve(vcpu_num);
         for (size_t i = 0; i < vcpu_num; ++i) {
             owned_std_threads.emplace_back(
@@ -63,17 +68,18 @@ public:
             while (vcpus.size()) std::this_thread::yield();
         }
         worker_lock.lock();
+        FlexRingChannel::destroy(ring);
     }
 
     void enqueue(Delegate<void> call, AutoContext = {}) {
-        if (likely(CURRENT)) ring.send<PhotonPause>(call);
-        else                 ring.send<ThreadPause>(call);
+        if (likely(CURRENT)) ring->send<PhotonPause>(call);
+        else                 ring->send<ThreadPause>(call);
     }
     void enqueue(Delegate<void> call, StdContext) {
-        ring.send<ThreadPause>(call);
+        ring->send<ThreadPause>(call);
     }
     void enqueue(Delegate<void> call, PhotonContext) {
-        ring.send<PhotonPause>(call);
+        ring->send<PhotonPause>(call);
     }
     template <typename Context>
     void do_call(Delegate<void> call) {
@@ -123,7 +129,7 @@ public:
         ready_vcpu.signal(1);
         for (;;) {
             auto yc = running_tasks ? 0 : QUEUE_YIELD_COUNT;
-            auto task = ring.recv(yc, QUEUE_YIELD_US);
+            auto task = ring->recv(yc, QUEUE_YIELD_US);
             if (!task) break;
             running_tasks = running_tasks + 1; // ++ -- are deprecated for volatile in C++20
             TaskLB tasklb{task, &running_tasks};
@@ -197,8 +203,8 @@ private:
     StdSemaphore ready_vcpu;
 };
 
-WorkPool::WorkPool(size_t vcpu_num, int ev_engine, int io_engine, int mode)
-    : pImpl(new impl(vcpu_num, ev_engine, io_engine, mode)) {}
+WorkPool::WorkPool(size_t vcpu_num, int ev_engine, int io_engine, int mode, size_t ring_size)
+    : pImpl(new impl(vcpu_num, ev_engine, io_engine, mode, ring_size)) {}
 
 WorkPool::~WorkPool() { /* implicitly delete pImpl */}
 

--- a/thread/workerpool.h
+++ b/thread/workerpool.h
@@ -37,9 +37,12 @@ public:
      * @param thread_mod threads work in which mode, -1 for non-thread mode, set
      * to 0 will create photon thread for every task, and >0 to create photon
      * thread in photon thread pool with this size.
+     * @param ring_size capacity of the internal lock-free ring buffer for task
+     * dispatching (default 65536). Must be > 0; rounded up to the next power of
+     * two internally.
      */
     explicit WorkPool(size_t vcpu_num, int ev_engine = 0, int io_engine = 0,
-                      int thread_mod = -1);
+                      int thread_mod = -1, size_t ring_size = 65536);
 
     WorkPool(const WorkPool& other) = delete;
     WorkPool& operator=(const WorkPool& rhs) = delete;


### PR DESCRIPTION
Previously the internal lock-free ring buffer capacity was hardcoded at
65536 (RING_SIZE constant). This commit makes it a constructor parameter
with 65536 as the default, preserving full backward compatibility.

The ring uses FlexLockfreeMPMCRingQueue (dynamically-sized) allocated via
FlexQueue::create(). The photon-style send/recv waiting logic (semaphore +
yield spinning) is implemented directly in WorkPool::impl rather than using
RingChannel, because RingChannel inherits from the flex queue and its
derived members would overlap with the flexible slots[] array.

Changes:
- thread/workerpool.h: add ring_size parameter (default 65536)
- thread/workerpool.cpp: switch to FlexLockfreeMPMCRingQueue with inline
  semaphore-based waiting, exception-safe construction, ring_size > 0
  validation, and runtime abort on allocation failure
- thread/test/test-pool.cpp: add tests for custom ring sizes