### PR TITLE
[Backport][0.9 to 0.8] | Fix fd leak in accept() when setsockopt fails (#1248) (#1330) 

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -359,6 +359,7 @@ public:
             return nullptr;
         }
         if (m_opts.setsockopt(cfd) != 0) {
+            ::close(cfd);
             return nullptr;
         }
         return create_stream(cfd);


### PR DESCRIPTION
> Fix fd leak in accept() when setsockopt fails (#1248) (#1330)

When KernelSocketServer::accept() successfully accepts a connection
but setsockopt() subsequently fails, the accepted fd was leaked.
Added ::close(cfd) on the error path.

Co-authored-by: Jiangtian Feng <jiangtianf97@163.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.