### PR TITLE
[Backport][main to 0.9] | [Pick][0.9 to main] | feat(cache): probe fiemap support and track ranges as fallback (#1230)  (#1275) 

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -10,7 +10,11 @@ jobs:
 
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
+<<<<<<< HEAD
       options: --cpus 4 --shm-size 512m
+=======
+      options: --cpus 4 --shm-size 512m --privileged
+>>>>>>> 5fe2fd5 ([Pick][0.9 to main] | feat(cache): probe fiemap support and track ranges as fallback (#1230)  (#1275))
 
     steps:
       - uses: szenius/set-timezone@v2.0

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -25,6 +25,10 @@ limitations under the License.
 
 #include <cstring>
 #include <algorithm>
+<<<<<<< HEAD
+=======
+#include <set>
+>>>>>>> 5fe2fd5 ([Pick][0.9 to main] | feat(cache): probe fiemap support and track ranges as fallback (#1230)  (#1275))
 #include <random>
 #include <vector>
 


### PR DESCRIPTION
> [Pick][0.9 to main] | feat(cache): probe fiemap support and track ranges as fallback (#1230)  (#1275)

* feat(cache): probe fiemap support and track ranges as fallback (#1230)

* feat(cache): probe fiemap support at pool init and track ranges as fallback

* add lock && fix test

* fix fiemap probe

* fix

* fix query refill range && fix test

* optimize

* fix build

* fix conflict

---------

Co-authored-by: Xiaoyang Lu <luxiaoyang.lxy@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.