### PR TITLE
[Backport][main to 0.9] | Fix macOS sendfile source/dest argument order (#1306) 

### DIFF
--- a/net/basic_socket.cpp
+++ b/net/basic_socket.cpp
@@ -146,7 +146,7 @@ ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count,
                  Timeout timeout) {
 #ifdef __APPLE__
     off_t len = count;
-    ssize_t ret = DOIO_ONCE(::sendfile(out_fd, in_fd, *offset, &len, nullptr, 0),
+    ssize_t ret = DOIO_ONCE(::sendfile(in_fd, out_fd, *offset, &len, nullptr, 0),
                   wait_for_fd_writable(out_fd, timeout));
     return (ret == 0) ? len : (int)ret;
 #else


### PR DESCRIPTION
> Fix macOS sendfile source/dest argument order (#1306)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.