### PR TITLE
try_goto: insert target before current to reduce runq reordering

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -670,7 +670,7 @@ namespace photon
         Switch try_goto(thread* th) const {
             assert(th->vcpu == vcpu);
             th->remove_from_list();
-            current->insert_after(th);
+            current->insert_before(th);
             return _do_goto(th);
         }
         bool single() const {

--- a/thread/workerpool.cpp
+++ b/thread/workerpool.cpp
@@ -132,10 +132,9 @@ public:
             } else {
                 auto th = !pool ? thread_create(&delegate_helper, &tasklb) :
                            pool-> thread_create(&delegate_helper, &tasklb) ;
-                (void)th;
                 // Once yield the current coroutine, the newly created coroutine will always
                 // be scheduled before the current coroutine. tasklb will not be overwritten.
-                photon::thread_yield();
+                photon::thread_yield_to(th);
             }
         }
         while (running_tasks)


### PR DESCRIPTION
## Summary

In `try_goto`, replace `current->insert_after(th)` with `current->insert_before(th)` to minimize the disturbance to runq order on `thread_yield_to(th)`, keeping scheduling more uniform.

## Motivation

`thread_yield_to` only promises to hand control over to `th`; subsequent scheduling is left to the runq. The previous `insert_after` form unconditionally relocated the target to `current->next`, which significantly perturbed the runq order — most notably for the very common pattern:

```cpp
auto th = thread_create(...);   // appended at the tail (current->prev())
thread_yield_to(th);
```

Here `th == current->prev()` already, so any rearrangement is wasted work and forces every later round-robin step to revisit the relocated thread first.

## Change

Use `current->insert_before(th)` instead. The semantics of `yield_to` are unchanged. As a side benefit, when `th == current->prev()` the operation degenerates to a no-op on the list, eliminating the overhead for the `thread_create + yield_to` dispatch pattern.

## Test

- Existing `thread/test` cases continue to pass.
