### PR TITLE
[Backport][0.9 to 0.8] | feat(oss): support custom headers on all OSS SDK requests (#1312) (#1347) 

### DIFF
--- a/ecosystem/oss.cpp
+++ b/ecosystem/oss.cpp
@@ -1,0 +1,1814 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "oss.h"
+
+#include <netinet/in.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/common/alog.h>
+#include <photon/common/checksum/digest.h>
+#include <photon/common/estring.h>
+#include <photon/common/expirecontainer.h>
+#include <photon/common/iovector.h>
+#include <photon/ecosystem/simple_dom.h>
+#include <photon/net/http/client.h>
+#include <photon/net/http/url.h>
+#include <photon/net/utils.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+
+namespace photon {
+namespace objstore {
+
+// unused constants will trigger compile error in photon,
+// unless they are defined in a header file
+#include "oss_constants.h"
+
+using Verb = net::http::Verb;
+using HTTP_STACK_OP =
+    photon::net::http::Client::OperationOnStack<16 * 1024 - 1>;
+using photon::net::http::verbstr;
+
+#define make_ccl estring::make_conditional_cat_list
+#define DEFINE_ONSTACK_OP(client, verb, url)          \
+  int _CONCAT(__eno__, __LINE__) = 0;                 \
+  DEFER(errno = _CONCAT(__eno__, __LINE__));          \
+  HTTP_STACK_OP op(client, verb, (url));              \
+  op.retry = 0;                                       \
+  auto _CONCAT(_CONCAT(__defer__, __LINE__), __1__) = \
+      make_defer([&]() __INLINE__ { _CONCAT(__eno__, __LINE__) = errno; });
+
+static SimpleDOM::Node get_xml_node(HTTP_STACK_OP& op) {
+  auto length = op.resp.headers.content_length();
+  if (length > XML_LIMIT || length == 0)
+    LOG_ERROR_RETURN(EINVAL, {}, "xml length invalid `", length);
+  auto body_buf = (char*)malloc(length + 1);
+  auto rc = op.resp.read(body_buf, length);
+  body_buf[length] = '\0';
+  if (rc != (ssize_t)length) {
+    free(body_buf);
+    LOG_ERROR_RETURN(0, {}, "body read error ` `", rc, length);
+  }
+
+  auto doc = SimpleDOM::parse(body_buf, length,
+                              SimpleDOM::DOC_XML | SimpleDOM::DOC_OWN_TEXT);
+  if (!doc) LOG_ERROR_RETURN(0, {}, "failed to parse resp_body");
+  return doc;
+}
+
+// convert oss last modified time, e.g. "Fri, 04 Mar 2022 02:46:25 GMT"
+static time_t get_lastmodified(std::string_view sv) {
+  if (sv.size() != 29) {
+    LOG_ERROR_RETURN(0, 0, "invalid lastmodified time: ", sv);
+  }
+  struct tm tm{};
+  if (!strptime(sv.data(), "%a, %d %b %Y %H:%M:%S GMT", &tm)) {
+    LOG_ERROR_RETURN(0, 0, "invalid lastmodified time: ", sv);
+  }
+  return timegm(&tm);  // GMT
+}
+
+// convert oss last modified time in listobjects, e.g.
+// "2023-10-12T02:03:53.000Z"
+static time_t get_list_lastmodified(std::string_view sv) {
+  if (sv.size() != 24) {
+    LOG_ERROR_RETURN(0, 0, "invalid lastmodified time: ", sv);
+  }
+  struct tm tm{};
+  if (!strptime(sv.data(), "%Y-%m-%dT%H:%M:%S.000Z", &tm)) {
+    LOG_ERROR_RETURN(0, 0, "invalid lastmodified time: ", sv);
+  }
+  return timegm(&tm);  // GMT
+}
+
+std::string_view lookup_mime_type(std::string_view name) {
+  auto last_pos = name.find_last_of('.');
+  if (last_pos != std::string_view::npos) name = name.substr(last_pos + 1);
+
+  // extract the last extension
+  const size_t MAX_EXT_LENGTH = 8;
+  if (name.size() > MAX_EXT_LENGTH) name = name.substr(0, MAX_EXT_LENGTH);
+  char ext[MAX_EXT_LENGTH + 1] = {};
+  std::transform(name.begin(), name.end(), ext, ::tolower);
+  return MIME_TYPE_MAP[ext];
+}
+
+class OssUrl {
+ public:
+  estring m_url, m_raw_object;
+  uint64_t m_url_size;
+  rstring_view16 m_bucket, m_object;
+  OssUrl() = default;
+  OssUrl(std::string_view endpoint, std::string_view bucket,
+         std::string_view object, bool is_http) {
+    assert(!bucket.empty());
+    init(endpoint, bucket, object, is_http);
+  }
+  void init(std::string_view endpoint, std::string_view bucket,
+            std::string_view object, bool is_http) {
+    bool has_slash = (object.size() > 0 && object[0] == '/');
+    if (has_slash) object = object.substr(1);
+
+    auto escaped_obj = photon::net::http::url_escape(object);
+    m_url.appends(photon::net::http::http_or_s(is_http), bucket, ".", endpoint,
+                  "/", escaped_obj);
+
+    auto escaped = escaped_obj.size() > object.size();
+    if (escaped) m_raw_object = object;
+
+    m_url_size = m_url.size();
+    m_bucket = {(is_http ? 7ul : 8ul), bucket.size()};
+    m_object = {m_bucket.offset() + bucket.size() + endpoint.size() + 1 + 1,
+                escaped_obj.size()};  // start without prefix /
+  }
+  estring_view bucket() const { return m_url | m_bucket; }
+  estring_view object(bool url_escaped = false) const {
+    if (url_escaped || m_raw_object.empty()) {
+      return m_url | m_object;
+    }
+    return m_raw_object;
+  }
+
+  estring_view append_params(const StringKV& params) {
+    if (!params.empty()) {
+      auto it = params.begin();
+      m_url.appends("?", it->first,
+                    make_ccl(!it->second.empty(), "=", it->second));
+      while (++it != params.end()) {
+        m_url.appends("&", it->first,
+                      make_ccl(!it->second.empty(), "=", it->second));
+      }
+    }
+    return m_url;
+  }
+
+  estring_view url() { return m_url; }
+};
+
+template <typename T>
+struct NodeValue {
+  explicit NodeValue(SimpleDOM::Node node) : node_(node) {}
+  operator T() const { return convert_node_value(); }
+  bool has_value() const { return node_; }
+
+ private:
+  T convert_node_value() const {
+    return convert_impl(static_cast<T*>(nullptr));
+  }
+  estring_view convert_impl(estring_view*) const {
+    return node_.to_string_view();
+  }
+  int64_t convert_impl(int64_t*) const { return node_.to_int64_t(); }
+  SimpleDOM::Node node_;
+};
+using NodeStrValue = NodeValue<estring_view>;
+using NodeInt64Value = NodeValue<int64_t>;
+
+// Should be called only when status code is in error state.
+// Normally with 4xx or 5xx.
+static int error_http_status_to_errno(int status_code) {
+  switch (status_code) {
+    case 400:
+      return EINVAL;
+    case 401:
+    case 403:
+      return EACCES;
+    case 404:
+      return ENOENT;
+    case 409:
+      return ENOTSUP;
+    case 416:
+      return EINVAL;
+  }
+  return EIO;
+}
+
+static int do_http_call(HTTP_STACK_OP& op, const ClientOptions& options,
+                        std::string_view object) {
+  int ret = -1;
+  auto retry_times = options.retry_times;
+  auto retry_interval = options.retry_base_interval_us;
+
+  uint64_t qps_limit_retry_interval = 1000'000;
+  auto qps_limit_total_retry_time =
+      std::max(options.request_timeout_us, qps_limit_retry_interval);
+
+__retry:
+  int __saved_errno = errno;
+  {
+    int r = 0;
+    auto start_time = std::chrono::steady_clock::now();
+    LOG_DEBUG("Sending oss request ` ` Range[`]", verbstr[op.req.verb()],
+              op.req.target(), op.req.headers["Range"]);
+    if (r == 0) {
+      r = op.call();
+      __saved_errno = errno;
+    }
+    auto latency = std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::steady_clock::now() - start_time)
+                       .count();
+    LOG_DEBUG(
+        "Got oss response ` ` Range[`], code=` content_length=` latency_us=`",
+        verbstr[op.req.verb()], op.req.target(), op.req.headers["Range"],
+        op.resp.status_code(), op.resp.headers.content_length(), latency);
+    if (r < 0) {
+      if (retry_times-- > 0) {
+        photon::thread_usleep(retry_interval);
+        retry_interval *= 2;
+        LOG_ERROR("Retrying oss request ` `", verbstr[op.req.verb()],
+                  op.req.target());
+        goto __retry;
+      }
+    }
+  }
+
+  if (op.status_code != 200 && op.status_code != 206 && op.status_code != 204) {
+    if (op.status_code != -1 && op.status_code != 404) {
+      auto reader = get_xml_node(op);
+      auto error_res = reader["Error"];
+      std::string_view code_view = error_res["Code"].to_string_view();
+      // clang-format off
+      LOG_ERROR(
+          "Operation on [`] failed! RequestId[`], OSSError: Code[`], Message[`], EC[`]",
+          object, op.resp.headers["x-oss-request-id"], code_view,
+          error_res["Message"].to_string_view(),
+          error_res["EC"].to_string_view());
+      // clang-format on
+
+      if (code_view.find("QpsLimitExceeded") != std::string::npos) {
+        if (qps_limit_retry_interval > 0) {
+          photon::thread_usleep(qps_limit_retry_interval);
+          qps_limit_total_retry_time -= qps_limit_retry_interval;
+          qps_limit_retry_interval = std::min(qps_limit_retry_interval * 2,
+                                              qps_limit_total_retry_time);
+          LOG_ERROR("Retrying oss request ` `, ` us more to retry",
+                    verbstr[op.req.verb()], op.req.target(),
+                    qps_limit_total_retry_time);
+          goto __retry;
+        }
+        retry_times = 0;  // no more tryings in qps limit case
+      }
+    }
+
+    if (op.status_code / 100 == 5) {
+      if (retry_times-- > 0) {
+        photon::thread_usleep(retry_interval);
+        retry_interval *= 2;
+        LOG_ERROR("Retrying oss request ` `", verbstr[op.req.verb()],
+                  op.req.target());
+        goto __retry;
+      }
+    }
+    if (op.status_code == -1) {
+        LOG_ERROR("operation on [`] failed!, http connection error `", 
+                  object, ERRNO(__saved_errno));
+        errno = __saved_errno;
+        if (errno != ETIMEDOUT) errno = EIO;
+        return ret;
+    }
+    if (op.status_code / 100 == 4) {
+      errno = error_http_status_to_errno(op.status_code);
+    }
+    return ret;
+  }
+  return 0;
+}
+
+static int verify_crc64_if_needed(HTTP_STACK_OP& op, std::string_view object,
+                                  const uint64_t* expected_crc64) {
+  if (!expected_crc64) return 0;
+  auto it = op.resp.headers.find("x-oss-hash-crc64ecma");
+  if (it == op.resp.headers.end()) {
+    LOG_WARN("crc64 not found in object ", object);
+    return 0;
+  }
+  uint64_t crc64;
+  if (!estring_view(it.second()).to_uint64_check(&crc64) ||
+      *expected_crc64 != crc64) {
+    LOG_ERROR_RETURN(EIO, -1,
+                     "crc64 mismatch of object: `, expected: `, actual: `",
+                     object, *expected_crc64, it.second());
+  }
+  return 0;
+}
+
+static ssize_t body_writer_cb(void* iov_view, photon::net::http::Request* req) {
+  auto view = static_cast<iovector_view*>(iov_view);
+  auto ret = req->writev(view->iov, view->iovcnt);
+  if (ret != static_cast<ssize_t>(view->sum())) {
+    LOG_ERROR_RETURN(0, -1, "stream writev failed!", VALUE(ret), VALUE(errno));
+  }
+  return 0;
+}
+
+static std::string md5_base64(iovector_view view) {
+  std::string ret;
+  unsigned char hash[MD5_DIGEST_LENGTH];
+  md5 md5sum;
+  for (const auto& iov : view) {
+    md5sum.update(iov.iov_base, iov.iov_len);
+  }
+  md5sum.finalize(hash);
+  photon::net::Base64Encode({(char*)hash, MD5_DIGEST_LENGTH}, ret);
+  return ret;
+}
+
+class OssClientImpl : public Client {
+ public:
+  OssClientImpl(const ClientOptions& options, Authenticator* authenticator);
+  ~OssClientImpl();
+
+  int list_objects(std::string_view prefix, ListObjectsCallback cb,
+                   ListObjectsParameters = {}, std::string* marker = nullptr);
+
+  int head_object(std::string_view object, ObjectHeaderMeta& meta);
+
+  int fill_meta(HTTP_STACK_OP& op, ObjectMeta& meta);
+  int fill_meta(HTTP_STACK_OP& op, ObjectHeaderMeta& meta);
+  int fill_upload_response(HTTP_STACK_OP& op, ObjectUploadOptions& opts);
+
+  ssize_t get_object_range(std::string_view object, const struct iovec* iov,
+                           int iovcnt, off_t offset,
+                           ObjectHeaderMeta* meta = nullptr);
+
+  int batch_get_objects(std::vector<GetObjectParameters>& params);
+
+  ssize_t put_object(std::string_view object, const struct iovec* iov,
+                     int iovcnt, ObjectUploadOptions& opts);
+
+  ssize_t append_object(std::string_view object, const struct iovec* iov,
+                        int iovcnt, off_t position,
+                        ObjectUploadOptions& opts);
+
+  int copy_object(std::string_view src_object, std::string_view dst_object,
+                  bool overwrite = false, bool set_mime = false);
+
+  int init_multipart_upload(std::string_view object, void** context);
+
+  ssize_t upload_part(void* context, const struct iovec* iov, int iovcnt,
+                      int part_number, ObjectUploadOptions& opts);
+
+  int upload_part_copy(void* context, off_t offset, size_t count,
+                       int part_number, std::string_view from = {});
+
+  int complete_multipart_upload(void* context, ObjectUploadOptions& opts);
+
+  int abort_multipart_upload(void* context);
+
+  int delete_objects(const std::vector<std::string_view>& objects,
+                     std::string_view prefix = {});
+
+  int delete_object(std::string_view obj);
+
+  int rename_object(std::string_view src_path, std::string_view dst_path,
+                    bool set_mime = false);
+
+  int put_symlink(std::string_view obj, std::string_view target);
+
+  int get_symlink(std::string_view obj, std::string& target);
+
+  int get_object_meta(std::string_view obj, ObjectMeta& meta);
+
+  void set_credentials(CredentialParameters&& credentials);
+
+ private:
+  int append_auth_headers(photon::net::http::Verb v, const OssUrl& oss_url,
+                          photon::net::http::Headers& headers,
+                          const StringKV& query_params = {},
+                          bool invalidate_cache = false);
+  void inject_custom_headers(photon::net::http::Headers& headers);
+  int sign_and_call(HTTP_STACK_OP& op, photon::net::http::Verb verb,
+                    const OssUrl& oss_url, const StringKV& query_params = {},
+                    bool invalidate_cache = false);
+
+  int walk_list_results(const SimpleDOM::Node& node, ListObjectsCallback cb);
+  int do_list_objects_v2(std::string_view bucket, std::string_view prefix,
+                         ListObjectsCallback cb, bool delimiters, int maxKeys,
+                         std::string* marker, std::string_view start_after);
+  int do_list_objects_v1(std::string_view bucket, std::string_view prefix,
+                         ListObjectsCallback cb, bool delimiters, int maxKeys,
+                         std::string* marker);
+
+  int do_copy_object(OssUrl& src_oss_url, OssUrl& dst_oss_url, bool overwrite,
+                     bool set_mime);
+  int do_delete_object(OssUrl& oss_url);
+
+  int do_delete_objects(estring_view bucket, estring_view prefix,
+                        const std::vector<std::string_view>& objects,
+                        size_t start, size_t count);
+
+  std::string m_endpoint, m_bucket;
+  bool m_is_http = false;
+
+  ClientOptions m_oss_options;
+  photon::net::http::Client* m_client = nullptr;
+  Authenticator* m_authenticator = nullptr;
+};
+
+#define OssClient OssClientImpl
+
+OssClient::OssClient(const ClientOptions& options, Authenticator* authenticator)
+    : m_bucket(options.bucket),
+      m_oss_options(options),
+      m_authenticator(authenticator) {
+  estring_view esv(options.endpoint);
+  if (esv.starts_with("https://")) {
+    m_endpoint = options.endpoint.substr(8);
+    m_is_http = false;
+  } else if (esv.starts_with("http://")) {
+    m_endpoint = options.endpoint.substr(7);
+    m_is_http = true;
+  } else {
+    m_endpoint = options.endpoint;
+  }
+
+  m_client = photon::net::http::new_http_client();
+  m_client->timeout(m_oss_options.request_timeout_us);
+  m_client->set_user_agent(m_oss_options.user_agent);
+  if (!m_oss_options.proxy.empty()) m_client->set_proxy(m_oss_options.proxy);
+
+  auto& ch = m_oss_options.custom_headers;
+  for (auto it = ch.begin(); it != ch.end();) {
+    std::transform(it->first.begin(), it->first.end(), it->first.begin(), ::tolower);
+    // reserved for authenticator;
+    if (it->first == "authorization" || it->first == "date")
+      it = ch.erase(it);
+    else
+      ++it;
+  }
+
+  if (!options.bind_ips.empty()) {
+    std::vector<photon::net::IPAddr> ip_vec;
+    auto ips = estring_view(options.bind_ips).split(',');
+    for (const auto& ip : ips) {
+      photon::net::IPAddr addr(ip.to_string().c_str());
+      if (!addr.undefined()) {
+        ip_vec.push_back(addr);
+      } else {
+        LOG_WARN("invalid bind ip: `", ip);
+      }
+    }
+
+    if (!ip_vec.empty()) {
+      m_client->set_bind_ips(ip_vec);
+      LOG_INFO("Use customized bind_ips: `", options.bind_ips);
+    } else {
+      LOG_ERROR("Invalid bind_ips: `, fallback to default mode",
+                options.bind_ips);
+    }
+  }
+}
+
+OssClient::~OssClient() {
+  delete m_client;
+  delete m_authenticator;
+}
+
+#undef OssClient
+#define OssClient inline OssClientImpl
+
+int OssClient::append_auth_headers(photon::net::http::Verb v, const OssUrl& oss_url,
+                                   photon::net::http::Headers& headers,
+                                   const StringKV& query_params,
+                                   bool invalidate_cache) {
+  Authenticator::SignParameters params;
+  params.verb = v;
+  params.query_params = query_params;
+  params.region = m_oss_options.region;
+  params.endpoint = m_oss_options.endpoint;
+  params.bucket = m_oss_options.bucket;
+  params.object = oss_url.object();
+  params.invalidate_cache = invalidate_cache;
+
+  // inject custom headers before sign so x-oss-* headers participate in signing
+  inject_custom_headers(headers);
+  return m_authenticator->sign(headers, params);
+}
+
+void OssClient::inject_custom_headers(photon::net::http::Headers& headers) {
+  for (const auto& kv : m_oss_options.custom_headers) {
+    headers.insert(kv.first, kv.second);
+  }
+}
+
+int OssClient::sign_and_call(HTTP_STACK_OP& op, photon::net::http::Verb verb,
+                             const OssUrl& oss_url,
+                             const StringKV& query_params,
+                             bool invalidate_cache) {
+  int r = append_auth_headers(verb, oss_url, op.req.headers, query_params,
+                              invalidate_cache);
+  if (r < 0) return r;
+  return do_http_call(op, m_oss_options, oss_url.object());
+}
+
+int OssClient::walk_list_results(const SimpleDOM::Node& list_bucket_result,
+                                 ListObjectsCallback cb) {
+  for (auto child : list_bucket_result.enumerable_children("Contents")) {
+    auto key = NodeStrValue(child["Key"]);
+    auto size = NodeInt64Value(child["Size"]);
+    auto mtime = NodeStrValue(child["LastModified"]);
+    auto etag = NodeStrValue(child["ETag"]);
+    auto type = NodeStrValue(child["Type"]);
+
+    if (!key.has_value() || !size.has_value() || !mtime.has_value() ||
+        !etag.has_value() || !type.has_value())
+      LOG_ERROR_RETURN(EINVAL, -1,
+                       "unexpected response: missing required fields");
+
+    auto mtim = get_list_lastmodified(mtime);
+    auto r = cb({key, etag, type, static_cast<size_t>(size), mtim,
+                 false /*not comm prefix*/});
+    if (r < 0) return r;
+  }
+  for (auto child : list_bucket_result.enumerable_children("CommonPrefixes")) {
+    auto key = NodeStrValue(child["Prefix"]);
+    if (!key.has_value())
+      LOG_ERROR_RETURN(EINVAL, -1,
+                       "unexpected response: missing required fields");
+    auto r = cb({key, {}, {}, 0, 0, true /*comm prefix*/});
+    if (r < 0) return r;
+  }
+  return 0;
+}
+
+int OssClient::do_list_objects_v2(std::string_view bucket, std::string_view prefix,
+                                  ListObjectsCallback cb, bool delimiters, int maxKeys,
+                                  std::string* marker, std::string_view start_after) {
+  if (maxKeys > 1000 || maxKeys <= 0) maxKeys = m_oss_options.max_list_ret_cnt;
+  estring_view _mark;
+  if (marker) _mark = *marker;
+
+  estring escaped_prefix = photon::net::http::url_escape(prefix);
+  estring escaped_delimiter = photon::net::http::url_escape("/");
+  estring escaped_marker = photon::net::http::url_escape(_mark);
+  estring escaped_start_after = photon::net::http::url_escape(start_after);
+  estring max_key_str = std::to_string(maxKeys);
+  // must appear in dictionary order!
+  DEFINE_APPENDABLE_ORDERED_STRING_KV(
+      query_params, 2,
+      {
+          {OSS_PARAM_KEY_LIST_TYPE, "2"},
+          {OSS_PARAM_KEY_MAX_KEYS, max_key_str},
+          {OSS_PARAM_KEY_PREFIX, escaped_prefix},
+      });
+
+  if (delimiters)
+    query_params.insert({OSS_PARAM_KEY_DELIMITER, escaped_delimiter});
+  if (!_mark.empty())
+    query_params.insert({OSS_PARAM_KEY_CONTINUATION_TOKEN, escaped_marker});
+  if (!start_after.empty())
+    query_params.insert({OSS_PARAM_KEY_START_AFTER, escaped_start_after});
+  OssUrl oss_url(m_endpoint, bucket, {}, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::GET, oss_url.append_params(query_params));
+  int r = sign_and_call(op, Verb::GET, oss_url, query_params);
+  if (r < 0) return r;
+
+  auto reader = get_xml_node(op);
+  if (!reader) LOG_ERROR_RETURN(0, -1, "failed to parse xml resp_body");
+  auto list_bucket_result = reader["ListBucketResult"];
+  if (!list_bucket_result) LOG_ERROR_RETURN(EINVAL, -1, "unexpected empty response");
+  r = walk_list_results(list_bucket_result, cb);
+  if (r < 0) return r;
+  if (marker) {
+    auto next_marker = list_bucket_result["NextContinuationToken"];
+    *marker = next_marker ? next_marker.to_string_view() : "";
+  }
+  return 0;
+}
+
+int OssClient::do_list_objects_v1(std::string_view bucket,
+                                  std::string_view prefix,
+                                  ListObjectsCallback cb, bool delimiters,
+                                  int maxKeys, std::string* marker) {
+  if (maxKeys > 1000 || maxKeys <= 0) maxKeys = m_oss_options.max_list_ret_cnt;
+  estring_view _mark;
+  if (marker) _mark = *marker;
+
+  estring escaped_prefix = photon::net::http::url_escape(prefix);
+  estring escaped_delimiter = photon::net::http::url_escape("/");
+  estring escaped_marker = photon::net::http::url_escape(_mark);
+  estring max_key_str = std::to_string(maxKeys);
+  // must appear in dictionary order!
+  DEFINE_APPENDABLE_ORDERED_STRING_KV(
+      query_params, 2,
+      {
+          {OSS_PARAM_KEY_MAX_KEYS, max_key_str},
+          {OSS_PARAM_KEY_PREFIX, escaped_prefix},
+      });
+  if (delimiters)
+    query_params.insert({OSS_PARAM_KEY_DELIMITER, escaped_delimiter});
+  if (!_mark.empty())
+    query_params.insert({OSS_PARAM_KEY_MARKER, escaped_marker});
+
+  OssUrl oss_url(m_endpoint, bucket, {}, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::GET, oss_url.append_params(query_params));
+  int r = sign_and_call(op, Verb::GET, oss_url, query_params);
+  if (r < 0) return r;
+
+  auto reader = get_xml_node(op);
+  if (!reader) LOG_ERROR_RETURN(0, -1, "failed to parse xml resp_body");
+  auto list_bucket_result = reader["ListBucketResult"];
+  if (!list_bucket_result) LOG_ERROR_RETURN(EINVAL, -1, "unexpected empty response");
+  r = walk_list_results(list_bucket_result, cb);
+  if (r < 0) return r;
+  if (marker) {
+    auto next_marker = list_bucket_result["NextMarker"];
+    *marker = next_marker ? next_marker.to_string_view() : "";
+  }
+  return 0;
+}
+
+int OssClient::do_copy_object(OssUrl& src_oss_url, OssUrl& dst_oss_url,
+                              bool overwrite, bool set_mime) {
+  DEFINE_ONSTACK_OP(m_client, Verb::PUT, dst_oss_url.url());
+
+  estring oss_copy_source =
+      estring("/").appends(src_oss_url.bucket(), "/", src_oss_url.object(true));
+  op.req.headers.insert(OSS_HEADER_KEY_X_OSS_COPY_SOURCE, oss_copy_source);
+  if (!overwrite) {
+    op.req.headers.insert(OSS_HEADER_KEY_X_OSS_FORBID_OVERWRITE, "true");
+  }
+
+  std::string_view dst_type{};  // use the same content type as the source
+  if (set_mime) {
+    auto src_type = lookup_mime_type(src_oss_url.object());
+    auto new_dst_type = lookup_mime_type(dst_oss_url.object());
+    if (src_type != new_dst_type) dst_type = new_dst_type;
+    if (!dst_type.empty()) {
+      op.req.headers.insert(OSS_HEADER_KEY_X_OSS_METADATA_DIRECTIVE, "REPLACE");
+      op.req.headers.insert(OSS_HEADER_KEY_CONTENT_TYPE, dst_type);
+    }
+  }
+
+  return sign_and_call(op, Verb::PUT, dst_oss_url);
+}
+
+int OssClient::do_delete_object(OssUrl& oss_url) {
+  DEFINE_ONSTACK_OP(m_client, Verb::DELETE, oss_url.url());
+  return sign_and_call(op, Verb::DELETE, oss_url);
+}
+
+static std::string xml_escape(std::string_view object) {
+  static const std::unordered_map<char, std::string> xml_escape_map = {
+      {'&', "&amp;"},
+      {'<', "&lt;"},
+      {'>', "&gt;"},
+      {'"', "&quot;"},
+      {'\'', "&apos;"},
+      // refer to go sdk to handle belowing charactors in deleting multiple
+      // objects
+      {'\t', "&#x9;"},
+      {'\n', "&#xA;"},
+      {'\r', "&#xD;"},
+  };
+
+  std::string escaped_object;
+  escaped_object.reserve(object.size() * 2);
+  for (auto c : object) {
+    auto it = xml_escape_map.find(c);
+    if (it != xml_escape_map.end())
+      escaped_object += it->second;
+    else
+      escaped_object += c;
+  }
+  return escaped_object;
+}
+
+int OssClient::do_delete_objects(estring_view bucket, estring_view prefix,
+                                 const std::vector<std::string_view>& objects,
+                                 size_t start, size_t to_delete_size) {
+  std::string_view req_head = "<Delete><Quiet>false</Quiet>";
+  std::string_view req_tail = "</Delete>";
+  estring req_list;
+  for (size_t i = start; i < start + to_delete_size; ++i) {
+    req_list.appends("<Object><Key>", xml_escape(prefix),
+                     xml_escape(objects[i]), "</Key></Object>");
+  }
+
+  int retry_times = m_oss_options.retry_times;
+  auto retry_interval = m_oss_options.retry_base_interval_us;
+
+  struct iovec iov[3] = {{(void*)req_head.data(), req_head.size()},
+                         {(void*)req_list.data(), req_list.size()},
+                         {(void*)req_tail.data(), req_tail.size()}};
+  iovector_view body_view(iov, 3);
+  OssUrl oss_url(m_endpoint, bucket, "/", m_is_http);
+  auto md5 = md5_base64(body_view);
+
+  DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
+                                        {// must appear in dictionary order!
+                                         {OSS_PARAM_KEY_DELETE, ""}});
+
+  DEFINE_ONSTACK_OP(m_client, Verb::POST, oss_url.append_params(query_params));
+  op.req.headers.insert(OSS_HEADER_KEY_CONTENT_MD5, md5);
+  op.req.headers.content_length(body_view.sum());
+  op.body_writer = {&body_view, &body_writer_cb};
+  int r =
+      append_auth_headers(Verb::POST, oss_url, op.req.headers, query_params);
+  if (r < 0) return r;
+
+retry:
+  size_t deleted_size = 0;
+  r = do_http_call(op, m_oss_options, oss_url.object());
+  if (r < 0) return r;
+
+  auto reader = get_xml_node(op);
+  auto result = reader["DeleteResult"];
+  for (auto child : result.enumerable_children("Deleted")) {
+    auto key = child["Key"];
+    if (key) deleted_size++;
+  }
+
+  if (deleted_size != to_delete_size) {
+    // Partial deletion happens when OSS server side is with pressure.
+    // If this is the case , we just have another try. It's OK if some keys
+    // have been deleted by the server in last round as OSS will treat it as
+    // successful when deleting one non-existed key. And the returned deleted
+    // result will contain the non-existed key.
+    if (retry_times-- > 0) {
+      LOG_WARN("Partial deletion. To delete ` deleted `. Retrying...",
+               to_delete_size, deleted_size);
+      photon::thread_usleep(retry_interval);
+      goto retry;
+    }
+    LOG_ERROR_RETURN(EIO, -1, "Partial deletion");
+  }
+  return 0;
+}
+
+int OssClient::rename_object(std::string_view src_path,
+                             std::string_view dst_path, bool set_mime) {
+  OssUrl src_oss_url(m_endpoint, m_bucket, src_path, m_is_http);
+  OssUrl dst_oss_url(m_endpoint, m_bucket, dst_path, m_is_http);
+
+  if (do_copy_object(src_oss_url, dst_oss_url, true, set_mime) < 0) return -1;
+  return do_delete_object(src_oss_url);
+}
+
+int OssClient::put_symlink(std::string_view obj, std::string_view target) {
+  DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
+                                        {
+                                            {OSS_PARAM_KEY_SYMLINK, ""},
+                                        });
+  OssUrl oss_url(m_endpoint, m_bucket, obj, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.append_params(query_params));
+  auto escaped_tgt = photon::net::http::url_escape(target);
+  op.req.headers.insert(OSS_HEADER_KEY_X_OSS_SYMLINK_TARGET, escaped_tgt);
+  return sign_and_call(op, Verb::PUT, oss_url, query_params);
+}
+
+int OssClient::get_symlink(std::string_view obj, std::string& target) {
+  DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
+                                        {
+                                            {OSS_PARAM_KEY_SYMLINK, ""},
+                                        });
+  OssUrl oss_url(m_endpoint, m_bucket, obj, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::GET, oss_url.append_params(query_params));
+  int r = sign_and_call(op, Verb::GET, oss_url, query_params);
+  if (r < 0) return r;
+  target = photon::net::http::url_unescape(
+      op.resp.headers[OSS_HEADER_KEY_X_OSS_SYMLINK_TARGET]);
+  return r;
+}
+
+int OssClient::delete_objects(const std::vector<std::string_view>& objects,
+                              std::string_view obj_prefix) {
+  size_t start = 0;
+  // 1000 is the largest allowed batch size.
+  while (start < objects.size()) {
+    size_t cnt = std::min(objects.size() - start, (size_t)1000);
+    int r = do_delete_objects(m_bucket, obj_prefix, objects, start, cnt);
+    if (r < 0) return r;
+    start += cnt;
+  }
+  return 0;
+}
+
+int OssClient::list_objects(std::string_view prefix, ListObjectsCallback cb,
+                            ListObjectsParameters params, std::string* nct) {
+  std::string marker;
+  int max_keys = params.max_keys;
+  if (nct) marker = *nct;
+  if (max_keys == 0) max_keys = m_oss_options.max_list_ret_cnt;
+
+  int r = 0;
+  do {
+    if (params.ver == 2) {
+      r = do_list_objects_v2(m_bucket, prefix, cb, params.slash_delimiter,
+                             max_keys, &marker, params.start_after);
+    } else {
+      r = do_list_objects_v1(m_bucket, prefix, cb, params.slash_delimiter,
+                             max_keys, &marker);
+    }
+    if (r < 0) return r;
+  } while (!nct && !marker.empty());
+  if (nct) *nct = marker;
+  return 0;
+}
+
+int OssClient::head_object(std::string_view object, ObjectHeaderMeta& meta) {
+  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::HEAD, oss_url.url());
+  int r = sign_and_call(op, Verb::HEAD, oss_url);
+  if (r < 0) return r;
+  return fill_meta(op, meta);
+}
+
+int OssClient::fill_meta(HTTP_STACK_OP& op, ObjectHeaderMeta& meta) {
+  int ret = fill_meta(op, (ObjectMeta&)meta);
+  if (ret < 0) return ret;
+
+  auto it = op.resp.headers.find("x-oss-storage-class");
+  if (it != op.resp.headers.end()) {
+    meta.set_storage_class();
+    meta.storage_class.assign(it.second().data(), it.second().size());
+  }
+
+  it = op.resp.headers.find("x-oss-hash-crc64ecma");
+  if (it != op.resp.headers.end()) {
+    meta.set_crc64(estring_view(it.second()).to_uint64());
+  }
+  return 0;
+}
+
+int OssClient::fill_meta(HTTP_STACK_OP& op, ObjectMeta& meta) {
+  auto len = op.resp.resource_size();
+  if (len == -1) LOG_ERROR_RETURN(0, -1, "Unexpected http response header");
+
+  meta.set_size(len);
+  auto it = op.resp.headers.find("Last-Modified");
+  if (it != op.resp.headers.end()) {
+    if (it.second().empty())
+      meta.set_mtime(0);
+    else
+      meta.set_mtime(get_lastmodified(it.second()));
+  }
+
+  it = op.resp.headers.find("ETag");
+  if (it != op.resp.headers.end()) {
+    meta.set_etag();
+    meta.etag.assign(it.second().data(), it.second().size());
+  }
+
+  it = op.resp.headers.find("x-oss-object-type");
+  if (it != op.resp.headers.end()) {
+    meta.set_type();
+    meta.type.assign(it.second().data(), it.second().size());
+  }
+  return 0;
+}
+
+int OssClient::fill_upload_response(HTTP_STACK_OP& op,
+                                    ObjectUploadOptions& opts) {
+  if (opts.etag) {
+    auto it = op.resp.headers.find("ETag");
+    if (it != op.resp.headers.end()) {
+      opts.etag->assign(it.second().data(), it.second().size());
+    }
+  }
+  return 0;
+}
+
+ssize_t OssClient::get_object_range(std::string_view obj_path,
+                                    const struct iovec* iov, int iovcnt,
+                                    off_t offset, ObjectHeaderMeta* meta) {
+  int retry_times = m_oss_options.retry_times;
+  auto retry_interval = m_oss_options.retry_base_interval_us;
+
+  iovector_view view((struct iovec*)iov, iovcnt);
+  auto cnt = view.sum();
+  if (cnt == 0) return 0;
+
+  bool invalidate_cache = false;
+retry:
+  OssUrl oss_url(m_endpoint, m_bucket, obj_path, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::GET, oss_url.url());
+  op.req.headers.insert(OSS_HEADER_KEY_X_OSS_RANGE_BEHAVIOR, "standard");
+  op.req.headers.range(offset, offset + cnt - 1);
+  int r = sign_and_call(op, Verb::GET, oss_url, {}, invalidate_cache);
+  if (r < 0) {
+    if (errno == EACCES && !invalidate_cache) {
+      invalidate_cache = true;
+      errno = 0;
+      goto retry;
+    }
+    return r;
+  }
+
+  uint64_t content_length = op.resp.headers.content_length();
+  auto ret = op.resp.readv(iov, iovcnt);
+
+  // we have encountered partial read issue because of the socket was
+  // unexpectedly closed
+  if (ret != static_cast<ssize_t>(content_length)) {
+    LOG_ERROR("Get object ` return partial data, offset `, expected: `, got: `",
+              obj_path, offset, cnt, ret);
+    if (retry_times-- > 0) {
+      photon::thread_usleep(retry_interval);
+      retry_interval *= 2;
+      LOG_ERROR("Retrying oss request ` `", verbstr[op.req.verb()],
+                op.req.target());
+      // op.reset(nullptr);
+      goto retry;
+    }
+    ret = -1;
+    errno = EIO;
+  } else {
+    if (meta) fill_meta(op, *meta);
+  }
+
+  return ret;
+}
+
+struct BatchGetResult {
+  uint32_t request_count = 0;
+  uint32_t success_count = 0;
+  uint32_t status_code = 0;
+  std::string error_msg;
+};
+
+class FrameStream;
+struct Frame {
+  enum class FrameKind : uint8_t { None, Data, Meta, End };
+
+  FrameKind kind = FrameKind::None;
+  uint32_t ref_id = 0;
+  uint32_t payload_size = 0;
+  uint32_t tail_size = 0;  // checksum size
+
+  BatchGetResult read_end(FrameStream& stream) const;
+  std::unordered_map<estring_view, estring> read_meta(
+      FrameStream& stream) const;
+  ssize_t read_data(FrameStream& stream, const struct iovec* iov,
+                    int iovcnt) const;
+  bool skip(FrameStream& stream) const;
+
+  operator bool() const { return kind != FrameKind::None; }
+};
+
+static inline uint32_t be32_to_host(const uint8_t* p) {
+  return (static_cast<uint32_t>(p[0]) << 24) |
+         (static_cast<uint32_t>(p[1]) << 16) |
+         (static_cast<uint32_t>(p[2]) << 8) | (static_cast<uint32_t>(p[3]));
+}
+
+class FrameStream {
+ public:
+  using Response = photon::net::http::Response;
+
+  explicit FrameStream(Response* response) : response_(response) {}
+
+  Frame next() {
+    static constexpr uint32_t FRAME_DATA = 0xFF2;
+    static constexpr uint32_t FRAME_META = 0xFF1;
+    static constexpr uint32_t FRAME_END = 0xFF4;
+
+    // |version| Frame-Type |  ref-id    | Payload Length|Header
+    // Checksum|Payload|Payload Checksum|
+    // |<1---->| <--3 bytes>|<--4 bytes->| <--4 bytes--->|<--4
+    // bytes-----><-n/a--><--4 bytes----->|
+
+    uint8_t header[16];
+    if (!read_exact(header, sizeof(header))) {
+      return {};
+    }
+
+    header[0] = 0;  // ignore version bit
+
+    uint32_t type = be32_to_host(header);
+    if (type != FRAME_DATA && type != FRAME_META && type != FRAME_END) {
+      return {};
+    }
+
+    Frame frame;
+    frame.ref_id = be32_to_host(header + 4);
+    frame.payload_size = be32_to_host(header + 8);
+    frame.tail_size = 4;
+
+    if (type == FRAME_DATA)
+      frame.kind = Frame::FrameKind::Data;
+    else if (type == FRAME_META)
+      frame.kind = Frame::FrameKind::Meta;
+    else if (type == FRAME_END)
+      frame.kind = Frame::FrameKind::End;
+    return frame;
+  }
+
+ private:
+  BatchGetResult read_end_frame(const Frame& frame) {
+    size_t total = frame.payload_size + frame.tail_size;
+    std::vector<uint8_t> buf(total);
+    if (total < 12 || !read_exact(buf.data(), total)) return {};
+
+    BatchGetResult ret;
+    ret.request_count = be32_to_host(buf.data());
+    ret.success_count = be32_to_host(buf.data() + 4);
+    ret.status_code = be32_to_host(buf.data() + 8);
+
+    if (frame.payload_size > 12) {
+      ret.error_msg.assign(reinterpret_cast<const char*>(buf.data() + 12),
+                           frame.payload_size - 12);
+    }
+    // ignore last 4 bytes (checksum)
+    return ret;
+  }
+  std::unordered_map<estring_view, estring> read_meta_frame(
+      const Frame& frame) {
+    size_t total = frame.payload_size + frame.tail_size;
+    std::vector<char> buf(total);
+    if (!read_exact(reinterpret_cast<uint8_t*>(buf.data()), total)) return {};
+
+    static const std::unordered_set<estring_view> headers = {
+        "x-oss-storage-class", "x-oss-hash-crc64ecma",
+        "x-oss-object-type",   "ETag",
+        "x-oss-response-code", "Last-Modified",
+        "x-oss-object-size"};
+
+    estring_view meta_str(buf.data(), frame.payload_size);
+    std::unordered_map<estring_view, estring> meta;
+    for (auto line : meta_str.split_lines()) {
+      auto pos = line.find(':');
+      if (pos == estring_view::npos) continue;
+      estring_view key(line.substr(0, pos));
+      auto it = headers.find(key.trim());
+      if (it == headers.end()) continue;
+      estring_view val(line.substr(pos + 1));
+      meta.emplace(*it, photon::net::http::url_unescape(val.trim()));
+    }
+    return meta;
+  }
+
+  ssize_t read_data_frame(const Frame& frame, const struct iovec* iov,
+                          int iovcnt) {
+    ssize_t ret = response_->readv(iov, iovcnt);
+    if (ret < 0 || static_cast<size_t>(ret) != frame.payload_size) {
+      LOG_ERROR("Data frame mismatch: expected `, got `", frame.payload_size,
+                ret);
+      return ret < 0 ? ret : -1;
+    }
+    if (!skip_bytes(frame.tail_size))
+      LOG_ERROR_RETURN(EIO, -1, "Failed to skip data frame tail");
+    return ret;
+  }
+
+  bool skip_frame(const Frame& frame) {
+    return skip_bytes(frame.payload_size + frame.tail_size);
+  }
+
+  bool read_exact(uint8_t* buf, size_t n) {
+    while (n > 0) {
+      size_t got = response_->read(buf, n);
+      if (got == 0 || got > n) return false;
+      buf += got;
+      n -= got;
+    }
+    return true;
+  }
+
+  bool skip_bytes(size_t n) {
+    std::vector<uint8_t> dummy(std::min(n, size_t(128 * 1024)));
+    while (n > 0) {
+      size_t chunk = std::min(n, dummy.size());
+      if (!read_exact(dummy.data(), chunk)) return false;
+      n -= chunk;
+    }
+    return true;
+  }
+
+  Response* response_ = nullptr;
+  friend struct Frame;
+};
+
+BatchGetResult Frame::read_end(FrameStream& stream) const {
+  assert(kind == FrameKind::End);
+  return stream.read_end_frame(*this);
+}
+
+std::unordered_map<estring_view, estring> Frame::read_meta(
+    FrameStream& stream) const {
+  assert(kind == FrameKind::Meta);
+  return stream.read_meta_frame(*this);
+}
+
+ssize_t Frame::read_data(FrameStream& stream, const struct iovec* iov,
+                         int iovcnt) const {
+  assert(kind == FrameKind::Data);
+  return stream.read_data_frame(*this, iov, iovcnt);
+}
+
+bool Frame::skip(FrameStream& stream) const { return stream.skip_frame(*this); }
+
+int OssClient::batch_get_objects(std::vector<GetObjectParameters>& params) {
+  static std::string_view req_head = "<GetObjectsRequest>";
+  static std::string_view req_tail = "</GetObjectsRequest>";
+  estring req_list;
+  for (size_t i = 0; i < params.size(); i++) {
+    iovector_view view((struct iovec*)params[i].iov, params[i].iovcnt);
+    auto cnt = view.sum();
+    req_list.appends("<Object><ObjectName>", xml_escape(params[i].object),
+                     "</ObjectName><Range>bytes=", params[i].offset, "-",
+                     params[i].offset + cnt - 1, "</Range><RefId>", i + 1,
+                     "</RefId></Object>");
+    params[i].result = -1;
+  }
+
+  struct iovec iov[3] = {{(void*)req_head.data(), req_head.size()},
+                         {(void*)req_list.data(), req_list.size()},
+                         {(void*)req_tail.data(), req_tail.size()}};
+  iovector_view body_view(iov, 3);
+
+  OssUrl oss_url(m_endpoint, m_bucket, "/", m_is_http);
+  auto md5 = md5_base64(body_view);
+
+  DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
+                                        {// must appear in dictionary order!
+                                         {OSS_PARAM_KEY_BATCH_GET, ""}});
+
+  DEFINE_ONSTACK_OP(m_client, Verb::POST, oss_url.append_params(query_params));
+  op.req.headers.insert(OSS_HEADER_KEY_CONTENT_MD5, md5);
+  op.req.headers.insert(OSS_HEADER_KEY_X_OSS_RANGE_BEHAVIOR, "standard");
+  op.req.headers.content_length(body_view.sum());
+  op.body_writer = {&body_view, &body_writer_cb};
+
+  int r = sign_and_call(op, Verb::POST, oss_url, query_params);
+  if (r < 0) return r;
+
+  uint32_t read_good_cnt = 0;
+  FrameStream stream(&op.resp);
+  while (auto frame = stream.next()) {
+    if (frame.kind == Frame::FrameKind::Meta) {
+      auto& param = params[frame.ref_id - 1];
+      auto meta_map = frame.read_meta(stream);
+      auto it = meta_map.find("x-oss-response-code");
+      if (it != meta_map.end()) {
+        auto status_code = estring_view(it->second).to_int64();
+        param.result = 0;
+        if (status_code / 100 != 2) {
+          param.result = -error_http_status_to_errno(status_code);
+        }
+        if (param.result < 0) {
+          LOG_ERROR("Object ` failed with status code `", param.object,
+                    status_code);
+        }
+      }
+
+      if (param.meta && param.result == 0) {
+        param.meta->set_type(meta_map["x-oss-object-type"]);
+        param.meta->set_etag(meta_map["ETag"]);
+        param.meta->set_storage_class(meta_map["x-oss-storage-class"]);
+        param.meta->set_mtime(
+            get_lastmodified(meta_map["Last-Modified"]));
+        param.meta->set_crc64(
+            estring_view(meta_map["x-oss-hash-crc64ecma"]).to_uint64());
+        param.meta->set_size(
+            estring_view(meta_map["x-oss-object-size"]).to_int64());
+      }
+    } else if (frame.kind == Frame::FrameKind::Data) {
+      auto& param = params[frame.ref_id - 1];
+      if (param.result < 0) {
+        std::string msg(frame.payload_size, 0);
+        iovec iov = {&msg[0], frame.payload_size};
+        r = frame.read_data(stream, &iov, 1);
+        if (r < 0) return r;
+        LOG_ERROR("reading object ` failed with result ` msg `", param.object,
+                  param.result, msg);
+        continue;
+      }
+
+      iovector_view view((struct iovec*)param.iov, param.iovcnt);
+      if (view.sum() < frame.payload_size) {
+        LOG_ERROR("Skip object ` data frame expected `, got `, result `",
+                  param.object, view.sum(), frame.payload_size, param.result);
+        if (!frame.skip(stream))
+          LOG_ERROR_RETURN(EIO, -1, "Failed to skip data frame");
+        continue;
+      }
+
+      if (view.sum() > frame.payload_size) {
+        // rebuild the iovs if the returned data is less than expected.
+        std::vector<iovec> iovs;
+        iovs.reserve(param.iovcnt);
+        size_t remaining = frame.payload_size;
+        for(auto i = 0; i < param.iovcnt; i++) {
+          auto cur = std::min(remaining, param.iov[i].iov_len);
+          iovs.push_back({param.iov[i].iov_base, cur});
+          remaining -= cur;
+          if (remaining == 0) break;
+        }
+
+        r = frame.read_data(stream, &iovs[0], iovs.size());
+      } else {
+        r = frame.read_data(stream, param.iov, param.iovcnt);
+      }
+
+      if (r < 0) return r;
+      param.result = r;
+      read_good_cnt++;
+    } else {
+      auto result = frame.read_end(stream);
+      LOG_DEBUG("End frame status code ` request cnt ` success cnt `",
+                result.status_code, result.request_count, result.success_count);
+      if (read_good_cnt != result.success_count) {
+        LOG_ERROR("Mismatch between read good cnt ` and success cnt `",
+                  read_good_cnt, result.success_count);
+        return -1;
+      }
+      return result.success_count;
+    }
+  }
+  return 0;
+}
+
+ssize_t OssClient::put_object(std::string_view object, const struct iovec* iov,
+                              int iovcnt, ObjectUploadOptions& opts) {
+  iovector_view view((struct iovec*)iov, iovcnt);
+  auto cnt = view.sum();
+
+  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+  auto content_type = lookup_mime_type(object);
+
+  DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.url());
+  if (!content_type.empty()) {
+    op.req.headers.insert(OSS_HEADER_KEY_CONTENT_TYPE, content_type);
+  }
+  op.req.headers.content_length(cnt);
+  op.body_writer = {&view, &body_writer_cb};
+  int r = sign_and_call(op, Verb::PUT, oss_url);
+  if (r < 0) return r;
+  r = verify_crc64_if_needed(op, oss_url.object(), opts.expected_crc64);
+  if (r < 0) return r;
+  fill_upload_response(op, opts);
+  return cnt;
+}
+
+ssize_t OssClient::append_object(std::string_view object,
+                                 const struct iovec* iov, int iovcnt,
+                                 off_t position, ObjectUploadOptions& opts) {
+  iovector_view view((struct iovec*)iov, iovcnt);
+  auto cnt = view.sum();
+
+  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+
+  estring position_str = std::to_string(position);
+
+  // must appear in dictionary order!
+  DEFINE_ORDERED_STRING_KV(
+      query_params,
+      {{OSS_PARAM_KEY_APPEND, ""}, {OSS_PARAM_KEY_POSITION, position_str}});
+
+  DEFINE_ONSTACK_OP(m_client, Verb::POST, oss_url.append_params(query_params));
+  auto content_type = lookup_mime_type(object);
+  if (!content_type.empty()) {
+    op.req.headers.insert(OSS_HEADER_KEY_CONTENT_TYPE, content_type);
+  }
+  op.req.headers.content_length(cnt);
+  op.body_writer = {&view, &body_writer_cb};
+  int r = sign_and_call(op, Verb::POST, oss_url, query_params);
+  if (r < 0) return r;
+  r = verify_crc64_if_needed(op, oss_url.object(), opts.expected_crc64);
+  if (r < 0) return r;
+  fill_upload_response(op, opts);
+  return cnt;
+}
+
+int OssClient::copy_object(std::string_view src_object,
+                           std::string_view dst_object, bool overwrite,
+                           bool set_mime) {
+  OssUrl src_oss_url(m_endpoint, m_bucket, src_object, m_is_http);
+  OssUrl dst_oss_url(m_endpoint, m_bucket, dst_object, m_is_http);
+
+  return do_copy_object(src_oss_url, dst_oss_url, overwrite, set_mime);
+}
+
+struct oss_multipart_context {
+  estring obj_path;
+  std::string upload_id;
+  std::vector<std::pair<int, std::string>> part_list;
+  photon::spinlock lock;
+};
+
+int OssClient::init_multipart_upload(std::string_view object, void** context) {
+  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+
+  DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
+                                        {// must appear in dictionary order!
+                                         {OSS_PARAM_KEY_UPLOADS, ""}});
+
+  DEFINE_ONSTACK_OP(m_client, Verb::POST, oss_url.append_params(query_params));
+
+  auto content_type = lookup_mime_type(object);
+  if (!content_type.empty())
+    op.req.headers.insert(OSS_HEADER_KEY_CONTENT_TYPE, content_type);
+
+  int r = sign_and_call(op, Verb::POST, oss_url, query_params);
+  if (r < 0) return r;
+
+  auto reader = get_xml_node(op);
+  if (!reader) LOG_ERROR_RETURN(EINVAL, -1, "failed to parse xml resp_body");
+  auto upload_id = NodeStrValue(reader["InitiateMultipartUploadResult"]["UploadId"]);
+  if (!upload_id.has_value())
+    LOG_ERROR_RETURN(EINVAL, -1, "invalid response with no upload id provided");
+
+  oss_multipart_context* ctx = new oss_multipart_context;
+  ctx->obj_path.appends(object);
+  ctx->upload_id = static_cast<estring_view>(upload_id);
+
+  *context = ctx;
+  return 0;
+}
+
+ssize_t OssClient::upload_part(void* context, const struct iovec* iov,
+                               int iovcnt, int part_number,
+                               ObjectUploadOptions& opts) {
+  iovector_view view((struct iovec*)iov, iovcnt);
+  auto cnt = view.sum();
+  assert(cnt > 0);
+
+  assert(context);
+
+  oss_multipart_context* ctx = (oss_multipart_context*)context;
+  assert(!ctx->upload_id.empty());
+
+  estring part_nums_str = std::to_string(part_number);
+
+  // must appear in dictionary order!
+  DEFINE_ORDERED_STRING_KV(query_params,
+                           {{OSS_PARAM_KEY_PART_NUMBER, part_nums_str},
+                            {OSS_PARAM_KEY_UPLOAD_ID, ctx->upload_id}});
+
+  OssUrl oss_url(m_endpoint, m_bucket, ctx->obj_path, m_is_http);
+
+  DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.append_params(query_params));
+
+  op.req.headers.content_length(cnt);
+  op.body_writer = {&view, &body_writer_cb};
+  int r = sign_and_call(op, Verb::PUT, oss_url, query_params);
+  if (r < 0) return r;
+
+  auto etag = op.resp.headers["ETag"];
+  if (etag.empty())
+    LOG_ERROR_RETURN(EINVAL, -1, "unexpected response with empty etag");
+
+  r = verify_crc64_if_needed(op, oss_url.object(), opts.expected_crc64);
+  if (r < 0) return r;
+
+  SCOPED_LOCK(ctx->lock);
+  ctx->part_list.emplace_back(part_number, etag);
+  return cnt;
+}
+
+int OssClient::upload_part_copy(void* context, off_t offset, size_t count,
+                                int part_number, std::string_view from) {
+  assert(context);
+  oss_multipart_context* ctx = (oss_multipart_context*)context;
+  assert(!ctx->upload_id.empty());
+
+  OssUrl oss_url(m_endpoint, m_bucket, ctx->obj_path, m_is_http);
+
+  estring part_num_str = std::to_string(part_number);
+
+  // must appear in dictionary order!
+  DEFINE_ORDERED_STRING_KV(query_params,
+                           {{OSS_PARAM_KEY_PART_NUMBER, part_num_str},
+                            {OSS_PARAM_KEY_UPLOAD_ID, ctx->upload_id}});
+
+  estring oss_copy_source;
+  if (from.empty()) {  // just copy myself
+    oss_copy_source.appends("/", oss_url.bucket(), "/", oss_url.object(true));
+  } else {
+    oss_copy_source.appends("/", oss_url.bucket(), "/",
+                            photon::net::http::url_escape(from));
+  }
+  std::string range = "bytes=" + std::to_string(offset) + "-" +
+                      std::to_string(offset + count - 1);
+
+  DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.append_params(query_params));
+  op.req.headers.insert(OSS_HEADER_KEY_X_OSS_COPY_SOURCE, oss_copy_source);
+  op.req.headers.insert(OSS_HEADER_KEY_X_OSS_COPY_SOURCE_RANGE, range);
+  int r = sign_and_call(op, Verb::PUT, oss_url, query_params);
+  if (r < 0) return r;
+
+  auto reader = get_xml_node(op);
+  if (!reader) LOG_ERROR_RETURN(EINVAL, -1, "failed to parse xml resp_body");
+  auto etag = NodeStrValue(reader["CopyPartResult"]["ETag"]);
+  if (!etag.has_value())
+    LOG_ERROR_RETURN(EINVAL, -1, "invalid response with no etag provided");
+
+  if ((static_cast<estring_view>(etag)).empty())
+    LOG_ERROR_RETURN(EINVAL, -1, "unexpected response with empty etag");
+
+  SCOPED_LOCK(ctx->lock);
+  ctx->part_list.emplace_back(part_number, static_cast<estring_view>(etag));
+  return 0;
+}
+
+int OssClient::complete_multipart_upload(void* context,
+                                         ObjectUploadOptions& opts) {
+  assert(context);
+
+  oss_multipart_context* ctx = (oss_multipart_context*)context;
+  assert(!ctx->upload_id.empty());
+
+  estring req_body;
+  req_body.appends("<CompleteMultipartUpload>");
+
+  std::sort(ctx->part_list.begin(), ctx->part_list.end(),
+            [](auto& a, auto& b) { return a.first < b.first; });
+  for (auto& part : ctx->part_list) {
+    req_body.appends(
+        "<Part>"
+        "<PartNumber>",
+        part.first,
+        "</PartNumber>"
+        "<ETag>",
+        part.second,
+        "</ETag>"
+        "</Part>");
+  }
+  req_body.appends("</CompleteMultipartUpload>");
+
+  struct iovec iov{(void*)(req_body.data()), req_body.size()};
+
+  iovector_view view(&iov, 1);
+  OssUrl oss_url(m_endpoint, m_bucket, ctx->obj_path, m_is_http);
+
+  DEFER(delete ctx);
+
+  // must appear in dictionary order!
+  DEFINE_ORDERED_STRING_KV(query_params,
+                           {{OSS_PARAM_KEY_UPLOAD_ID, ctx->upload_id}});
+  DEFINE_ONSTACK_OP(m_client, Verb::POST, oss_url.append_params(query_params));
+  op.req.headers.content_length(req_body.size());
+  op.body_writer = {&view, &body_writer_cb};
+  int r = sign_and_call(op, Verb::POST, oss_url, query_params);
+  if (r < 0) return r;
+  r = verify_crc64_if_needed(op, oss_url.object(), opts.expected_crc64);
+  if (r < 0) return r;
+  fill_upload_response(op, opts);
+  return r;
+}
+
+int OssClient::abort_multipart_upload(void* context) {
+  assert(context);
+
+  oss_multipart_context* ctx = (oss_multipart_context*)context;
+  assert(!ctx->upload_id.empty());
+
+  OssUrl oss_url(m_endpoint, m_bucket, ctx->obj_path, m_is_http);
+
+  DEFER(delete ctx);
+
+  // must appear in dictionary order!
+  DEFINE_ORDERED_STRING_KV(query_params,
+                           {{OSS_PARAM_KEY_UPLOAD_ID, ctx->upload_id}});
+
+  DEFINE_ONSTACK_OP(m_client, Verb::DELETE,
+                    oss_url.append_params(query_params));
+  return sign_and_call(op, Verb::DELETE, oss_url, query_params);
+}
+
+int OssClient::get_object_meta(std::string_view object, ObjectMeta& meta) {
+  DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
+                                        {
+                                            // must appear in dictionary order!
+                                            {OSS_PARAM_KEY_OBJECT_META, ""},
+                                        });
+  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::HEAD, oss_url.append_params(query_params));
+  int r = sign_and_call(op, Verb::HEAD, oss_url, query_params);
+  if (r < 0) return r;
+  return fill_meta(op, meta);
+}
+
+int OssClient::delete_object(std::string_view obj_path) {
+  OssUrl oss_url(m_endpoint, m_bucket, obj_path, m_is_http);
+  return do_delete_object(oss_url);
+}
+
+void OssClient::set_credentials(CredentialParameters&& credentials) {
+  if (m_authenticator) {
+    m_authenticator->set_credentials(std::move(credentials));
+  }
+}
+
+#undef OssClient
+
+class BasicAuthenticator : public Authenticator {
+  char m_gmt_date[GMT_DATE_LIMIT];
+  char m_gmt_date_iso8601[GMT_DATE_LIMIT];
+  time_t m_last_tim = 0;
+  CredentialParameters m_credentials;
+  void append_query_params(estring& s, const StringKV& params,
+                           bool need_question_mark = true) {
+    if (!params.empty()) {
+      auto it = params.begin();
+      s.appends(make_ccl(need_question_mark, "?"), it->first,
+                make_ccl(!it->second.empty(), "=", it->second));
+      while (++it != params.end()) {
+        s.appends("&", it->first,
+                  make_ccl(!it->second.empty(), "=", it->second));
+      }
+    }
+  }
+
+  void append_headers(estring& s, const photon::net::http::Headers& header_map,
+                      bool v4_signature) {
+    for (auto kv : header_map) {
+      if (kv.first.substr(0, 5) != "x-oss" &&
+          (!v4_signature || (kv.first != OSS_HEADER_KEY_CONTENT_MD5 &&
+                             kv.first != OSS_HEADER_KEY_CONTENT_TYPE)))
+        continue;
+      s.appends(kv.first, ":", kv.second, "\n");
+    }
+  }
+
+  void sign_v1(photon::net::http::Headers& headers,
+               const Authenticator::SignParameters& params,
+               const CredentialParameters& cred) {
+    estring auth, data2sign;
+    std::string_view ak = cred.accessKeyId;
+    std::string_view sk = cred.accessKeySecret;
+    std::string_view token = cred.securityToken;
+
+    update_gmt_date();
+
+    std::string_view method = photon::net::http::verbstr[params.verb];
+    auto content_md5 = headers.get_value(OSS_HEADER_KEY_CONTENT_MD5);
+    auto content_type = headers.get_value(OSS_HEADER_KEY_CONTENT_TYPE);
+
+    data2sign.appends(method, "\n", content_md5, "\n", content_type, "\n",
+                      m_gmt_date, "\n");
+
+    if (!token.empty()) {
+      headers.insert("x-oss-security-token", token);
+    }
+    append_headers(data2sign, headers, false);
+
+    data2sign.appends("/", params.bucket, "/", params.object);
+
+    // complete this list if needed. currently it's for ossfs use only.
+    // must appear in dictionary order!
+    const static std::string_view sub_resources[] = {
+        OSS_PARAM_KEY_APPEND,      OSS_PARAM_KEY_CONTINUATION_TOKEN,
+        OSS_PARAM_KEY_DELETE,      OSS_PARAM_KEY_OBJECT_META,
+        OSS_PARAM_KEY_PART_NUMBER, OSS_PARAM_KEY_POSITION,
+        OSS_PARAM_KEY_SYMLINK,     OSS_PARAM_KEY_UPLOAD_ID,
+        OSS_PARAM_KEY_UPLOADS,     OSS_PARAM_KEY_BATCH_GET
+    };
+
+    if (params.query_params.size()) {
+      DEFINE_APPENDABLE_ORDERED_STRING_KV(sub_params, LEN(sub_resources), {{}});
+      for (auto x : sub_resources) {  // x is ordered
+        auto it = params.query_params.find(x);
+        if (it != params.query_params.end()) {
+          sub_params.append(*it);
+        }
+      }
+      // skip the 1st empty key
+      append_query_params(data2sign,
+                          StringKV(sub_params.begin() + 1, sub_params.end()));
+    }
+    // LOG_INFO("data2sign is `", data2sign);
+
+    estring signature;
+    net::Base64Encode(HMAC_SHA1(sk, data2sign), signature);
+
+    auth.appends("OSS ", ak, ":", signature);
+    headers.insert("Authorization", auth);
+    headers.insert("Date", m_gmt_date);
+  }
+
+  void sign_v4(photon::net::http::Headers& headers,
+               const Authenticator::SignParameters& params,
+               const CredentialParameters& cred) {
+    estring auth, canonical_request, string2sign, signing_key;
+    std::string_view ak = cred.accessKeyId;
+    std::string_view sk = cred.accessKeySecret;
+    std::string_view token = cred.securityToken;
+
+    update_gmt_date();
+
+    std::string_view method = photon::net::http::verbstr[params.verb];
+    canonical_request.appends(
+        method, "\n", "/", params.bucket, "/",
+        photon::net::http::url_escape(params.object, false), "\n");
+    if (params.query_params.size()) {
+      append_query_params(canonical_request, params.query_params, false);
+    }
+
+    canonical_request.appends("\n");
+
+    // headers are aloso sorted in lexicographical order
+    // header1:value1\n
+    // header2:value2\n
+    // StringKV header_map = headers;
+    headers.insert("x-oss-content-sha256", "UNSIGNED-PAYLOAD");
+    headers.insert("x-oss-date", m_gmt_date_iso8601);
+    if (!token.empty()) {
+      headers.insert("x-oss-security-token", token);
+    }
+    append_headers(canonical_request, headers, true);
+
+    canonical_request.appends("\n", "\n" /*no additional headers*/,
+                              "UNSIGNED-PAYLOAD");
+
+    string2sign.appends("OSS4-HMAC-SHA256\n", m_gmt_date_iso8601, "\n",
+                        estring_view(m_gmt_date_iso8601, 8), "/", params.region,
+                        "/oss/aliyun_v4_request\n",
+                        sha256_hash(canonical_request));
+
+    auto signature = hex(HMAC_SHA256(
+        HMAC_SHA256(
+            HMAC_SHA256(
+                HMAC_SHA256(HMAC_SHA256(estring("aliyun_v4").appends(sk),
+                                        estring_view(m_gmt_date_iso8601, 8)),
+                            params.region),
+                "oss"),
+            "aliyun_v4_request"),
+        string2sign));
+
+    // LOG_INFO("string2sing ` canonical request `", string2sign,
+    // canonical_request);
+
+    // Authorization: "OSS4-HMAC-SHA256 Credential=" + AccessKeyId + "/" +
+    // SignDate + "/" + SignRegion + "/oss/aliyun_v4_request," + [
+    // "AdditionalHeaders=" + AdditionalHeadersVal + "," ] + "Signature=" +
+    // SignatureVal
+    auth.appends("OSS4-HMAC-SHA256 Credential=", ak, "/",
+                 estring_view(m_gmt_date_iso8601, 8), "/", params.region,
+                 "/oss/aliyun_v4_request,", "Signature=", signature);
+    headers.insert("Authorization", auth);
+  }
+
+  std::string hex(std::string_view bytes) {
+    static const std::string hex_map = "0123456789abcdef";
+    std::string hex_data;
+    hex_data.reserve(bytes.size() * 2);
+    for (unsigned char c : bytes) {
+      hex_data += hex_map[c >> 4];
+      hex_data += hex_map[c & 0xf];
+    }
+    return hex_data;
+  }
+
+  std::string sha256_hash(std::string_view data) {
+    unsigned char hash[SHA256_DIGEST_LENGTH];
+    sha256 shax(data);
+    shax.finalize(hash);
+    return hex({(char*)hash, SHA256_DIGEST_LENGTH});
+  }
+
+  void update_gmt_date() {  // avoid updating GMT Time every time
+    time_t t = photon::now / 1000 / 1000;
+    if (t - m_last_tim > GMT_UPDATE_INTERVAL || m_last_tim == 0) {
+      std::time_t now = std::time(nullptr);
+      struct tm tm{};
+      if (gmtime_r(&now, &tm)) {
+        m_last_tim = t;
+        strftime(m_gmt_date, GMT_DATE_LIMIT, "%a, %d %b %Y %H:%M:%S GMT", &tm);
+        strftime(m_gmt_date_iso8601, GMT_DATE_LIMIT, "%Y%m%dT%H%M%SZ", &tm);
+      }
+    }
+  }
+
+ public:
+  BasicAuthenticator(CredentialParameters&& credentials)
+      : m_credentials(std::move(credentials)) {}
+
+  void set_credentials(CredentialParameters&& credentials) {
+    m_credentials = std::move(credentials);
+  }
+
+  int sign(photon::net::http::Headers& headers,
+           const Authenticator::SignParameters& params) {
+    if (params.region.empty()) {
+      sign_v1(headers, params, m_credentials);
+    } else {
+      sign_v4(headers, params, m_credentials);
+    }
+    return 0;
+  }
+};
+
+class CachedAuthenticator : public Authenticator {
+  Authenticator* m_auth = nullptr;
+  uint32_t m_cached_ttl_secs = 300;
+  using CachedObjHeader = std::vector<std::pair<std::string, std::string>>;
+  std::shared_ptr<ObjectCache<std::string, CachedObjHeader*>> m_cached_headers;
+
+ public:
+  CachedAuthenticator(Authenticator* auth, uint32_t cache_ttl_secs)
+      : m_auth(auth),
+        m_cached_ttl_secs(cache_ttl_secs),
+        m_cached_headers(
+            std::make_shared<ObjectCache<std::string, CachedObjHeader*>>(
+                1000ll * 1000 * cache_ttl_secs)) {}
+  ~CachedAuthenticator() { delete m_auth; }
+  int sign(photon::net::http::Headers& headers,
+           const Authenticator::SignParameters& params) override {
+    // only get obj range request among our supported interfaces will fall into
+    // this catagory currently
+    bool can_use_cache =
+        params.verb == Verb::GET && params.query_params.empty();
+    if (!can_use_cache) return m_auth->sign(headers, params);
+
+    std::string cached_key =
+        estring().appends(params.bucket, "/", params.object);
+
+    static const std::vector<std::string_view> to_cache_keys = {
+        "Authorization", "x-oss-security-token", "x-oss-date",
+        "x-oss-content-sha256", "Date" /*v1 signature needed*/};
+
+    bool evict_cache = params.invalidate_cache;
+    int r = 0;
+
+    auto ctor = [&]() -> CachedObjHeader* {
+      if (evict_cache) evict_cache = false;
+      r = m_auth->sign(headers, params);
+      if (r != 0) return nullptr;
+      auto* cached = new CachedObjHeader();
+      for (const auto& k : to_cache_keys) {
+        auto it = headers.find(k);
+        if (it != headers.end()) {
+          cached->emplace_back(k, it.second());
+        }
+      }
+      // LOG_INFO("cached headers for key ` `", cached_key,  cached);
+      return cached;
+    };
+
+    bool should_retry = false;
+    do {
+      should_retry = false;
+      auto cached = m_cached_headers->borrow(cached_key, ctor);
+      if (cached) {
+        if (evict_cache) {
+          // LOG_INFO("recycling cached headers for key `", cached_key);
+          cached.recycle(true);
+          evict_cache = false;
+          should_retry = true;
+          continue;
+        }
+
+        if (!cached->empty()) {
+          for (const auto& kv : *cached) {
+            headers.insert(kv.first, kv.second);
+          }
+          // LOG_INFO("using cached headers for key `", cached_key);
+          return 0;
+        }
+      }
+    } while (should_retry);
+    return r;
+  }
+
+  void set_credentials(CredentialParameters&& credentials) override {
+    // create one new cache instance to discard all the old entries
+    m_cached_headers =
+        std::make_shared<ObjectCache<std::string, CachedObjHeader*>>(
+            1000ll * 1000 * m_cached_ttl_secs);
+    m_auth->set_credentials(std::move(credentials));
+  }
+};
+
+Client* new_oss_client(const ClientOptions& opt, Authenticator* auth) {
+  return new OssClientImpl(opt, auth);
+}
+
+Client* new_oss_client(const ClientOptions& opt, uint32_t cache_ttl_secs,
+                       CredentialParameters&& credentials) {
+  auto auth = new_basic_oss_authenticator(std::move(credentials));
+  if (!auth) return nullptr;
+  if (cache_ttl_secs) auth = new_cached_oss_authenticator(auth, cache_ttl_secs);
+  return new_oss_client(opt, auth);
+}
+
+Authenticator* new_basic_oss_authenticator(CredentialParameters&& credentials) {
+  return new BasicAuthenticator(std::move(credentials));
+}
+
+Authenticator* new_cached_oss_authenticator(Authenticator* auth,
+                                            uint32_t cache_ttl_secs) {
+  if (cache_ttl_secs) return new CachedAuthenticator(auth, cache_ttl_secs);
+  return auth;
+}
+
+}  // namespace objstore
+}  // namespace photon

--- a/ecosystem/oss.h
+++ b/ecosystem/oss.h
@@ -1,0 +1,328 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+#include <inttypes.h>
+#include <photon/common/callback.h>
+#include <photon/common/object.h>
+#include <photon/common/ordered_span.h>
+#include <photon/common/string_view.h>
+#include <photon/net/http/headers.h>
+#include <photon/net/http/verb.h>
+#include <sys/uio.h>
+
+#include <string>
+#include <vector>
+
+namespace photon {
+namespace objstore {
+
+using StringKV = ordered_string_kv;
+
+std::string_view lookup_mime_type(std::string_view name);
+
+static constexpr int OSS_MAX_PATH_LEN = 1023;
+
+struct ClientOptions {
+  std::string endpoint;
+  std::string bucket;
+  std::string region;
+  std::string proxy;
+  int max_list_ret_cnt = 1000;
+  std::string user_agent = "Photon-ObjStore-Client";
+  std::string bind_ips;
+  uint64_t request_timeout_us = 60ull * 1000 * 1000;
+  int retry_times = 2;
+
+  // When the request timeouts or encounters 5xx error, we will
+  // retry the request with times of the base interval.
+  // For QPSLimit case, the policy is different. We will retry more
+  // times until we have waited the "request time out" period.
+  uint64_t retry_base_interval_us = 100'000;
+  std::vector<std::pair<std::string, std::string>> custom_headers;
+};
+
+struct ObjectMeta {
+  uint8_t flags = 0;
+
+  void reset() { flags = 0; }
+
+#define DEFINE_OPTIONAL_FIELD(type, name, flag)                  \
+  static_assert((flag) > 0 && ((flag) & ((flag) - 1)) == 0,      \
+                "Flag must be a power of two");                  \
+  static_assert(((flag) & ~((uint8_t)0xFF)) == 0,                \
+                "Flag must fit within uint8_t bit range (0-7)"); \
+  type name{};                                                   \
+  bool has_##name() const { return flags & (flag); }             \
+  void set_##name() { flags |= (flag); }                         \
+  void set_##name(const type& value) {                           \
+    name = value;                                                \
+    flags |= (flag);                                             \
+  }                                                              \
+  void reset_##name() {                                          \
+    name = {};                                                   \
+    flags &= ~(flag);                                            \
+  }
+
+  DEFINE_OPTIONAL_FIELD(size_t, size, 1)
+  DEFINE_OPTIONAL_FIELD(time_t, mtime, 1 << 1)
+  DEFINE_OPTIONAL_FIELD(std::string, etag, 1 << 2)
+  DEFINE_OPTIONAL_FIELD(std::string, type, 1 << 3)  // Appendable/Normal/...
+};
+
+struct ObjectHeaderMeta : public ObjectMeta {
+  DEFINE_OPTIONAL_FIELD(std::string, storage_class, 1 << 4)
+  DEFINE_OPTIONAL_FIELD(uint64_t, crc64, 1 << 5)
+
+#undef DEFINE_OPTIONAL_FIELD
+};
+
+struct ListObjectsParameters {
+  uint8_t ver = 2;
+  bool slash_delimiter = false;
+  uint16_t max_keys = 0;
+  std::string_view start_after = {};
+};
+
+struct ListObjectsCBParameters {
+  std::string_view key;
+  std::string_view etag;
+  std::string_view type;
+  size_t size = 0;
+  time_t mtime = 0;
+  bool is_com_prefix = false;
+};
+
+using ListObjectsCallback = Delegate<int, const ListObjectsCBParameters&>;
+
+struct CredentialParameters {
+  std::string accessKeyId;
+  std::string accessKeySecret;
+  std::string securityToken;
+};
+
+class Authenticator : Object {
+ public:
+  struct SignParameters {
+    std::string_view region, endpoint, bucket, object;
+    StringKV query_params;
+    photon::net::http::Verb verb;
+    bool invalidate_cache = false;
+  };
+
+  virtual int sign(photon::net::http::Headers& headers,
+                   const SignParameters& params) = 0;
+
+  virtual const CredentialParameters* get_credentials() { return nullptr; }
+
+  // may be ignored for some implementations
+  virtual void set_credentials(CredentialParameters&& credentials) = 0;
+};
+
+struct GetObjectParameters {
+  std::string_view object;
+  const iovec* iov = nullptr;
+  int iovcnt = 0;
+  off_t offset = 0;
+
+  ObjectHeaderMeta* meta = nullptr;
+  int result = -1;
+};
+
+struct ObjectUploadOptions {
+  // inputs
+  const uint64_t *expected_crc64 = nullptr;
+
+  // outputs
+  std::string *etag = nullptr;
+};
+
+class Client : public Object {
+ public:
+  virtual int list_objects(std::string_view prefix, ListObjectsCallback cb,
+                           ListObjectsParameters = {},
+                           std::string* marker = nullptr) = 0;
+
+  virtual int head_object(std::string_view object, ObjectHeaderMeta& meta) = 0;
+
+  // return value is the real size if the operation succeeds, otherwise
+  // return -1
+  virtual ssize_t get_object_range(std::string_view object,
+                                   const struct iovec* iov, int iovcnt,
+                                   off_t offset,
+                                   ObjectHeaderMeta* meta = nullptr) = 0;
+
+  // return value is the object count which data is successfully downloaded.
+  // It's possible only some objects get to be downloaded successfully.
+  // return -1 if some other errors happen.
+  // The batch_get_objects interface works only when whitelisting enabled
+  // at OSS server side.
+  virtual int batch_get_objects(std::vector<GetObjectParameters>& params) = 0;
+
+  // return value is the object size if the operation succeeds, otherwise
+  // return -1.
+  // if expected_crc64 is specified, we will compare the value with the
+  // returned object crc64 to validate the object integrity.
+  ssize_t put_object(std::string_view object, const struct iovec* iov,
+                     int iovcnt, uint64_t* expected_crc64 = nullptr) {
+    ObjectUploadOptions opts{.expected_crc64 = expected_crc64};
+    return put_object(object, iov, iovcnt, opts);
+  };
+  virtual ssize_t put_object(std::string_view object, const struct iovec* iov,
+                             int iovcnt, ObjectUploadOptions& opts) = 0;
+
+  // return value is the newly appended size if the operation succeeds,
+  // otherwise return -1.
+  // if expected_crc64 is specified, we will compare the value with the
+  // returned object crc64 to validate the object integrity.
+  ssize_t append_object(std::string_view object, const struct iovec* iov,
+                        int iovcnt, off_t position,
+                        uint64_t* expected_crc64 = nullptr) {
+    ObjectUploadOptions opts{.expected_crc64 = expected_crc64};
+    return append_object(object, iov, iovcnt, position, opts);
+  };
+  virtual ssize_t append_object(std::string_view object,
+                                const struct iovec* iov, int iovcnt,
+                                off_t position,
+                                ObjectUploadOptions& opts) = 0;
+
+  virtual int copy_object(std::string_view src_object,
+                          std::string_view dst_object, bool overwrite = false,
+                          bool set_mime = false) = 0;
+
+  virtual int init_multipart_upload(std::string_view object,
+                                    void** context) = 0;
+
+  // return value is the part size if the operation succeeds, otherwise
+  // return -1.
+  // if expected_crc64 is specified, we will compare the value with the
+  // returned part crc64 to validate the part integrity.
+  ssize_t upload_part(void* context, const struct iovec* iov, int iovcnt,
+                      int part_number, uint64_t* expected_crc64 = nullptr) {
+    ObjectUploadOptions opts{.expected_crc64 = expected_crc64};
+    return upload_part(context, iov, iovcnt, part_number, opts);
+  };
+  virtual ssize_t upload_part(void* context, const struct iovec* iov,
+                              int iovcnt, int part_number,
+                              ObjectUploadOptions& opts) = 0;
+
+  virtual int upload_part_copy(void* context, off_t offset, size_t count,
+                               int part_number, std::string_view from = {}) = 0;
+
+  // if expected_crc64 is specified, we will compare the value with the
+  // returned object crc64 to validate the object integrity.
+  int complete_multipart_upload(void* context,
+                                uint64_t* expected_crc64 = nullptr) {
+    ObjectUploadOptions opts{.expected_crc64 = expected_crc64};
+    return complete_multipart_upload(context, opts);
+  }
+  virtual int complete_multipart_upload(void* context,
+                                        ObjectUploadOptions& opts) = 0;
+
+  virtual int abort_multipart_upload(void* context) = 0;
+
+  class MultipartUploadContext {
+    Client* _client;
+    void* _ctx;
+
+   public:
+    MultipartUploadContext(Client* client, void* ctx)
+        : _client(client), _ctx(ctx) {}
+
+    ssize_t upload(const struct iovec* iov, int iovcnt, int part_number,
+                   uint64_t* expected_crc64 = nullptr) {
+      return _client->upload_part(_ctx, iov, iovcnt, part_number,
+                                  expected_crc64);
+    }
+
+    int copy(off_t offset, size_t count, int part_number,
+             std::string_view from = {}) {
+      return _client->upload_part_copy(_ctx, offset, count, part_number, from);
+    }
+
+    int complete(uint64_t* expected_crc64) {
+      return _client->complete_multipart_upload(_ctx, expected_crc64);
+    }
+
+    int abort() { return _client->abort_multipart_upload(_ctx); }
+
+    operator bool() { return _ctx; }
+  };
+
+  MultipartUploadContext init_multipart_upload(std::string_view object) {
+    void* ctx = nullptr;
+    init_multipart_upload(object, &ctx);
+    return {this, ctx};
+  }
+
+  // prefix + objects are to be deleted
+  // no slash will be added after the prefix
+  virtual int delete_objects(const std::vector<std::string_view>& objects,
+                             std::string_view prefix = {}) = 0;
+
+  virtual int delete_object(std::string_view obj) = 0;
+
+  virtual int rename_object(std::string_view src_path,
+                            std::string_view dst_path,
+                            bool set_mime = false) = 0;
+
+  virtual int put_symlink(std::string_view obj, std::string_view target) = 0;
+
+  virtual int get_symlink(std::string_view obj, std::string& target) = 0;
+
+  virtual int get_object_meta(std::string_view obj, ObjectMeta& meta) = 0;
+
+  virtual void set_credentials(CredentialParameters&& credentials) = 0;
+};
+
+Client* new_oss_client(const ClientOptions& opt, Authenticator* auth);
+
+// if cache_ttl_secs is 0, no cache authenticator will be created.
+Client* new_oss_client(const ClientOptions& opt, uint32_t cache_ttl_secs = 60,
+                       CredentialParameters&& credentials = {});
+
+Authenticator* new_basic_oss_authenticator(
+    CredentialParameters&& credentials = {});
+
+// if cache_ttl_secs is 0, the original authenticator will be returned.
+Authenticator* new_cached_oss_authenticator(Authenticator* auth,
+                                            uint32_t cache_ttl_secs = 60);
+
+// one typical CustomAutheticator example
+/*class CustomAuthenticator : public Authenticator {
+  Authenticator* auth_ = nullptr;
+ public:
+  CustomAuthenticator(Authenticator* auth) : auth_(auth) {}
+
+  ~CustomAuthenticator() { delete auth_; }
+
+  virtual int sign(photon::net::http::Headers& headers,
+                   const SignParameters& params) override {
+    // add your own logic here
+    return auth_->sign(headers, params);
+  }
+
+  virtual const CredentialParameters* get_credentials() override {
+    // add your own logic here
+    return auth_->get_credentials();
+  }
+
+  virtual void set_credentials(CredentialParameters&& credentials) override {
+    auth_->set_credentials(std::move(credentials));
+  }
+};*/
+}  // namespace objstore
+}  // namespace photon

--- a/ecosystem/test/CMakeLists.txt
+++ b/ecosystem/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+<<<<<<< HEAD
 add_executable(test-ecosystem test.cpp test_simple_dom.cpp)
+=======
+add_executable(test-ecosystem test.cpp test_simple_dom.cpp test_redis.cpp test_oss_custom_headers.cpp)
+>>>>>>> dab1c19 (feat(oss): support custom headers on all OSS SDK requests (#1312) (#1347))
 target_link_libraries(test-ecosystem PRIVATE photon_shared)
 add_test(NAME test-ecosystem COMMAND $<TARGET_FILE:test-ecosystem>)

--- a/ecosystem/test/test_oss.cpp
+++ b/ecosystem/test/test_oss.cpp
@@ -1,0 +1,670 @@
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+#include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/common/checksum/crc64ecma.h>
+#include <photon/common/estring.h>
+#include <photon/photon.h>
+#include <photon/thread/thread.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <random>
+#include <algorithm>
+
+#include "../oss.h"
+
+DEFINE_string(ak, "", "OSS Access Key ID");
+DEFINE_string(sk, "", "OSS Access Key Secret");
+DEFINE_string(endpoint, "", "OSS Endpoint");
+DEFINE_string(bucket, "", "OSS Bucket Name");
+DEFINE_string(region, "", "OSS Region");
+
+using namespace photon::objstore;
+
+class BasicAuthOssTest : public ::testing::Test {
+ protected:
+  Client* client = nullptr;
+  virtual void CreateOssClient(const ClientOptions& opts) {
+    auto auth = new_basic_oss_authenticator({FLAGS_ak, FLAGS_sk, ""});
+    client = new_oss_client(opts, auth);
+    ASSERT_NE(client, nullptr) << "Failed to create OSS client";
+  }
+  void SetUp() override {
+    auto random_suffix =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    bucket_prefix_ = "test_prefix_" + std::to_string(random_suffix) + "/";
+
+    ClientOptions opts_;
+    opts_.bucket = FLAGS_bucket;
+    opts_.endpoint = FLAGS_endpoint;
+    opts_.max_list_ret_cnt = 2;
+
+    // v4 signature with non-empty region, otherwise v1 signature.
+    opts_.region = FLAGS_region;
+
+    if (random_suffix % 2) {
+      opts_.custom_headers = {{"x-custom-trace-id", "test-run-" + std::to_string(random_suffix)},
+                              {"x-oss-custom-client", "photon-test"}};
+    }
+
+    CreateOssClient(opts_);
+  }
+
+  void TearDown() override {
+    if (client && !bucket_prefix_.empty()) {
+      std::vector<std::string> objects;
+      auto cb = [&](const ListObjectsCBParameters& cb) {
+        objects.emplace_back(std::string(cb.key));
+        return 0;
+      };
+      int ret = client->list_objects(bucket_prefix_, cb);
+      ASSERT_EQ(ret, 0);
+
+      if (objects.size()) {
+        if (rand() % 2) {
+          client->delete_objects(
+              std::vector<std::string_view>(objects.begin(), objects.end()));
+        } else {
+          for (auto& obj : objects) {
+            ret = client->delete_object(obj);
+            ASSERT_EQ(ret, 0);
+          }
+        }
+        objects.clear();
+        ret = client->list_objects(bucket_prefix_, cb);
+        ASSERT_EQ(ret, 0);
+        ASSERT_EQ(objects.size(), 0);
+      }
+    }
+    if (client) delete client;
+  }
+
+  estring get_real_test_path(std::string_view suffix) {
+    estring path;
+    if (suffix.size() && suffix.front() == '/') suffix.remove_prefix(1);
+    path.appends(bucket_prefix_, suffix);
+    return path;
+  }
+
+  void list_objects();
+  void put_and_get_meta();
+  void copy_and_rename();
+  void append_and_get();
+  void multipart();
+  void symlink();
+  void batch_get_objects();
+  void upload_with_options();
+
+ private:
+  std::string bucket_prefix_;
+};
+
+class CachedAuthOssTest : public BasicAuthOssTest {
+ protected:
+  void CreateOssClient(const ClientOptions& opts) override {
+    auto auth = new_basic_oss_authenticator({FLAGS_ak, FLAGS_sk, ""});
+    auth = new_cached_oss_authenticator(auth, 3 /*ttl*/);
+    client = new_oss_client(opts, auth);
+    ASSERT_NE(client, nullptr) << "Failed to create OSS client";
+  }
+
+  void repeatedly_get();
+};
+
+class RandInvalidateCacheAuthenticator : public Authenticator {
+  Authenticator* auth_ = nullptr;
+
+ public:
+  RandInvalidateCacheAuthenticator(Authenticator* auth) : auth_(auth) {}
+  ~RandInvalidateCacheAuthenticator() { delete auth_; }
+  virtual int sign(photon::net::http::Headers& headers,
+                   const SignParameters& params) override {
+    auto new_params = params;
+    new_params.invalidate_cache = rand() % 2;
+    return auth_->sign(headers, new_params);
+  }
+
+  virtual void set_credentials(CredentialParameters&& credentials) override {
+    auth_->set_credentials(std::move(credentials));
+  }
+};
+
+class CustomCachedAuthOssTest : public CachedAuthOssTest {
+ protected:
+  void CreateOssClient(const ClientOptions& opts) override {
+    auto auth = new_basic_oss_authenticator({FLAGS_ak, FLAGS_sk, ""});
+    auth = new_cached_oss_authenticator(auth, 3 /*ttl*/);
+    client = new_oss_client(opts, new RandInvalidateCacheAuthenticator(auth));
+    ASSERT_NE(client, nullptr) << "Failed to create OSS client";
+  }
+};
+
+void BasicAuthOssTest::list_objects() {
+  std::vector<std::string> test_objects = {
+      // they are in lexicographic order
+      get_real_test_path("list-test/obj1.txt"),
+      get_real_test_path("list-test/obj2.txt"),
+      get_real_test_path("list-test/obj3.txt"),
+      get_real_test_path("list-test/obj4.txt"),
+      get_real_test_path("list-test/obj5.txt"),
+      get_real_test_path("list-test/ocomprefix/obj6.txt")};
+  auto com_prefix_key = get_real_test_path("list-test/ocomprefix/");
+
+  char buf[3] = {3};
+  iovec iov{buf, 3};
+  auto crc64 = crc64ecma(buf, 3, 0);
+  for (const auto& key : test_objects) {
+    int ret = client->put_object(key, &iov, 1, &crc64);
+    ASSERT_EQ(ret, 3);
+  }
+
+  struct ListObjectsInfo {
+    estring key;
+    estring etag;
+    size_t size;
+    time_t mtime;
+    bool is_com_prefix;
+    ListObjectsInfo(estring_view k, estring_view e, size_t s, time_t m,
+                    bool is_com)
+        : key(k), etag(e), size(s), mtime(m), is_com_prefix(is_com) {}
+  };
+  std::vector<ListObjectsInfo> listed_objects;
+  auto list_callback = [&](const ListObjectsCBParameters& params) {
+    listed_objects.emplace_back(params.key, params.etag, params.size,
+                                params.mtime, params.is_com_prefix);
+    return 0;
+  };
+
+  auto test_list_func = [&](auto list_fun) {
+    listed_objects.clear();
+    int ret =
+        list_fun(get_real_test_path("list-test/"), list_callback, false, 2);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(listed_objects.size(), test_objects.size());
+
+    for (size_t i = 0; i < listed_objects.size(); ++i) {
+      EXPECT_EQ(listed_objects[i].key, test_objects[i]);
+      EXPECT_FALSE(listed_objects[i].etag.empty());
+      EXPECT_FALSE(listed_objects[i].is_com_prefix);
+      EXPECT_EQ(listed_objects[i].size, 3);
+      EXPECT_NE(listed_objects[i].mtime, 0);
+    }
+
+    listed_objects.clear();
+    ret = list_fun(get_real_test_path("list-test/"), list_callback, true, 2);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(listed_objects.size(), test_objects.size());
+
+    for (size_t i = 0; i < listed_objects.size() - 1; ++i) {
+      EXPECT_EQ(listed_objects[i].key, test_objects[i]);
+      EXPECT_FALSE(listed_objects[i].etag.empty());
+      EXPECT_FALSE(listed_objects[i].is_com_prefix);
+      EXPECT_EQ(listed_objects[i].size, 3);
+      EXPECT_NE(listed_objects[i].mtime, 0);
+    }
+
+    EXPECT_TRUE(listed_objects.back().is_com_prefix);
+    EXPECT_EQ(listed_objects.back().key, com_prefix_key);
+  };
+
+  test_list_func([&](std::string_view prefix, ListObjectsCallback cb,
+                     bool delimiter, int max_keys) {
+    ListObjectsParameters params;
+    params.slash_delimiter = delimiter;
+    params.max_keys = max_keys;
+    params.ver = 2;
+    return client->list_objects(prefix, cb, params);
+  });
+  test_list_func([&](std::string_view prefix, ListObjectsCallback cb,
+                     bool delimiter, int max_keys) {
+    ListObjectsParameters params;
+    params.slash_delimiter = delimiter;
+    params.max_keys = max_keys;
+    params.ver = 1;
+    return client->list_objects(prefix, cb, params);
+  });
+
+  auto test_one_shot = [&](auto list_fun) {
+    listed_objects.clear();
+    std::string marker;
+    int ret = list_fun(get_real_test_path("list-test/"), list_callback, false,
+                       2, &marker);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(listed_objects.size(), 2);
+
+    ret = list_fun(get_real_test_path("list-test/"), list_callback, false, 2,
+                   &marker);
+    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(listed_objects.size(), 4);
+
+    for (size_t i = 0; i < listed_objects.size(); ++i) {
+      EXPECT_EQ(listed_objects[i].key, test_objects[i]);
+    }
+  };
+  test_one_shot([&](std::string_view prefix, ListObjectsCallback cb,
+                    bool delimiter, int max_keys, std::string* marker) {
+    ListObjectsParameters params;
+    params.slash_delimiter = delimiter;
+    params.max_keys = max_keys;
+    params.ver = 1;
+    return client->list_objects(prefix, cb, params, marker);
+  });
+  test_one_shot([&](std::string_view prefix, ListObjectsCallback cb,
+                    bool delimiter, int max_keys, std::string* marker) {
+    ListObjectsParameters params;
+    params.slash_delimiter = delimiter;
+    params.max_keys = max_keys;
+    params.ver = 2;
+    return client->list_objects(prefix, cb, params, marker);
+  });
+}
+
+void BasicAuthOssTest::put_and_get_meta() {
+  auto path = get_real_test_path("object_meta/testfile.unknown_suffix");
+  const size_t file_size = 1025;
+  char buf[file_size] = {3};
+  auto crc64 = crc64ecma(buf, file_size, 0);
+  iovec iov{buf, file_size};
+  int ret = client->put_object(path, &iov, 1, &crc64);
+  ASSERT_EQ(ret, file_size) << "Failed to upload object for metadata test";
+  crc64 += 1;
+  ret = client->put_object(path, &iov, 1, &crc64);
+  ASSERT_EQ(ret, -1) << "crc64 check did not work";
+
+  // todo: add crc64 comparison
+  ObjectHeaderMeta hmeta;
+  ret = client->head_object(path, hmeta);
+  ASSERT_EQ(ret, 0);
+  EXPECT_TRUE(hmeta.has_etag());
+  EXPECT_TRUE(hmeta.has_size());
+  EXPECT_TRUE(hmeta.has_mtime());
+  EXPECT_TRUE(hmeta.has_crc64());
+  EXPECT_TRUE(hmeta.has_storage_class());
+  EXPECT_TRUE(hmeta.has_type());
+  EXPECT_EQ(hmeta.size, file_size);
+  EXPECT_TRUE(!hmeta.etag.empty());
+  EXPECT_NE(hmeta.mtime, 0);
+  EXPECT_TRUE(hmeta.has_crc64());
+  EXPECT_TRUE(!hmeta.storage_class.empty());
+  EXPECT_TRUE(!hmeta.type.empty());
+
+  ObjectMeta meta;
+  ret = client->get_object_meta(path, meta);
+  ASSERT_EQ(ret, 0);
+  EXPECT_TRUE(meta.has_etag());
+  EXPECT_TRUE(meta.has_size());
+  EXPECT_TRUE(meta.has_mtime());
+  EXPECT_EQ(meta.size, file_size);
+  EXPECT_TRUE(!meta.etag.empty());
+  EXPECT_EQ(meta.mtime, hmeta.mtime);
+
+  ObjectHeaderMeta hmeta2;
+  char buf2[2];
+  iovec iov2{buf2, 2};
+  ret = client->get_object_range(path, &iov2, 1, file_size - 1, &hmeta2);
+  ASSERT_EQ(ret, 1);
+  /// From testing, get obj range will return all the following fileds.
+  EXPECT_EQ(hmeta2.flags, hmeta.flags);
+  EXPECT_EQ(hmeta2.size, hmeta.size);
+  EXPECT_EQ(hmeta2.crc64, hmeta.crc64);
+  EXPECT_EQ(hmeta2.mtime, hmeta.mtime);
+  EXPECT_EQ(hmeta2.storage_class, hmeta.storage_class);
+  EXPECT_EQ(hmeta2.crc64, hmeta.crc64);
+  EXPECT_EQ(hmeta2.etag, hmeta.etag);
+
+  auto expected_crc64 = hmeta2.crc64;
+  ret = client->put_object(path, &iov, 1, &expected_crc64);
+  ASSERT_EQ(ret, file_size);
+  expected_crc64 = hmeta2.crc64 + 1;
+  ret = client->put_object(path, &iov, 1, &expected_crc64);
+  ASSERT_EQ(ret, -1);
+}
+
+void BasicAuthOssTest::copy_and_rename() {
+  auto src = get_real_test_path("copy_and_rename_object/src.mp3");
+  auto dst = get_real_test_path("copy_and_rename_object/dst.mp4");
+
+  iovec iov{nullptr, 0};
+  int ret = client->put_object(src, &iov, 1);
+  ASSERT_EQ(ret, 0);
+  ret = client->copy_object(src, dst, false, true);
+  ASSERT_EQ(ret, 0);
+  ret = client->copy_object(src, dst, false, true);
+  ASSERT_EQ(ret, -1);  // overwrite is not allowed
+  ret = client->rename_object(src, dst);
+  ASSERT_EQ(ret, 0);
+}
+
+void BasicAuthOssTest::append_and_get() {
+  auto path = get_real_test_path("append_and_get/testfile");
+
+  char buf[2] = {'1', '2'};
+  iovec iov{buf, 2};
+  int ret = client->append_object(path, &iov, 1, 0);
+  ASSERT_EQ(ret, 2);
+  ret = client->append_object(path, &iov, 1, 2);
+  ASSERT_EQ(ret, 2);
+
+  char buf2[4];
+  iovec iov2{buf2, 4};
+  ret = client->get_object_range(path, &iov2, 1, 0);
+  ASSERT_EQ(ret, 4);
+  ASSERT_EQ(std::string(buf2, 4), "1212");
+}
+
+void BasicAuthOssTest::multipart() {
+  auto path = get_real_test_path("multipart_upload/testfile");
+
+  void* context = nullptr;
+  int ret = client->init_multipart_upload(path, &context);
+  ASSERT_EQ(ret, 0);
+  const size_t buf_size = 1048577;
+  uint64_t crc64 = 0;
+  for (int i = 0; i < 5; i++) {
+    char buf[buf_size] = {(char)i};
+    crc64 = crc64ecma(buf, buf_size, crc64);
+    iovec iov{buf, buf_size};
+
+    auto part_crc64 = crc64ecma(buf, buf_size, 0);
+    ret = client->upload_part(context, &iov, 1, i + 1, &part_crc64);
+    ASSERT_EQ(ret, buf_size);
+  }
+  ret = client->complete_multipart_upload(context, &crc64);
+  ASSERT_EQ(ret, 0);
+
+  ObjectMeta meta;
+  ret = client->get_object_meta(path, meta);
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(meta.size, buf_size * 5);
+
+  auto path4copy = get_real_test_path("multipart_upload/testfile_copy");
+  auto ctx = client->init_multipart_upload(path4copy);
+  if (!ctx) {
+    ASSERT_TRUE(false);
+  }
+  for (int i = 0; i < 5; i++) {
+    ret = ctx.copy(i * buf_size, buf_size, i + 1, path);
+    ASSERT_EQ(ret, 0);
+  }
+  ret = ctx.complete(nullptr);
+  ASSERT_EQ(ret, 0);
+
+  ObjectMeta meta_copyed;
+  ret = client->get_object_meta(path4copy, meta_copyed);
+  ASSERT_EQ(ret, 0);
+  EXPECT_EQ(meta.size, meta_copyed.size);
+  EXPECT_EQ(meta.etag, meta_copyed.etag);
+
+  auto path4abort = get_real_test_path("multipart_upload/testfile_abort");
+  ctx = client->init_multipart_upload(path4abort);
+  if (!ctx) {
+    ASSERT_TRUE(false);
+  }
+  for (int i = 0; i < 5; i++) {
+    ret = ctx.copy(i * buf_size, buf_size, i + 1, path);
+    ASSERT_EQ(ret, 0);
+  }
+  ret = ctx.abort();
+  ASSERT_EQ(ret, 0);
+}
+
+void BasicAuthOssTest::symlink() {
+  auto src = get_real_test_path("symlink/source");
+  auto target = "symlink/target";
+
+  int r = client->put_symlink(src, target);
+  ASSERT_EQ(r, 0);
+
+  std::string oss_target;
+  r = client->get_symlink(src, oss_target);
+  ASSERT_EQ(r, 0);
+
+  EXPECT_EQ(oss_target, target);
+
+  std::vector<std::string> objects;
+  auto cb = [&](const ListObjectsCBParameters& cb) {
+    objects.emplace_back(cb.key);
+    if (cb.type == "Symlink") return 0;
+    return -1;
+  };
+  int ret = client->list_objects(get_real_test_path("symlink/"), cb);
+  EXPECT_EQ(ret, 0);
+  ASSERT_EQ(objects.size(), 1);
+  EXPECT_EQ(objects[0], src);
+}
+
+void BasicAuthOssTest::batch_get_objects() {
+  int good_obj_cnt = 6, bad_obj_cnt = 3;
+  std::vector<std::string> good_objs;
+  std::vector<std::string> bad_objs;
+
+  const size_t file_size = 1024;
+  char test_data[file_size];
+  for (size_t i = 0; i < file_size; i++) {
+    test_data[i] = 'A' + (i % 26);
+  }
+  iovec iov{test_data, file_size};
+
+  for (int i = 0; i < good_obj_cnt; i++) {
+    auto src = get_real_test_path("batch_get_objects/good_testfile" +
+                                  std::to_string(i));
+    good_objs.push_back(src);
+
+    auto crc64 = crc64ecma(test_data, file_size, 0);
+    int ret = client->put_object(src, &iov, 1, &crc64);
+    ASSERT_EQ(ret, (int)file_size) << "Failed to upload test object " << i;
+  }
+
+  for (int i = 0; i < bad_obj_cnt; i++) {
+    auto src = get_real_test_path("batch_get_objects/bad_testfile" +
+                                  std::to_string(i));
+    bad_objs.push_back(src);
+  }
+
+  std::vector<GetObjectParameters> params_vec;
+  std::vector<char*> bufs(good_objs.size());
+  std::vector<struct iovec> iovs(good_objs.size());
+  DEFER(for (auto buf : bufs) { delete buf; });
+
+  for (size_t i = 0; i < good_objs.size(); i++) {
+    auto buf_size = (i == 0) ? (file_size + 1) : (file_size - i);
+
+    char* buffer = (char *)malloc(buf_size);
+    bufs[i] = buffer;
+    iovs[i] = {buffer, buf_size};
+
+    GetObjectParameters params;
+    params.offset = i;
+    params.iov = &iovs[i];
+    params.iovcnt = 1;
+    params.object = good_objs[i];
+    params_vec.push_back(params);
+  }
+
+  for (size_t i = 0; i < bad_objs.size(); i++) {
+    GetObjectParameters params;
+    params.object = bad_objs[i];
+    params_vec.push_back(params);
+
+    // no need to fill other information for bad objects
+  }
+
+  ObjectHeaderMeta hmeta;
+  if (good_obj_cnt > 0) {
+    params_vec[rand() % good_obj_cnt].meta = &hmeta;
+  }
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::shuffle(params_vec.begin(), params_vec.end(), gen);
+
+  int ret = client->batch_get_objects(params_vec);
+  ASSERT_EQ(ret, good_obj_cnt);
+
+  if (good_obj_cnt > 0) {
+    EXPECT_EQ(hmeta.size, file_size);
+    EXPECT_TRUE(!hmeta.etag.empty());
+    EXPECT_NE(hmeta.mtime, 0);
+    EXPECT_TRUE(hmeta.has_crc64());
+    EXPECT_TRUE(!hmeta.storage_class.empty());
+    EXPECT_TRUE(!hmeta.type.empty());
+    LOG_INFO("etag ` mtime ` crc64 ` storage_class ` type `", hmeta.etag,
+             hmeta.mtime, hmeta.crc64, hmeta.storage_class, hmeta.type);
+  }
+
+  for (auto& param : params_vec) {
+    if (param.iov) {
+      // good object 
+      if (param.iov->iov_len > file_size) {
+        ASSERT_EQ(param.result, file_size); // only valid data are returned
+      } else {
+        ASSERT_EQ(param.result, param.iov->iov_len);
+      }
+    }
+  }
+
+  for (size_t i = 0; i < good_objs.size(); i++) {
+    bool data_correct = true;
+    for (size_t j = i; j < file_size ; j++) {
+      if (bufs[i][j-i] != (char)('A' + (j % 26))) {
+        data_correct = false;
+        LOG_INFO("Data mismatch for good object ` at offset ` ` `", i, j, (int)bufs[i][j], ('A' + (j % 26)));
+        break;
+      }
+    }
+    ASSERT_TRUE(data_correct) << "Data mismatch for good object " << i;
+  }
+}
+
+void BasicAuthOssTest::upload_with_options() {
+  // put_object
+  auto path = get_real_test_path("upload_with_options/testfile");
+  const size_t file_size = 1025;
+  char buf[file_size] = {3};
+  auto crc64 = crc64ecma(buf, file_size, 0);
+  iovec iov{buf, file_size};
+
+  std::string etag;
+  ObjectUploadOptions opts{&crc64, &etag};
+  int ret = client->put_object(path, &iov, 1, opts);
+  ASSERT_EQ(ret, file_size) << "Failed to put object for upload test";
+
+  uint64_t invalid_crc64 = 0xdeadbeef;
+  ObjectUploadOptions opts_wrong_crc64{&invalid_crc64, &etag};
+  ret = client->put_object(path, &iov, 1, opts_wrong_crc64);
+  ASSERT_EQ(ret, -1) << "crc64 check did not work";
+
+  ObjectMeta meta;
+  ret = client->get_object_meta(path, meta);
+  ASSERT_EQ(ret, 0);
+  EXPECT_TRUE(meta.has_etag());
+  EXPECT_EQ(meta.etag, etag);
+
+  // append_object
+  path = get_real_test_path("upload_with_options/testfile.append");
+
+  ret = client->append_object(path, &iov, 1, 0, opts);
+  ASSERT_EQ(ret, file_size) << "Failed to append object for upload test";
+
+  ret = client->get_object_meta(path, meta);
+  ASSERT_EQ(ret, 0);
+  EXPECT_TRUE(meta.has_etag());
+  EXPECT_EQ(meta.etag, etag);
+
+  // multipart
+  path = get_real_test_path("upload_with_options/testfile.multipart");
+  void* context = nullptr;
+  ret = client->init_multipart_upload(path, &context);
+  ASSERT_EQ(ret, 0);
+
+  ret = client->upload_part(context, &iov, 1, 1, opts);
+  ASSERT_EQ(ret, file_size) << "Failed to upload object for upload test";
+
+  ret = client->complete_multipart_upload(context, opts);
+  ASSERT_EQ(ret, 0);
+
+  ret = client->get_object_meta(path, meta);
+  ASSERT_EQ(ret, 0);
+  EXPECT_TRUE(meta.has_etag());
+  EXPECT_EQ(meta.etag, etag);
+}
+
+void CachedAuthOssTest::repeatedly_get() {
+  std::vector<std::string> paths;
+  const size_t file_size = 1025;
+  char buf[file_size] = {2};
+  iovec iov{buf, file_size};
+  auto crc64 = crc64ecma(buf, file_size, 0);
+  for (int i = 0; i < 10; i++) {
+    auto path =
+        get_real_test_path("rput_and_get/testfile.suffix" + std::to_string(i));
+    int ret = client->put_object(path, &iov, 1, &crc64);
+    ASSERT_EQ(ret, file_size) << "Failed to upload object for metadata test";
+    paths.push_back(path);
+  }
+
+  for (size_t i = 0; i < 10; i++) {
+    for (size_t j = 0; j < paths.size(); j++) {
+      iov.iov_len = i + 1;
+      auto ret = client->get_object_range(paths[j], &iov, 1, i, nullptr);
+      EXPECT_EQ(ret, i + 1);
+    }
+  }
+
+  client->set_credentials({"invalid creds"});
+  LOG_INFO("creds invalidated");
+  iov.iov_len = 1;
+  auto ret = client->get_object_range(paths[0], &iov, 1, 0, nullptr);
+  EXPECT_EQ(ret, -1);
+  client->set_credentials({FLAGS_ak, FLAGS_sk});
+  ret = client->get_object_range(paths[0], &iov, 1, 0, nullptr);
+  EXPECT_EQ(ret, 1);
+}
+
+TEST_F(BasicAuthOssTest, list_objects) { list_objects(); }
+TEST_F(BasicAuthOssTest, multipart) { multipart(); }
+TEST_F(BasicAuthOssTest, append_and_get) { append_and_get(); }
+TEST_F(BasicAuthOssTest, put_and_get_meta) { put_and_get_meta(); }
+TEST_F(BasicAuthOssTest, copy_and_rename) { copy_and_rename(); }
+TEST_F(BasicAuthOssTest, symlink) { symlink(); }
+TEST_F(BasicAuthOssTest, batch_get_objects) { batch_get_objects(); }
+
+TEST_F(BasicAuthOssTest, upload_with_options) { upload_with_options(); }
+TEST_F(CachedAuthOssTest, listobjects) { list_objects(); }
+TEST_F(CachedAuthOssTest, multipart) { multipart(); }
+TEST_F(CachedAuthOssTest, append_and_get) { append_and_get(); }
+TEST_F(CachedAuthOssTest, put_and_get_meta) { put_and_get_meta(); }
+TEST_F(CachedAuthOssTest, copy_and_rename) { copy_and_rename(); }
+TEST_F(CachedAuthOssTest, repeatedly_get) { repeatedly_get(); }
+TEST_F(CachedAuthOssTest, symlink) { symlink(); }
+TEST_F(CachedAuthOssTest, batch_get_objects) { batch_get_objects(); }
+
+TEST_F(CachedAuthOssTest, upload_with_options) { upload_with_options(); }
+TEST_F(CustomCachedAuthOssTest, repeatedly_get) { repeatedly_get(); }
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_ak.empty() || FLAGS_sk.empty() || FLAGS_endpoint.empty() ||
+      FLAGS_bucket.empty()) {
+    std::cerr << "Error: All parameters (ak, sk, endpoint, bucket) are "
+                 "required! region is optional."
+              << std::endl;
+    std::cerr
+        << "Usage: " << argv[0]
+        << " --ak=<access_key_id> --sk=<access_key_secret> "
+        << "--endpoint=<endpoint> --bucket=<bucket_name> --region=<region>"
+        << std::endl;
+    gflags::ShowUsageWithFlags(argv[0]);
+    return 1;
+  }
+  photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+  DEFER(photon::fini());
+
+  return RUN_ALL_TESTS();
+}

--- a/ecosystem/test/test_oss_custom_headers.cpp
+++ b/ecosystem/test/test_oss_custom_headers.cpp
@@ -1,0 +1,170 @@
+#include <gtest/gtest.h>
+#include <photon/common/alog.h>
+#include <photon/common/estring.h>
+#include <photon/net/http/server.h>
+#include <photon/net/socket.h>
+#include <photon/photon.h>
+
+#include <photon/thread/thread.h>
+
+#include <map>
+#include <string>
+
+#include "../oss.h"
+
+using namespace photon::objstore;
+using namespace photon::net;
+using namespace photon::net::http;
+
+static std::map<std::string, std::string> g_captured_headers;
+static photon::mutex g_mutex;
+
+static int capture_handler(void*, Request& req, Response& resp,
+                           std::string_view) {
+  {
+    SCOPED_LOCK(g_mutex);
+    g_captured_headers.clear();
+    for (auto kv : req.headers) {
+      g_captured_headers[std::string(kv.first)] = std::string(kv.second);
+    }
+  }
+  char body[] = "x";
+  resp.set_result(200);
+  resp.headers.content_length(1);
+  resp.headers.insert("Content-Range", "bytes 0-0/1");
+  resp.write(body, 1);
+  return 0;
+}
+
+class NoopAuthenticator : public Authenticator {
+ public:
+  int sign(Headers& headers, const SignParameters& params) override {
+    return 0;
+  }
+  void set_credentials(CredentialParameters&& credentials) override {}
+};
+
+class FakeAuthenticator : public Authenticator {
+ public:
+  int sign(Headers& headers, const SignParameters& params) override {
+    headers.insert("Authorization", "OSS fake-ak:fake-sig");
+    headers.insert("Date", "Tue, 10 Jun 2026 00:00:00 GMT");
+    return 0;
+  }
+  void set_credentials(CredentialParameters&& credentials) override {}
+};
+
+class OssCustomHeaderTest : public ::testing::Test {
+ protected:
+  ISocketServer* tcp_server = nullptr;
+  HTTPServer* http_server = nullptr;
+
+  void SetUp() override {
+    photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+    tcp_server = new_tcp_socket_server();
+    tcp_server->timeout(1000UL * 1000);
+    tcp_server->bind_v4localhost();
+    tcp_server->listen();
+    http_server = new_http_server();
+    http_server->add_handler({nullptr, &capture_handler});
+    tcp_server->set_handler(http_server->get_connection_handler());
+    tcp_server->start_loop();
+  }
+
+  void TearDown() override {
+    delete http_server;
+    delete tcp_server;
+    photon::fini();
+  }
+
+  ClientOptions make_opts() {
+    ClientOptions opts;
+    opts.endpoint = "oss-test.example.com";
+    opts.bucket = "test-bucket";
+    opts.proxy = estring().appends("http://127.0.0.1:",
+                                   tcp_server->getsockname().port);
+    opts.retry_times = 0;
+    return opts;
+  }
+};
+
+TEST_F(OssCustomHeaderTest, custom_headers_are_sent) {
+  auto opts = make_opts();
+  opts.custom_headers = {{"x-custom-trace-id", "abc123"}};
+
+  auto client = new_oss_client(opts, new NoopAuthenticator());
+  ASSERT_NE(client, nullptr);
+  DEFER(delete client);
+
+  ObjectHeaderMeta meta;
+  client->head_object("test-obj", meta);
+
+  SCOPED_LOCK(g_mutex);
+  ASSERT_NE(g_captured_headers.find("x-custom-trace-id"),
+            g_captured_headers.end());
+  EXPECT_EQ(g_captured_headers["x-custom-trace-id"], "abc123");
+}
+
+TEST_F(OssCustomHeaderTest, keys_are_lowercased) {
+  auto opts = make_opts();
+  opts.custom_headers = {{"X-CUSTOM-UPPER", "val"}};
+
+  auto client = new_oss_client(opts, new NoopAuthenticator());
+  ASSERT_NE(client, nullptr);
+  DEFER(delete client);
+
+  ObjectHeaderMeta meta;
+  client->head_object("test-obj", meta);
+
+  SCOPED_LOCK(g_mutex);
+  EXPECT_EQ(g_captured_headers.count("X-CUSTOM-UPPER"), 0u);
+  ASSERT_NE(g_captured_headers.find("x-custom-upper"),
+            g_captured_headers.end());
+  EXPECT_EQ(g_captured_headers["x-custom-upper"], "val");
+}
+
+TEST_F(OssCustomHeaderTest, sdk_headers_override_custom) {
+  auto opts = make_opts();
+  opts.custom_headers = {{"x-oss-range-behavior", "custom-value"}};
+
+  auto client = new_oss_client(opts, new NoopAuthenticator());
+  ASSERT_NE(client, nullptr);
+  DEFER(delete client);
+
+  char buf[1];
+  iovec iov{buf, 1};
+  client->get_object_range("test-obj", &iov, 1, 0);
+
+  SCOPED_LOCK(g_mutex);
+  auto it = g_captured_headers.find("x-oss-range-behavior");
+  ASSERT_NE(it, g_captured_headers.end());
+  EXPECT_EQ(it->second, "standard");
+}
+
+TEST_F(OssCustomHeaderTest, case_insensitive_insert_prevents_override) {
+  auto opts = make_opts();
+  opts.custom_headers = {{"X-OSS-RANGE-BEHAVIOR", "custom-value"},
+                         {"authoriZation", "custom-auth"},
+                         {"dAte", "custom-date"}};
+
+  auto client = new_oss_client(opts, new FakeAuthenticator());
+  ASSERT_NE(client, nullptr);
+  DEFER(delete client);
+
+  char buf[1];
+  iovec iov{buf, 1};
+  client->get_object_range("test-obj", &iov, 1, 0);
+
+  SCOPED_LOCK(g_mutex);
+  auto it = g_captured_headers.find("x-oss-range-behavior");
+  ASSERT_NE(it, g_captured_headers.end());
+  EXPECT_EQ(it->second, "standard");
+
+  auto auth_it = g_captured_headers.find("Authorization");
+  ASSERT_NE(auth_it, g_captured_headers.end());
+  EXPECT_EQ(auth_it->second, "OSS fake-ak:fake-sig");
+
+  auto date_it = g_captured_headers.find("Date");
+  ASSERT_NE(date_it, g_captured_headers.end());
+  EXPECT_EQ(date_it->second, "Tue, 10 Jun 2026 00:00:00 GMT");
+}


### PR DESCRIPTION
> feat(oss): support custom headers on all OSS SDK requests (#1312) (#1347)

* feat(oss): support custom headers on all OSS SDK requests

Allow users to configure custom header key-value pairs in ClientOptions
that are automatically attached to every request. Keys are lowercased
once at construction time. SDK-internal headers take precedence over
custom headers via first-writer-wins insert semantics.

* test(oss): randomly attach custom headers in integration tests

Co-authored-by: zhenjiaseu <zhenjiaseu@gmail.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.