### PR TITLE
[Backport][0.9 to 0.8] | Fix HTTP range parsing, cookie jar, and body writev cap (#1288) (#1370) 

### DIFF
--- a/net/http/body.cpp
+++ b/net/http/body.cpp
@@ -258,11 +258,19 @@ public:
 
     virtual ssize_t writev(const struct iovec *iov, int iovcnt) override {
         auto count = iovector_view((struct iovec*)iov, iovcnt).sum();
-        if (m_cnt + count > m_size) LOG_WARN("data size overflow");
-        ssize_t wc = std::min(count, m_size - m_cnt);
-        if (m_stream->writev(iov, iovcnt) != wc) return -1;
-        m_cnt += wc;
-        return wc;
+        if (m_cnt + count > m_size) {
+            LOG_WARN("data size overflow");
+            ssize_t wc = m_size - m_cnt;
+            SmartCloneIOV<32> ciovec(iov, iovcnt);
+            iovector_view view(ciovec.ptr, iovcnt);
+            view.shrink_to(wc);
+            if (m_stream->writev(view.iov, view.iovcnt) != wc) return -1;
+            m_cnt += wc;
+            return wc;
+        }
+        if (m_stream->writev(iov, iovcnt) != (ssize_t)count) return -1;
+        m_cnt += count;
+        return count;
     }
 
 protected:

--- a/net/http/cookie_jar.cpp
+++ b/net/http/cookie_jar.cpp
@@ -80,7 +80,6 @@ public:
     }
 
     int set_cookies_to_headers(Request* request) {
-<<<<<<< HEAD
         bool first_kv = true;
         vector<string_view> eliminate;
         if (request->headers.insert("Cookie", "") != 0) return -1;
@@ -100,33 +99,6 @@ public:
         }
         for (auto key : eliminate) {
             m_kv.erase(key);
-=======
-        uint64_t now = time(0);
-        auto& h = request->headers;
-        bool first = true;
-        for (auto it = m_cookies.begin(); it != m_cookies.end(); ) {
-            if (now > it->second.expire) {
-                it = m_cookies.erase(it);
-                continue;
-            }
-            DEFER(++it);
-            if (!request->secure() && starts_with(it->first, "__Secure-")) continue;
-            if (!starts_with(request->abs_path(), it->second.get_path())) continue;
-            auto d = it->second.get_domain();
-            if (!d.empty() && d != request->host()) continue;
-            size_t size = it->first.size() + 1 + it->second.value.size();
-            if (first) {
-                if (h.space_remain() < size + 10+6) return -1;
-                h.insert("Cookie", "");
-                first = false;
-            } else {
-                if (h.space_remain() < size + 2+6) return -1;
-                h.value_append("; ");
-            }
-            h.value_append(it->first);
-            h.value_append("=");
-            h.value_append(it->second.get_value());
->>>>>>> 4aecbb9 (Fix HTTP range parsing, cookie jar, and body writev cap (#1288) (#1370))
         }
         return 0;
     }

--- a/net/http/cookie_jar.cpp
+++ b/net/http/cookie_jar.cpp
@@ -80,6 +80,7 @@ public:
     }
 
     int set_cookies_to_headers(Request* request) {
+<<<<<<< HEAD
         bool first_kv = true;
         vector<string_view> eliminate;
         if (request->headers.insert("Cookie", "") != 0) return -1;
@@ -99,6 +100,33 @@ public:
         }
         for (auto key : eliminate) {
             m_kv.erase(key);
+=======
+        uint64_t now = time(0);
+        auto& h = request->headers;
+        bool first = true;
+        for (auto it = m_cookies.begin(); it != m_cookies.end(); ) {
+            if (now > it->second.expire) {
+                it = m_cookies.erase(it);
+                continue;
+            }
+            DEFER(++it);
+            if (!request->secure() && starts_with(it->first, "__Secure-")) continue;
+            if (!starts_with(request->abs_path(), it->second.get_path())) continue;
+            auto d = it->second.get_domain();
+            if (!d.empty() && d != request->host()) continue;
+            size_t size = it->first.size() + 1 + it->second.value.size();
+            if (first) {
+                if (h.space_remain() < size + 10+6) return -1;
+                h.insert("Cookie", "");
+                first = false;
+            } else {
+                if (h.space_remain() < size + 2+6) return -1;
+                h.value_append("; ");
+            }
+            h.value_append(it->first);
+            h.value_append("=");
+            h.value_append(it->second.get_value());
+>>>>>>> 4aecbb9 (Fix HTTP range parsing, cookie jar, and body writev cap (#1288) (#1370))
         }
         return 0;
     }

--- a/net/http/headers.cpp
+++ b/net/http/headers.cpp
@@ -184,7 +184,7 @@ std::pair<ssize_t, ssize_t> Headers::range() const {
     auto range = found.second();
     auto eq_pos = range.find("=");
     auto dash_pos = range.find("-");
-    auto start_sv = estring_view(range.substr(eq_pos + 1, dash_pos - eq_pos + 1));
+    auto start_sv = estring_view(range.substr(eq_pos + 1, dash_pos - eq_pos - 1));
     auto end_sv = estring_view(range.substr(dash_pos + 1));
     auto start = start_sv.to_uint64();
     auto end = end_sv.to_uint64();


### PR DESCRIPTION
> Fix HTTP range parsing, cookie jar, and body writev cap (#1288) (#1370)

* Fix HTTP Range parsing, cookie header corruption, and writev cap



* Address review: move wc calculation into branches

- Only clone/shrink iovec in overflow path
- Calculate wc separately in each branch to avoid extra branching
- Fixes sign comparison warning

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.