### PR TITLE
[Backport][main to 0.9] | Fix fd leak in accept() when setsockopt fails (#1248) 

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -359,6 +359,7 @@ public:
             return nullptr;
         }
         if (m_opts.setsockopt(cfd) != 0) {
+            ::close(cfd);
             return nullptr;
         }
         return create_stream(cfd);


### PR DESCRIPTION
> Fix fd leak in accept() when setsockopt fails (#1248)

When KernelSocketServer::accept() successfully accepts a connection
but setsockopt() subsequently fails, the accepted fd was leaked.
Added ::close(cfd) on the error path.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.