### PR TITLE
[Backport][main to 0.9] | Fix Base64Encode underflow on empty input (#1266) 

### DIFF
--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -130,6 +130,7 @@ void base64_translate_3to4(const char *in, char *out)  {
 }
 
 void Base64Encode(std::string_view in, std::string &out) {
+    if (in.empty()) { out.clear(); return; }
     auto main = in.size() / 3;
     auto remain = in.size() % 3;
     if (0 == remain) {


### PR DESCRIPTION
> Fix Base64Encode underflow on empty input (#1266)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.