### PR TITLE
[Backport][0.9 to 0.8] | Fix missing continue in epoll event loops and dead-code UB (#1277) (#1345) 

### DIFF
--- a/io/epoll-ng.cpp
+++ b/io/epoll-ng.cpp
@@ -117,6 +117,7 @@ public:
                         LOG_ERROR_RETURN(err.no, , "epoll_wait() failed ", err);
                     timeout = sat_sub(timeout, cool_down_ms);
                     cool_down_ms *= 2;
+                    continue;
                 }
                 remains += ret;
                 return;

--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -218,6 +218,7 @@ ok:     entry.interests |= eint;
                     LOG_ERROR_RETURN(err.no, -1, "epoll_wait() failed ", err);
                 timeout = sat_sub(timeout, cool_down_ms);
                 cool_down_ms *= 2;
+                continue;
             }
             return _events_remain = ret;
         }

--- a/io/events_map.h
+++ b/io/events_map.h
@@ -53,6 +53,7 @@ struct EventsMap {
         if (event == EV_KEY::EV_READ) return EV_UNDERLAY::EV_READ;
         if (event == EV_KEY::EV_WRITE) return EV_UNDERLAY::EV_WRITE;
         if (event == EV_KEY::EV_ERR) return EV_UNDERLAY::EV_ERR;
+        return 0;
     }
 };
 


### PR DESCRIPTION
> Fix missing continue in epoll event loops and dead-code UB (#1277) (#1345)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.