### PR TITLE
[Backport][main to 0.9] | Fix missing setsockopt replay in SMC and fstack-dpdk bind (#1271) 

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -473,6 +473,9 @@ public:
             m_listen_fd = socket(AF_SMC, ver);
             if (m_listen_fd < 0) return -1;
         }
+        if (m_opts.setsockopt(m_listen_fd) != 0) {
+            return -1;
+        }
         int ret = ::bind(m_listen_fd, s.get_sockaddr(), s.get_socklen());
         if (ret < 0)
             LOG_ERRNO_RETURN(0, ret, "failed to bind to ", s.to_endpoint());
@@ -719,6 +722,9 @@ public:
         m_listen_fd = fstack_socket(s.get_sockaddr()->sa_family, SOCK_STREAM, 0);   // already non-blocking and no-delay
         if (m_listen_fd < 0) {
             LOG_ERRNO_RETURN(0, -1, "fail to setup DPDK listen fd");
+        }
+        if (m_opts.setsockopt(m_listen_fd) != 0) {
+            return -1;
         }
         int ret = fstack_bind(m_listen_fd, s.get_sockaddr(), s.get_socklen());
         if (ret < 0)


### PR DESCRIPTION
> Fix missing setsockopt replay in SMC and fstack-dpdk bind (#1271)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.