### PR TITLE
[Backport][main to 0.9] | Fix iouring eventfd double-close on repeated fini() (#1268) 

### DIFF
--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -64,6 +64,7 @@ public:
                     LOG_ERROR("iouring: failed to unregister cascading event fd ", ERRNO());
             }
             close(m_eventfd);
+            m_eventfd = -1;
         }
         if (m_ring != nullptr) {
             io_uring_queue_exit(m_ring);


### PR DESCRIPTION
> Fix iouring eventfd double-close on repeated fini() (#1268)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.