### PR TITLE
[Backport][main to 0.9] | Fix TLS null ctx crash, OpenSSL leaks, and curl init (#1285) 

### DIFF
--- a/net/curl.cpp
+++ b/net/curl.cpp
@@ -161,7 +161,10 @@ public:
         : loop(new_event_loop({this, &cURLLoop::wait_fds},
                               {this, &cURLLoop::on_poll})) {}
 
-    ~cURLLoop() override { delete loop; }
+    ~cURLLoop() override {
+        loop->stop();
+        delete loop;
+    }
 
     void start() { loop->async_run(); }
 
@@ -230,6 +233,7 @@ class CurlResetHandle : public ResetHandle {
      }
 };
 static thread_local CurlResetHandle *reset_handler = nullptr;
+void libcurl_fini();
 
 int libcurl_init(long flags, long pipelining, long maxconn) {
     if (cctx.g_loop == nullptr) {
@@ -241,16 +245,19 @@ int libcurl_init(long flags, long pipelining, long maxconn) {
             new photon::Timer(-1UL, {nullptr, &on_timer}, true, 8UL * 1024 * 1024);
         if (!cctx.g_timer)
             LOG_ERROR_RETURN(EFAULT, -1, "failed to create photon timer");
+        DEFER(if (!cctx.g_libcurl_multi) libcurl_fini());
 
-        if (global_initialized != CURLE_OK)
+        if (global_initialized != CURLE_OK) {
             LOG_ERROR_RETURN(EIO, -1, "CURL global init error: ",
                             curl_easy_strerror(global_initialized));
+        }
 
         LOG_DEBUG("libcurl version ", curl_version());
 
         cctx.g_libcurl_multi = curl_multi_init();
-        if (cctx.g_libcurl_multi == nullptr)
+        if (cctx.g_libcurl_multi == nullptr) {
             LOG_ERROR_RETURN(EIO, -1, "failed to init libcurl-multi");
+        }
 
         curl_multi_setopt(cctx.g_libcurl_multi, CURLMOPT_SOCKETFUNCTION, sock_cb);
         curl_multi_setopt(cctx.g_libcurl_multi, CURLMOPT_TIMERFUNCTION, timer_cb);
@@ -272,7 +279,6 @@ int libcurl_init(long flags, long pipelining, long maxconn) {
 void libcurl_fini() {
     delete cctx.g_timer;
     cctx.g_timer = nullptr;
-    cctx.g_loop->stop();
     delete cctx.g_loop;
     cctx.g_loop = nullptr;
     delete cctx.g_poller;

--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -121,7 +121,7 @@ public:
         ctx = SSL_CTX_new(method);
         if (ctx == nullptr) {
             ERR_error_string_n(ERR_get_error(), errbuf, MAX_ERRSTRING_SIZE);
-            LOG_ERROR(0, -1, "Failed to initial TLS: ", errbuf);
+            LOG_ERROR_RETURN(0, , "Failed to initial TLS: ", errbuf);
         }
         SSL_CTX_set_ecdh_auto(ctx, 1);
     }
@@ -144,6 +144,11 @@ public:
         auto bio = BIO_new_mem_buf((void*)cert_str, -1);
         DEFER(BIO_free(bio));
         auto cert = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
+        if (cert == nullptr) {
+            ERR_error_string_n(ERR_get_error(), errbuf, MAX_ERRSTRING_SIZE);
+            LOG_ERROR_RETURN(0, -1, "Failed to read X509 cert: ", errbuf);
+        }
+        DEFER(X509_free(cert));
         auto ret = SSL_CTX_use_certificate(ctx, cert);
         if (ret != 1) {
             ERR_error_string_n(ERR_get_error(), errbuf, MAX_ERRSTRING_SIZE);
@@ -162,6 +167,11 @@ public:
         DEFER(BIO_free(bio));
         auto key =
             PEM_read_bio_PrivateKey(bio, nullptr, &pem_password_cb, this);
+        if (key == nullptr) {
+            ERR_error_string_n(ERR_get_error(), errbuf, MAX_ERRSTRING_SIZE);
+            LOG_ERROR_RETURN(0, -1, "Failed to read private key: ", errbuf);
+        }
+        DEFER(EVP_PKEY_free(key));
         auto ret = SSL_CTX_use_PrivateKey(ctx, key);
         if (ret != 1) {
             ERR_error_string_n(ERR_get_error(), errbuf, MAX_ERRSTRING_SIZE);
@@ -270,16 +280,17 @@ public:
     };
 
     static BIO_METHOD* BIO_s_sockstream() {
-        static std::unique_ptr<BIO_METHOD, BIOMethodDeleter> meth(
-            BIO_meth_new(BIO_TYPE_SOURCE_SINK, "BIO_PHOTON_SOCKSTREAM"));
-        auto ret = meth.get();
-        BIO_meth_set_write(ret, &TLSSocketStream::ssbio_bwrite);
-        BIO_meth_set_read(ret, &TLSSocketStream::ssbio_bread);
-        BIO_meth_set_puts(ret, &TLSSocketStream::ssbio_bputs);
-        BIO_meth_set_ctrl(ret, &TLSSocketStream::ssbio_ctrl);
-        BIO_meth_set_create(ret, &TLSSocketStream::ssbio_create);
-        BIO_meth_set_destroy(ret, &TLSSocketStream::ssbio_destroy);
-        return ret;
+        static std::unique_ptr<BIO_METHOD, BIOMethodDeleter> meth([] {
+            auto m = BIO_meth_new(BIO_TYPE_SOURCE_SINK, "BIO_PHOTON_SOCKSTREAM");
+            BIO_meth_set_write(m, &TLSSocketStream::ssbio_bwrite);
+            BIO_meth_set_read(m, &TLSSocketStream::ssbio_bread);
+            BIO_meth_set_puts(m, &TLSSocketStream::ssbio_bputs);
+            BIO_meth_set_ctrl(m, &TLSSocketStream::ssbio_ctrl);
+            BIO_meth_set_create(m, &TLSSocketStream::ssbio_create);
+            BIO_meth_set_destroy(m, &TLSSocketStream::ssbio_destroy);
+            return m;
+        }());
+        return meth.get();
     }
 
     static ISocketStream* get_bio_sockstream(BIO* b) {


### PR DESCRIPTION
> Fix TLS null ctx crash, OpenSSL leaks, and curl init (#1285)

* Fix TLS null ctx crash, OpenSSL resource leaks, and curl init

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

* Fix TLS null ctx crash, OpenSSL resource leaks, and curl init

* Address review: use LOG_ERROR_RETURN and DEFER

- tls-stream.cpp: Replace LOG_ERROR + return with LOG_ERROR_RETURN
- curl.cpp: Use DEFER for cleanup on init failure instead of separate function

---------

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.