### PR TITLE
[Backport][main to 0.9] | Fix critical bugs in work-stealing and thread-pool (#1246) 

### DIFF
--- a/thread/thread-pool.cpp
+++ b/thread/thread-pool.cpp
@@ -27,7 +27,7 @@ namespace photon
     }
 
     void set_bypass_threadpool(bool flag) {
-        __bypass_threadpool = true;
+        __bypass_threadpool = flag;
     }
 
     TPControl* ThreadPoolBase::thread_create_ex(thread_entry start, void* arg, bool joinable)

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1993,7 +1993,7 @@ insert_list:
         auto u = vcpu->next;
         while (u != vcpu) {
             if (0 == (u->flags & VCPU_ENABLE_PASSIVE_WORK_STEALING)) {
-                SCOPED_LOCK(vcpu_t::vcpu_list_lock);
+                SCOPED_LOCK(vcpu_list_lock);
                 u = u->next();
                 continue;
             }

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1994,7 +1994,7 @@ insert_list:
         while (u != vcpu) {
             if (0 == (u->flags & VCPU_ENABLE_PASSIVE_WORK_STEALING)) {
                 SCOPED_LOCK(vcpu_list_lock);
-                u = u->next();
+                u = u->next;
                 continue;
             }
             thread* th;

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1975,7 +1975,7 @@ insert_list:
             th->vcpu->nthreads--;
             th->vcpu = v;
             v->nthreads++;
-        } while (q.front()->allow_work_stealing());
+        } while (!q.empty() && q.front()->allow_work_stealing());
         return stolen.eject_whole();
     }
     inline __attribute__((always_inline))
@@ -1992,8 +1992,11 @@ insert_list:
         scoped_rwlock _(vcpu_list_rwlock, RLOCK);
         auto u = vcpu->next;
         while (u != vcpu) {
-            if (0 == (u->flags & VCPU_ENABLE_PASSIVE_WORK_STEALING))
+            if (0 == (u->flags & VCPU_ENABLE_PASSIVE_WORK_STEALING)) {
+                SCOPED_LOCK(vcpu_t::vcpu_list_lock);
+                u = u->next();
                 continue;
+            }
             thread* th;
             if ((th = ws_scan_standbyq(vcpu, u)) || (th = ws_scan_runq(vcpu, u))) {
                 vcpu->idle_worker->insert_list_tail(th);


### PR DESCRIPTION
> Fix critical bugs in work-stealing and thread-pool (#1246)

1. Fix infinite loop in try_work_stealing(): the `continue` on the
   passive-work-stealing check skipped iterator advancement, causing
   the idle worker to spin forever when encountering a vCPU without
   VCPU_ENABLE_PASSIVE_WORK_STEALING.

2. Fix null pointer dereference in ws_scan_standbyq(): the do-while
   condition called q.front()->allow_work_stealing() without checking
   q.empty() first, crashing when all stealable threads were popped.

3. Fix set_bypass_threadpool() ignoring its parameter: the function
   always set __bypass_threadpool = true regardless of the flag argument.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.