### PR TITLE
[Backport][main to 0.9] | Fix FstackDpdkSocketServer hidden do_accept overloads (#1354) 

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -748,6 +748,8 @@ public:
     }
 
 protected:
+    using KernelSocketServer::do_accept;
+
     KernelSocketStream* create_stream(int fd) override {
         return new FstackDpdkSocketStream(fd);
     }


### PR DESCRIPTION
> Fix FstackDpdkSocketServer hidden do_accept overloads (#1354)

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.