### PR TITLE
[Backport][main to 0.9] | [Pick][0.8 to 0.9] | FIX: RingChannel signals and close send/recv notify race (#1239)  (#1274) (#1340) 

### DIFF
--- a/thread/test/CMakeLists.txt
+++ b/thread/test/CMakeLists.txt
@@ -54,6 +54,10 @@ add_executable(test-workpool-fanout test-workpool-fanout.cpp)
 target_link_libraries(test-workpool-fanout PRIVATE photon_shared ${GOOGLETEST_GTEST_MAIN_LIBRARIES})
 add_test(NAME test-workpool-fanout COMMAND $<TARGET_FILE:test-workpool-fanout>)
 
+add_executable(test-workpool-fanout test-workpool-fanout.cpp)
+target_link_libraries(test-workpool-fanout PRIVATE photon_shared ${GOOGLETEST_GTEST_MAIN_LIBRARIES})
+add_test(NAME test-workpool-fanout COMMAND $<TARGET_FILE:test-workpool-fanout>)
+
 add_executable(test-sleepq-stale-idx test-sleepq-stale-idx.cpp)
 target_link_libraries(test-sleepq-stale-idx PRIVATE photon_shared)
 add_test(NAME test-sleepq-stale-idx COMMAND $<TARGET_FILE:test-sleepq-stale-idx>)


### PR DESCRIPTION
> [Pick][0.8 to 0.9] | FIX: RingChannel signals and close send/recv notify race (#1239)  (#1274) (#1340)

* FIX: RingChannel signals and close send/recv notify race (#1239)

* FIX: RingChannel queue_sem may got too many signals leads to high CPU consuming

* more tests

* fix conflict

---------

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.