### PR TITLE
[Backport][main to 0.9] | Fix terminate() thread join and skip_read static buffer race (#1287) 

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -300,11 +300,9 @@ public:
         if (!workth) return;
         auto th = workth;
         workth = nullptr;
-        if (waiting) {
-            thread_interrupt(th);
-            if (!m_block_serv)
-                thread_join((join_handle*)th);
-        }
+        thread_interrupt(th);
+        if (!m_block_serv)
+            thread_join((join_handle*)th);
     }
 
     ISocketServer* set_handler(Handler handler) override {


### PR DESCRIPTION
> Fix terminate() thread join and skip_read static buffer race (#1287)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.