### PR TITLE
[Pick][0.9 to main] | [Pick][0.8 to 0.9] | FIX: RingChannel signals and close send/recv notify race (#1239)  (#1274) 

### DIFF
--- a/common/executor/executor.h
+++ b/common/executor/executor.h
@@ -36,7 +36,7 @@ public:
     Executor(int init_ev = photon::INIT_EVENT_DEFAULT,
              int init_io = photon::INIT_IO_DEFAULT,
              const PhotonOptions& options = {},
-             const ExecutorQueueOption& queue_options = {-1UL, 1024});
+             const ExecutorQueueOption& queue_options = {1024, 1024});
     ~Executor();
 
     template <

--- a/common/executor/test/CMakeLists.txt
+++ b/common/executor/test/CMakeLists.txt
@@ -22,3 +22,7 @@ add_executable(test-executor-std test_std.cpp)
 target_link_libraries(test-executor-std PRIVATE photon_shared ${GOOGLETEST_GTEST_MAIN_LIBRARIES})
 add_test(NAME test-executor-std COMMAND $<TARGET_FILE:test-executor-std>)
 
+add_executable(test-executor-burst-drain test_burst_drain.cpp)
+target_link_libraries(test-executor-burst-drain PRIVATE photon_shared ${GOOGLETEST_GTEST_MAIN_LIBRARIES})
+add_test(NAME test-executor-burst-drain COMMAND $<TARGET_FILE:test-executor-burst-drain>)
+

--- a/common/executor/test/test_burst_drain.cpp
+++ b/common/executor/test/test_burst_drain.cpp
@@ -1,0 +1,110 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <photon/common/alog.h>
+#include <photon/common/lockfree_queue.h>
+#include <photon/photon.h>
+#include <photon/thread/thread.h>
+
+#include "../../../test/gtest.h"
+
+// Regression test for the RingChannel notification refactor.
+//
+// Failure mode being guarded:
+//   When N producers fire a burst, the previous design issued one
+//   `queue_sem.signal(1)` per push every time the consumer happened to be in
+//   its `idler` window. The semaphore counter accumulated linearly with the
+//   burst size, so after the burst the consumer would loop forever between
+//   1ms busy-yield and a `wait()` that returned immediately, burning a full
+//   core for as long as the accumulated counter took to drain.
+//
+// Verification strategy (deterministic, no wall-clock assumptions):
+//   - Drive a real `RingChannel` directly, with `kProducers` std::thread
+//     producers and a single std::thread consumer that owns its own photon
+//     vCPU.
+//   - Synchronize using a producer-side `received` counter and a sentinel
+//     value to terminate the consumer. All "wait" operations are
+//     event-driven (`std::thread::join`, atomic counter spin), never
+//     wall-clock sleeps.
+//   - After the consumer thread has fully joined, all RingChannel state is
+//     quiescent and visible to the test thread. Assert the *invariant*
+//     `notification_pending() <= idler_peak`. With a single consumer,
+//     `idler_peak == 1`, so `pending` must remain ≤1 regardless of burst
+//     size. Without the fix, `pending` (== `queue_sem.m_count`) would carry
+//     leftover tokens proportional to how often the consumer dipped into
+//     the idler window during the burst.
+TEST(ring_channel, burst_drain_no_signal_accumulation) {
+    using QT = LockfreeMPMCRingQueue<int, 4096>;
+    photon::common::RingChannel<QT> ch(1024, 1024);
+
+    constexpr int kProducers = 4;
+    constexpr int kPerProducer = 25000;
+    constexpr int kBurst = kProducers * kPerProducer;
+    constexpr int kSentinel = 0;  // sentinel value to terminate consumer
+
+    std::atomic<int> received{0};
+
+    // Consumer owns its own photon vCPU, so it can be scheduled
+    // independently of the producers and of this test thread.
+    std::thread consumer([&] {
+        photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+        DEFER(photon::fini());
+        for (;;) {
+            int x = ch.recv();
+            if (x == kSentinel) break;
+            received.fetch_add(1, std::memory_order_acq_rel);
+        }
+    });
+
+    std::vector<std::thread> producers;
+    producers.reserve(kProducers);
+    for (int p = 0; p < kProducers; ++p) {
+        producers.emplace_back([&] {
+            for (int i = 0; i < kPerProducer; ++i) {
+                // Producers are plain std::threads; ThreadPause yields the
+                // OS thread on the (extremely unlikely) full-queue spin.
+                ch.template send<ThreadPause>(/*non-zero*/ 1);
+            }
+        });
+    }
+    for (auto& t : producers) t.join();
+
+    // Deterministic synchronization point: spin until the consumer has
+    // drained exactly the burst. No wall-clock sleeps.
+    while (received.load(std::memory_order_acquire) < kBurst) {
+        std::this_thread::yield();
+    }
+
+    // Terminate consumer cleanly, then join. After join() returns, no other
+    // thread can touch `ch`, so we can sample its state safely.
+    ch.template send<ThreadPause>(kSentinel);
+    consumer.join();
+
+    auto pending = ch.notification_pending();
+    LOG_INFO("after burst: received=`, notification_pending=`",
+             received.load(), pending);
+
+    // Strong invariant under the fix: in-flight wake-up tokens are capped
+    // by the historical peak of `idler`. With a single consumer that peak
+    // is 1, so `pending` must remain ≤1 regardless of burst size. Without
+    // the fix `pending` would scale with kBurst.
+    EXPECT_LE(pending, 1u);
+    EXPECT_EQ(kBurst, received.load());
+}

--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -602,11 +602,18 @@ namespace common {
 /**
  * @brief RingChannel is a photon wrapper to make LockfreeQueue send/recv
  * efficiently wait and spin using photon style sync mechanism.
- * In order.
- * In considering of performance, RingChannel will use semaphore to hang-up
- * photon thread when queue is empty, and once it got object by recv, it will
- * trying using `thread_yield` instead of semaphore, to get better performance
- * and load balancing.
+ *
+ * Notification model (multi-producer, multi-consumer safe):
+ *   - Each consumer entering the slow path bumps `idler`.
+ *   - Each producer, after `push`, may issue at most one `signal(1)` per push,
+ *     and only when `pending < idler`. `pending` mirrors the in-flight
+ *     `queue_sem.m_count`, so the semaphore counter is hard-capped by the
+ *     observed number of idle consumers, never accumulating with burst size.
+ *   - A `seq_cst` fence in send() and a `seq_cst` RMW on `idler` in recv()
+ *     close the Dekker-style window: at any time at least one of
+ *     (consumer sees the push) or (producer signals) must hold, so the queue
+ *     can never end up non-empty while every consumer sleeps.
+ *
  * Watch out that `recv` should run in photon environment (because it has to)
  * use photon semaphore to be notified that new item has sended. `send` could
  * running in photon or std::thread environment (needs to set template `Pause`
@@ -619,9 +626,10 @@ namespace common {
 template <typename QueueType>
 class RingChannel : public QueueType {
 protected:
-    photon::semaphore queue_sem;
-    std::atomic<uint64_t> idler{0};
-    uint64_t default_yield_turn = -1UL;
+    photon::semaphore     queue_sem;
+    std::atomic<uint64_t> idler{0};    // # consumers in idle/wait
+    std::atomic<uint64_t> pending{0};  // mirror of queue_sem.m_count
+    uint64_t default_yield_turn = 1024;
     uint64_t default_yield_usec = 1024;
 
     using T = decltype(std::declval<QueueType>().recv());
@@ -644,16 +652,43 @@ public:
         while (!push(x)) {
             Pause::pause();
         }
-        // meke sure that idler load happends after push work done.
-        if (idler.load(std::memory_order_seq_cst)) queue_sem.signal(1);
+        // Dekker barrier: ensure the prior push (mark.store release) is
+        // ordered before the following idler load, paired with the seq_cst
+        // RMW on `idler` in recv(). This guarantees that we cannot
+        // simultaneously miss the consumer's idler++ AND have the consumer
+        // miss our push.
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        auto cur_idler = idler.load(std::memory_order_seq_cst);
+        if (cur_idler == 0) return;
+
+        // Cap pending (== m_count) at cur_idler so a long burst can never
+        // accumulate stale wake-up tokens. Multiple producers may each succeed
+        // up to the observed idler count, preserving fan-out for N consumers.
+        auto p = pending.load(std::memory_order_acquire);
+        for (;;) {
+            if (p >= cur_idler) {
+                auto fresh = idler.load(std::memory_order_relaxed);
+                if (fresh <= cur_idler) return;
+                cur_idler = fresh;
+                continue;
+            }
+            if (pending.compare_exchange_weak(p, p + 1,
+                    std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+                queue_sem.signal(1);
+                return;
+            }
+            // CAS failed: `p` was refreshed automatically; retry.
+        }
     }
     T recv(uint64_t max_yield_turn, uint64_t max_yield_usec) {
         T x;
         if (pop(x)) return x;
-        // yield once if failed, so photon::now will be update
+        // yield once if failed, so photon::now will be updated
         photon::thread_yield();
-        idler.fetch_add(1, std::memory_order_acq_rel);
-        DEFER(idler.fetch_sub(1, std::memory_order_acq_rel));
+        // seq_cst on idler is the other half of the Dekker barrier (see send).
+        idler.fetch_add(1, std::memory_order_seq_cst);
+        DEFER(idler.fetch_sub(1, std::memory_order_seq_cst));
         Timeout yield_timeout(max_yield_usec);
         uint64_t yield_turn = max_yield_turn;
         while (!pop(x)) {
@@ -662,7 +697,12 @@ public:
                 photon::thread_yield();
             } else {
                 // wait for 100ms
-                queue_sem.wait(1, 100UL * 1000);
+                int r = queue_sem.wait(1, 100UL * 1000);
+                // r == 0 means we actually consumed one m_count token; mirror
+                // it on `pending`. r < 0 (timeout/interrupt) does not touch
+                // m_count, so we must not touch `pending` either.
+                if (r == 0)
+                    pending.fetch_sub(1, std::memory_order_acq_rel);
                 // reset yield mark and set into busy wait
                 yield_turn = max_yield_turn;
                 yield_timeout.timeout(max_yield_usec);
@@ -671,6 +711,13 @@ public:
         return x;
     }
     T recv() { return recv(default_yield_turn, default_yield_usec); }
+
+    // Diagnostic accessor: returns the current count of in-flight wake-up
+    // tokens (mirrors `queue_sem.m_count`). Tests use this to assert that no
+    // stale signals accumulate across a producer burst.
+    uint64_t notification_pending() const {
+        return pending.load(std::memory_order_acquire);
+    }
 };
 
 }  // namespace common

--- a/fs/path.h
+++ b/fs/path.h
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #pragma once
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <stack>

--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -54,6 +54,10 @@ add_executable(test-go-channel test-go-channel.cpp)
 target_link_libraries(test-go-channel PRIVATE photon_shared)
 add_test(NAME test-go-channel COMMAND $<TARGET_FILE:test-go-channel>)
 
+add_executable(test-workpool-fanout test-workpool-fanout.cpp)
+target_link_libraries(test-workpool-fanout PRIVATE photon_shared ${GOOGLETEST_GTEST_MAIN_LIBRARIES})
+add_test(NAME test-workpool-fanout COMMAND $<TARGET_FILE:test-workpool-fanout>)
+
 add_executable(test-sleepq-stale-idx test-sleepq-stale-idx.cpp)
 target_link_libraries(test-sleepq-stale-idx PRIVATE photon_shared)
 add_test(NAME test-sleepq-stale-idx COMMAND $<TARGET_FILE:test-sleepq-stale-idx>)

--- a/thread/test/test-workpool-fanout.cpp
+++ b/thread/test/test-workpool-fanout.cpp
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <atomic>
+
+#include <photon/common/alog.h>
+#include <photon/photon.h>
+#include <photon/thread/thread.h>
+#include <photon/thread/workerpool.h>
+
+#include "../../test/gtest.h"
+
+// Regression test for the RingChannel notification refactor's multi-consumer
+// behavior: when N idle workers share a RingChannel, a burst of N tasks must
+// fan out to all of them concurrently. A binary (single-token) notification
+// scheme would serialize the burst onto a single worker.
+//
+// Verification strategy (deterministic, no wall-clock assumptions):
+//   - Each task signals an `arrived` photon::semaphore on entry and then
+//     blocks on `release` until the harness allows it to finish.
+//   - The harness calls `arrived.wait(N, deadline_us)`. If fan-out works,
+//     all N tasks reach the wait point; if the notification path serializes,
+//     only one worker can run at a time (the others are stuck holding their
+//     vCPU on `release.wait`), so `arrived` will never reach N and the wait
+//     will return non-zero on timeout. The deadline is generous (5s) to
+//     tolerate CI noise without weakening the assertion.
+TEST(workpool, fanout_wakeup) {
+    // WorkPool::async_call uses PhotonPause and signals a photon::semaphore;
+    // the caller side must already be a photon vcpu.
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+    DEFER(photon::fini());
+
+    constexpr int N = 4;
+    photon::WorkPool pool(N, photon::INIT_EVENT_DEFAULT,
+                          photon::INIT_IO_NONE, -1);
+
+    photon::semaphore arrived(0);
+    photon::semaphore release(0);
+    std::atomic<int> done{0};
+
+    for (int i = 0; i < N; ++i) {
+        pool.async_call(new auto([&] {
+            // Mark this worker as woken-and-running. Hold the vCPU until the
+            // harness lets every other worker also reach this point.
+            arrived.signal(1);
+            release.wait(1);
+            done.fetch_add(1, std::memory_order_release);
+        }));
+    }
+
+    // Deterministic fan-out check. With the fix, all N tasks must reach
+    // `arrived.signal(1)` concurrently. Without it, only one worker would
+    // ever be released by the channel, so `arrived` saturates at 1 and the
+    // wait times out.
+    int r = arrived.wait(N, /*timeout_us=*/5UL * 1000 * 1000);
+    EXPECT_EQ(0, r);
+    LOG_INFO("fan-out check: arrived.wait(`) returned ` (vcpu_num=`)",
+             N, r, N);
+
+    // Release everyone so the WorkPool can be cleanly destroyed.
+    release.signal(N);
+    while (done.load(std::memory_order_acquire) < N) {
+        photon::thread_yield();
+    }
+}


### PR DESCRIPTION
> [Pick][0.8 to 0.9] | FIX: RingChannel signals and close send/recv notify race (#1239)  (#1274)

* FIX: RingChannel signals and close send/recv notify race (#1239)

* FIX: RingChannel queue_sem may got too many signals leads to high CPU consuming

* more tests

* fix conflict

---------

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits