### PR TITLE
[Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262) 

### DIFF
--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -268,6 +268,7 @@ size_t Message::body_size() const {
     if (it != headers.end()) return estring_view(it.second()).to_uint64();
     // or calc from Content-Range
     it = headers.find("Content-Range");
+<<<<<<< HEAD
     if (it != headers.end()) {
         size_t start, end;
         if (sscanf("bytes %lu-%lu", it.second().data(), &start, &end) == 2) {
@@ -277,6 +278,15 @@ size_t Message::body_size() const {
             return end;
         }
         return 0;
+=======
+    if (it == headers.end()) return 0;
+    size_t start, end;
+    if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
+        return end-start+1;
+    }
+    if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
+        return end;
+>>>>>>> d1eee9d (Fix swapped sscanf arguments in Content-Range parsing (#1262))
     }
     // No Content-Length and no Content-Range. If the connection will be closed
     // (Connection: close, Trailer, or HTTP/1.0 implicit close) and the response

--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -268,25 +268,15 @@ size_t Message::body_size() const {
     if (it != headers.end()) return estring_view(it.second()).to_uint64();
     // or calc from Content-Range
     it = headers.find("Content-Range");
-<<<<<<< HEAD
     if (it != headers.end()) {
         size_t start, end;
-        if (sscanf("bytes %lu-%lu", it.second().data(), &start, &end) == 2) {
+        if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
             return end-start+1;
         }
-        if (sscanf("bytes */%lu", it.second().data(), &end) == 1) {
+        if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
             return end;
         }
         return 0;
-=======
-    if (it == headers.end()) return 0;
-    size_t start, end;
-    if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
-        return end-start+1;
-    }
-    if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
-        return end;
->>>>>>> d1eee9d (Fix swapped sscanf arguments in Content-Range parsing (#1262))
     }
     // No Content-Length and no Content-Range. If the connection will be closed
     // (Connection: close, Trailer, or HTTP/1.0 implicit close) and the response


### PR DESCRIPTION
> Fix swapped sscanf arguments in Content-Range parsing (#1262)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.