### PR TITLE
[Backport][main to 0.9] | Fix HTTP range parsing, cookie jar, and body writev cap (#1288) 

### DIFF
--- a/net/http/body.cpp
+++ b/net/http/body.cpp
@@ -259,11 +259,19 @@ public:
 
     virtual ssize_t writev(const struct iovec *iov, int iovcnt) override {
         auto count = iovector_view((struct iovec*)iov, iovcnt).sum();
-        if (m_cnt + count > m_size) LOG_WARN("data size overflow");
-        ssize_t wc = std::min(count, m_size - m_cnt);
-        if (m_stream->writev(iov, iovcnt) != wc) return -1;
-        m_cnt += wc;
-        return wc;
+        if (m_cnt + count > m_size) {
+            LOG_WARN("data size overflow");
+            ssize_t wc = m_size - m_cnt;
+            SmartCloneIOV<32> ciovec(iov, iovcnt);
+            iovector_view view(ciovec.ptr, iovcnt);
+            view.shrink_to(wc);
+            if (m_stream->writev(view.iov, view.iovcnt) != wc) return -1;
+            m_cnt += wc;
+            return wc;
+        }
+        if (m_stream->writev(iov, iovcnt) != (ssize_t)count) return -1;
+        m_cnt += count;
+        return count;
     }
 
     virtual uint64_t timeout() const override {

--- a/net/http/cookie_jar.cpp
+++ b/net/http/cookie_jar.cpp
@@ -124,6 +124,7 @@ public:
     int set_cookies_to_headers(Request* request) {
         uint64_t now = time(0);
         auto& h = request->headers;
+        bool first = true;
         for (auto it = m_cookies.begin(); it != m_cookies.end(); ) {
             if (now > it->second.expire) {
                 it = m_cookies.erase(it);
@@ -135,9 +136,10 @@ public:
             auto d = it->second.get_domain();
             if (!d.empty() && d != request->host()) continue;
             size_t size = it->first.size() + 1 + it->second.value.size();
-            if (it == m_cookies.begin()) {
+            if (first) {
                 if (h.space_remain() < size + 10+6) return -1;
                 h.insert("Cookie", "");
+                first = false;
             } else {
                 if (h.space_remain() < size + 2+6) return -1;
                 h.value_append("; ");

--- a/net/http/headers.cpp
+++ b/net/http/headers.cpp
@@ -190,7 +190,7 @@ std::pair<ssize_t, ssize_t> Headers::range() const {
     auto range = found.second();
     auto eq_pos = range.find("=");
     auto dash_pos = range.find("-");
-    auto start_sv = estring_view(range.substr(eq_pos + 1, dash_pos - eq_pos + 1));
+    auto start_sv = estring_view(range.substr(eq_pos + 1, dash_pos - eq_pos - 1));
     auto end_sv = estring_view(range.substr(dash_pos + 1));
     auto start = start_sv.to_uint64();
     auto end = end_sv.to_uint64();


### PR DESCRIPTION
> Fix HTTP range parsing, cookie jar, and body writev cap (#1288)

* Fix HTTP Range parsing, cookie header corruption, and writev cap

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

* Address review: move wc calculation into branches

- Only clone/shrink iovec in overflow path
- Calculate wc separately in each branch to avoid extra branching
- Fixes sign comparison warning

---------

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.