### PR TITLE
[Backport][main to 0.9] | Fix WorkPool get_vcpu_in_pool data race on vcpus vector (#1299) 

### DIFF
--- a/thread/workerpool.cpp
+++ b/thread/workerpool.cpp
@@ -144,6 +144,7 @@ public:
     }
 
     photon::vcpu_base *get_vcpu_in_pool(size_t index) {
+        SCOPED_LOCK(worker_lock);
         auto size = vcpus.size();
         if (index >= size) {
             index = vcpu_index++ % size;


### PR DESCRIPTION
> Fix WorkPool get_vcpu_in_pool data race on vcpus vector (#1299)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.