### PR TITLE
[Backport][0.9 to 0.8] | fix(cache): skip 4K alignment for map path in queryRefillRange (#1353) (#1361) 

### DIFF
--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -9,7 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
+<<<<<<< HEAD
       options: --cpus 4 --privileged
+=======
+      options: --cpus 4 --privileged --shm-size 512m
+>>>>>>> 2b7fabf (fix(cache): skip 4K alignment for map path in queryRefillRange (#1353) (#1361))
     steps:
       - uses: szenius/set-timezone@v2.0
         with:

--- a/fs/cache/full_file_cache/cache_store.cpp
+++ b/fs/cache/full_file_cache/cache_store.cpp
@@ -1,0 +1,278 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "cache_store.h"
+
+#include <sys/stat.h>
+#include "sys/statvfs.h"
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include <photon/common/alog.h>
+#include <photon/common/alog-audit.h>
+#include <photon/fs/fiemap.h>
+#include <photon/fs/filesystem.h>
+#include <photon/common/iovector.h>
+#include "cache_pool.h"
+
+
+
+namespace photon {
+namespace fs {
+
+const uint64_t kDiskBlockSize = 512; // stat(2)
+constexpr int kFieExtentSize = 1000;
+const int kBlockSize = 4 * 1024;
+
+FileCacheStore::FileCacheStore(photon::fs::ICachePool* cachePool, IFile* localFile,
+  size_t refillUnit, FileIterator iterator)
+    : cachePool_(static_cast<FileCachePool*>(cachePool)),
+      localFile_(localFile),
+      refillUnit_(refillUnit),
+      iterator_(iterator),
+      fiemapSupported_(cachePool_->fiemapSupported()) {
+  if (!fiemapSupported_) {
+    rebuildFilledRanges();
+  }
+}
+
+FileCacheStore::~FileCacheStore() {
+  delete localFile_;  //  will close file
+  cachePool_->removeOpenFile(iterator_);
+}
+
+ICacheStore::try_preadv_result FileCacheStore::try_preadv2(const struct iovec *iov, int iovcnt,
+                                                           off_t offset, int flags) {
+  photon::scoped_rwlock rl(rw_lock_, photon::RLOCK);
+  return this->ICacheStore::try_preadv2(iov, iovcnt, offset, flags);
+}
+
+ssize_t FileCacheStore::do_preadv2(const struct iovec *iov, int iovcnt, off_t offset, int flags) {
+  // TODO(suoshi.yf): maybe a new interface for updating lru is better for avoiding
+  // multiple cacheStore preadvs but cacheFile preadv only once
+  ssize_t ret = 0;
+  cachePool_->updateLru(iterator_);
+  SCOPE_AUDIT_THRESHOLD(1UL * 1000, "file:read", AU_FILEOP("", offset, ret));
+  ret = localFile_->preadv(iov, iovcnt, offset);
+  return ret;
+}
+
+ssize_t FileCacheStore::do_pwritev(const struct iovec *iov, int iovcnt, off_t offset)
+{
+  ssize_t ret;
+  iovector_view view((iovec*)iov, iovcnt);
+  auto lruEntry = iterator_->second.get();
+  photon::scoped_rwlock rl(rw_lock_, photon::RLOCK);
+  if (!lruEntry->truncate_done) {
+    // May repeated ftruncate() here, but it doesn't matter
+    ret = localFile_->ftruncate(actual_size_);
+    if (ret) {
+      LOG_ERRNO_RETURN(0, -1, "failed to truncate media file: ", VALUE(ret));
+    }
+    lruEntry->truncate_done = true;
+  }
+  ScopedRangeLock lock(rangeLock_, offset, view.sum());
+  SCOPE_AUDIT_THRESHOLD(10UL * 1000, "file:write", AU_FILEOP("", offset, ret));
+  ret = localFile_->pwritev(iov, iovcnt, offset);
+  if (ret > 0 && !fiemapSupported_) {
+    addFilledRange(offset, ret);
+  }
+  return ret;
+}
+
+ssize_t FileCacheStore::do_pwritev2(const struct iovec *iov, int iovcnt, off_t offset, int flags) {
+  if (cacheIsFull()) {
+    errno = ENOSPC;
+    return -1;
+  }
+
+  auto ret = do_pwritev(iov, iovcnt, offset);
+  if (ret < 0 && ENOSPC == errno) {
+    cachePool_->forceRecycle();
+  }
+
+  if (ret > 0) {
+    struct stat st = {};
+    auto err = localFile_->fstat(&st);
+    if (err) {
+      LOG_ERRNO_RETURN(0, ret, "fstat failed")
+    }
+    cachePool_->updateLru(iterator_);
+    cachePool_->updateSpace(iterator_, kDiskBlockSize * st.st_blocks);
+  }
+  return ret;
+}
+
+std::pair<off_t, size_t> FileCacheStore::queryRefillRange(off_t offset, size_t size) {
+  ScopedRangeLock lock(rangeLock_, offset, size);
+
+  if (!fiemapSupported_) {
+    return queryRefillRangeByMap(offset, size);
+  }
+
+  off_t alignLeft = align_down(offset, kBlockSize);
+  off_t alignRight = align_up(offset + size, kBlockSize);
+  ReadRequest request{alignLeft, static_cast<size_t>(alignRight - alignLeft)};
+
+  struct fiemap_t<kFieExtentSize> fie(request.offset, request.size);
+  fie.fm_mapped_extents = 0;
+
+  if (request.size > 0) { //  fiemap cannot handle size zero.
+    auto ok = localFile_->fiemap(&fie);
+    if (ok != 0) {
+      LOG_ERRNO_RETURN(0, std::make_pair(-1, 0),
+                       "media fiemap failed : `, offset : `, size : `",
+                       ok, request.offset, request.size);
+    }
+    if (fie.fm_mapped_extents >= kFieExtentSize) { //TODO: qisheng.ds
+                                                   //it's supposed to be solved by
+                                                   //get fie extents twice,
+                                                   //but just do not concern much
+                                                   //about it rightnow.
+      LOG_ERROR_RETURN(EINVAL, std::make_pair(-1, 0),
+                       "read size is too big : `", request.size);
+    }
+  }
+
+  uint64_t holeStart = request.offset;
+  uint64_t holeEnd = request.offset + request.size;
+
+  for (ssize_t i = (ssize_t)(fie.fm_mapped_extents) - 1; i >= 0; i--) {
+    auto& extent = fie.fm_extents[i];
+    if ((extent.fe_flags == FIEMAP_EXTENT_UNKNOWN) || (extent.fe_flags == FIEMAP_EXTENT_UNWRITTEN)) continue;
+      if (extent.fe_logical < holeEnd){
+        if (extent.fe_logical_end() >= holeEnd){
+          holeEnd = extent.fe_logical;
+        } else break;
+      }
+  }
+
+  for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
+    auto& extent = fie.fm_extents[i];
+    if ((extent.fe_flags == FIEMAP_EXTENT_UNKNOWN) || (extent.fe_flags == FIEMAP_EXTENT_UNWRITTEN)) continue;
+      if (extent.fe_logical_end() > holeStart){
+        if (extent.fe_logical <= holeStart){
+          holeStart = extent.fe_logical_end();
+        } else break;
+      }
+  }
+
+  if (holeStart >= holeEnd) return std::make_pair(0, 0);
+  // CacheMiss
+  auto left = align_down(holeStart, refillUnit_);
+  auto right = align_up(holeEnd, refillUnit_);
+  return std::make_pair(left, right - left);
+}
+
+int FileCacheStore::set_quota(size_t quota) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int FileCacheStore::stat(CacheStat* stat) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int FileCacheStore::evict(off_t offset, size_t count, int flags) {
+  int ret;
+  if (static_cast<size_t>(-1) == count) {
+    ret = localFile_->ftruncate(offset);
+  } else {
+    #ifndef FALLOC_FL_KEEP_SIZE
+    #define FALLOC_FL_KEEP_SIZE     0x01 /* default is extend size */
+    #endif
+    #ifndef FALLOC_FL_PUNCH_HOLE
+    #define FALLOC_FL_PUNCH_HOLE	0x02 /* de-allocates range */
+    #endif
+    int mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
+    ret = localFile_->fallocate(mode, offset, count);
+  }
+
+  if (ret == 0 && !fiemapSupported_) {
+    removeFilledRange(offset, count);
+  }
+  return ret;
+}
+
+int FileCacheStore::fstat(struct stat *buf) {
+  return localFile_->fstat(buf);
+}
+
+bool FileCacheStore::cacheIsFull() {
+  return cachePool_->isFull();
+}
+
+std::pair<off_t, size_t> FileCacheStore::queryRefillRangeByMap(off_t offset, size_t size) {
+  std::pair<off_t, off_t> hole;
+  {
+    SCOPED_LOCK(filledRangesLock_);
+    hole = filledRanges_.queryRefillRange(offset, offset + size);
+  }
+  if (hole.first == 0 && hole.second == 0) return {0, 0};
+  auto left = align_down(hole.first, refillUnit_);
+  auto right = align_up(hole.second, refillUnit_);
+  return {left, right - left};
+}
+
+void FileCacheStore::addFilledRange(off_t offset, size_t size) {
+  if (size == 0) return;
+  SCOPED_LOCK(filledRangesLock_);
+  filledRanges_.addRange(offset, offset + size);
+}
+
+void FileCacheStore::removeFilledRange(off_t offset, size_t count) {
+  SCOPED_LOCK(filledRangesLock_);
+  if (count == static_cast<size_t>(-1)) {
+    filledRanges_.removeFrom(offset);
+  } else {
+    filledRanges_.removeRange(offset, offset + count);
+  }
+}
+
+void FileCacheStore::rebuildFilledRanges() {
+  // Note: we only hold filledRangesLock_ around the in-memory map mutations.
+  // addFilledRange already takes the lock internally.
+  {
+    SCOPED_LOCK(filledRangesLock_);
+    filledRanges_.clear();
+  }
+  // Skip rebuild on empty/new files.
+  struct stat st = {};
+  if (localFile_->fstat(&st) != 0 || st.st_size == 0) return;
+
+  off_t pos = 0;
+  while (pos < st.st_size) {
+    off_t dataStart = localFile_->lseek(pos, SEEK_DATA);
+    if (dataStart < 0) {
+      ERRNO e;
+      // ENXIO from SEEK_DATA means "no more data past pos".
+      if (e.no != ENXIO) {
+        LOG_ERRNO_RETURN(0, void(), "SEEK_DATA failed during range rebuild.");
+      }
+      break;
+    }
+    off_t holeStart = localFile_->lseek(dataStart, SEEK_HOLE);
+    if (holeStart < 0) {
+      LOG_ERRNO_RETURN(0, void(), "SEEK_HOLE failed during range rebuild.");
+    }
+    addFilledRange(dataStart, holeStart - dataStart);
+    pos = holeStart;
+  }
+}
+
+}
+}

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -1,0 +1,1362 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <algorithm>
+#include <random>
+#include <vector>
+
+#include <photon/common/utility.h>
+#include <photon/photon.h>
+#include <photon/common/alog.h>
+#include <photon/fs/localfs.h>
+#include <photon/fs/aligned-file.h>
+#include <photon/thread/thread.h>
+#include <photon/common/io-alloc.h>
+#include <photon/fs/cache/cache.h>
+
+#include "../full_file_cache/cache_pool.h"
+#include "../full_file_cache/cache_store.h"
+#include "random_generator.h"
+
+namespace photon {
+namespace fs {
+
+
+// Cleanup and recreate the test dir
+inline void SetupTestDir(const std::string& dir) {
+  if (::access(dir.c_str(), F_OK) != 0) {
+    ::mkdir(dir.c_str(), 0755);
+  }
+  std::string cmd = std::string("rm -r ") + dir;
+  EXPECT_NE(-1, system(cmd.c_str()));
+  cmd = std::string("mkdir -p ") + dir;
+  EXPECT_NE(-1, system(cmd.c_str()));
+}
+
+// Returns true if /dev/shm has at least requiredBytes free; otherwise prints a
+// skip notice and returns false. gtest 1.8 has no GTEST_SKIP, so callers must
+// `return` on false.
+inline bool RequireShmAvailable(size_t requiredBytes) {
+  struct statvfs st;
+  if (::statvfs("/dev/shm", &st) != 0) {
+    fprintf(stderr, "  [ SKIPPED ] statvfs /dev/shm failed: %s\n",
+            strerror(errno));
+    return false;
+  }
+  size_t avail = static_cast<size_t>(st.f_bavail) * st.f_frsize;
+  if (avail < requiredBytes) {
+    size_t needMB = (requiredBytes + 1024 * 1024 - 1) / (1024 * 1024);
+    size_t haveMB = avail / (1024 * 1024);
+    fprintf(stderr,
+            "  [ SKIPPED ] /dev/shm needs %zu MB free, only %zu MB available. "
+            "Re-run container with --shm-size=%zum or larger.\n",
+            needMB, haveMB, needMB + 64);
+    return false;
+  }
+  return true;
+}
+
+// Returns true and emits a [ SKIPPED ] notice + releases the store if the
+// host filesystem supports fiemap; the caller should `return` after a true
+// result so the fallback-path tests stay deterministic on either backend.
+inline bool SkipIfFiemapSupported(ICacheStore* store) {
+  if (static_cast<FileCacheStore*>(store)->isFiemapUnavailable()) return false;
+  fprintf(stderr,
+          "  [ SKIPPED ] fiemap is supported on this filesystem; "
+          "fallback range-map path cannot be exercised here.\n");
+  store->release();
+  return true;
+}
+
+void commonTest(bool cacheIsFull, bool enableDirControl, bool dirFull) {
+  std::string prefix = "";
+  const size_t dirQuota = 32ul * 1024 * 1024;
+  const uint64_t refillSize = 1024 * 1024;
+  if (enableDirControl) {
+    prefix = "/John/bucket/";
+  }
+
+  std::string root("/tmp/ease/cache/cache_test/");
+  SetupTestDir(root);
+
+  std::string subDir = prefix + "dir/dir/";
+  SetupTestDir(root + subDir);
+  EXPECT_NE(-1, std::system(std::string("touch " + root + subDir + "testFile").c_str()));
+
+  struct stat st;
+  auto ok = ::stat(std::string(root + subDir + "testFile").c_str(), &st);
+  EXPECT_EQ(0, ok);
+
+  std::string srcRoot("/tmp/ease/cache/src_test/");
+  SetupTestDir(srcRoot);
+  auto srcFs = new_localfs_adaptor(srcRoot.c_str(), ioengine_psync);
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(srcFs, alignFs, refillSize,
+      cacheIsFull ? 0 : 512, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, enableDirControl ? 2 : 0);
+  auto cachePool = roCachedFs->get_pool();
+
+  if (dirFull) {
+    cachePool->set_quota(prefix, dirQuota);
+  }
+  SetupTestDir(srcRoot + prefix + "testDir");
+  auto srcFile = srcFs->open(std::string(prefix + "/testDir/file_1").c_str(),
+   O_RDWR|O_CREAT|O_TRUNC, 0644);
+
+  UniformCharRandomGen gen(0, 255);
+  off_t offset = 0;
+  uint32_t kPageSize = 4 * 1024;
+  uint32_t kFileSize = kPageSize * 16384; // 64MB
+  uint32_t kPageCount = kFileSize / kPageSize;
+  for (uint32_t i = 0; i < kPageCount; ++i) {
+    std::vector<unsigned char> data;
+    for (uint32_t j = 0; j < kPageSize; ++j) {
+      data.push_back(gen.next());
+    }
+    srcFile->pwrite(data.data(), data.size(), offset);
+    offset += kPageSize;
+  }
+
+  //  write some unaligned
+  off_t lastOffset = offset;
+  off_t unAlignedLen = 750;
+  {
+    std::vector<unsigned char> data;
+    for (uint32_t j = 0; j < kPageSize; ++j) {
+      data.push_back(gen.next());
+    }
+    srcFile->pwrite(data.data(), unAlignedLen, offset);
+  }
+
+  auto cachedFile = static_cast<ICachedFile*>(roCachedFs->open(
+    std::string(prefix + "/testDir/file_1").c_str(), 0, 0644));
+
+  //  test unaligned block
+  {
+    void* buf = malloc(kPageSize);
+    auto ret = cachedFile->pread(buf, kPageSize, lastOffset);
+
+    std::vector<unsigned char> src;
+    src.reserve(kPageSize);
+    auto retSrc = srcFile->pread(src.data(), kPageSize, lastOffset);
+
+    EXPECT_EQ(0, std::memcmp(buf, src.data(), unAlignedLen));
+    EXPECT_EQ(unAlignedLen, retSrc);
+    EXPECT_EQ(unAlignedLen, ret);
+
+    LOG_INFO("read again");
+
+    // read again
+    ret = cachedFile->pread(buf, kPageSize, lastOffset);
+    EXPECT_EQ(unAlignedLen, ret);
+
+    free(buf);
+  }
+
+  //  test aligned and unaligned block
+  {
+    void* buf = malloc(kPageSize * 4);
+    auto ret = cachedFile->pread(buf, kPageSize * 4, lastOffset - 2 * kPageSize);
+
+    std::vector<unsigned char> src;
+    src.reserve(kPageSize * 4);
+    auto retSrc = srcFile->pread(src.data(), kPageSize * 4, lastOffset - 2 * kPageSize);
+
+    EXPECT_EQ(0, std::memcmp(buf, src.data(), 2 * kPageSize + unAlignedLen));
+    EXPECT_EQ(2 * kPageSize + unAlignedLen, retSrc);
+    EXPECT_EQ(2 * kPageSize + unAlignedLen, ret);
+
+    LOG_INFO("read again");
+
+    // read again
+    ret = cachedFile->pread(buf, kPageSize * 4, lastOffset - 2 * kPageSize);
+    EXPECT_EQ(2 * kPageSize + unAlignedLen, ret);
+
+    free(buf);
+  }
+
+  std::vector<char> readBuf;
+  readBuf.reserve(kPageSize);
+  std::vector<char> readSrcBuf;
+  readSrcBuf.reserve(kPageSize);
+  for (int i = 0; i != 5; ++i) {
+    EXPECT_EQ(kPageSize, cachedFile->read(readBuf.data(), kPageSize));
+    srcFile->read(readSrcBuf.data(), kPageSize);
+    EXPECT_EQ(0, std::memcmp(readBuf.data(), readSrcBuf.data(), kPageSize));
+  }
+
+  if (enableDirControl && !cacheIsFull) {
+    CacheStat cstat = {};
+    EXPECT_EQ(0, cachePool->stat(&cstat, std::string(prefix + "/testDir/file_1").c_str()));
+    EXPECT_EQ(kFileSize / refillSize, cstat.total_size);
+    cstat = {};
+    EXPECT_EQ(0, cachedFile->get_store()->stat(&cstat));
+    EXPECT_EQ(kFileSize / refillSize, cstat.total_size);
+  }
+
+  // test refill(3)
+  if (!cacheIsFull) {
+    auto inSrcFile = cachedFile->get_source();
+    cachedFile->set_source(nullptr);
+    struct stat stat;
+    inSrcFile->fstat(&stat);
+    cachedFile->ftruncate(stat.st_size);
+    void* buf = malloc(kPageSize * 3);
+    DEFER(free(buf));
+    std::vector<char> src;
+    src.reserve(kPageSize * 3);
+    EXPECT_EQ(kPageSize, srcFile->pread(src.data(), kPageSize, 0));
+    memcpy(buf, src.data(), kPageSize);
+
+    EXPECT_EQ(kPageSize, cachedFile->refill(buf, kPageSize, 0));
+
+    memset(buf, 0, kPageSize);
+    EXPECT_EQ(kPageSize, cachedFile->pread(buf, kPageSize, 0));
+    EXPECT_EQ(0, memcmp(buf, src.data(), kPageSize));
+
+    struct stat st1;
+    ::stat(std::string(root + prefix + "/testDir/file_1").c_str(), &st1);
+    EXPECT_EQ(0, cachedFile->evict(0, kPageSize));
+    struct stat st2;
+    ::stat(std::string(root + prefix + "/testDir/file_1").c_str(), &st2);
+    EXPECT_EQ(kPageSize, st1.st_blocks * 512 - st2.st_blocks * 512);
+
+    // test refill last block
+    src.clear();
+    EXPECT_EQ(kPageSize + unAlignedLen, srcFile->pread(src.data(), kPageSize * 3, lastOffset - kPageSize));
+    memcpy(buf, src.data(), kPageSize * 3);
+    EXPECT_EQ(kPageSize + unAlignedLen, cachedFile->refill(buf, kPageSize * 3, lastOffset - kPageSize));
+    memset(buf, 0, kPageSize * 3);
+    EXPECT_EQ(kPageSize + unAlignedLen, cachedFile->pread(buf, kPageSize * 3, lastOffset - kPageSize));
+    EXPECT_EQ(0, memcmp(buf, src.data(), kPageSize + unAlignedLen));
+
+    cachedFile->set_source(inSrcFile);
+  }
+
+  //  test refill(2)
+  if (!cacheIsFull) {
+    auto inSrcFile = cachedFile->get_source();
+
+    void* buf = malloc(kPageSize * 2);
+    DEFER(free(buf));
+    EXPECT_EQ(0, cachedFile->refill(kPageSize, 2 * kPageSize));
+
+    cachedFile->set_source(nullptr);
+    EXPECT_EQ(2 * kPageSize, cachedFile->pread(buf, 2 * kPageSize, kPageSize));
+    std::vector<char> src;
+    src.reserve(kPageSize * 2);
+    EXPECT_EQ(kPageSize * 2, srcFile->pread(src.data(), 2 * kPageSize, kPageSize));
+    EXPECT_EQ(0, memcmp(buf, src.data(), 2 * kPageSize));
+    cachedFile->set_source(inSrcFile);
+
+    // prefetch more than 16MB
+    EXPECT_EQ(0, cachedFile->fadvise(234, 5000 * kPageSize, POSIX_FADV_WILLNEED));
+    // prefetch tail
+    EXPECT_EQ(0, cachedFile->fadvise(lastOffset - kPageSize, 5000 * kPageSize, POSIX_FADV_WILLNEED));
+  }
+
+  if (dirFull) {
+    CacheStat cstat = {};
+    EXPECT_EQ(0, cachePool->stat(&cstat, prefix));
+    EXPECT_EQ(dirQuota / refillSize, cstat.total_size);
+  }
+
+  // test aligned section
+  UniformInt32RandomGen genOffset(0, (kPageCount + 1) * kPageSize);
+  UniformInt32RandomGen genSize(0, 8 * kPageSize);
+  struct stat srcSt = {};
+  srcFile->fstat(&srcSt);
+  for (int i = 0; i != 10000; ++i) {
+    auto tmpOffset = genOffset.next();
+    auto size = genSize.next();
+
+    if (tmpOffset >= srcSt.st_size) {
+      size = 0;
+    } else {
+      size = tmpOffset + size > srcSt.st_size ? srcSt.st_size - tmpOffset : size;
+    }
+    void* buf = malloc(size);
+    auto ret = cachedFile->pread(buf, size, tmpOffset);
+
+    std::vector<unsigned char> src;
+    src.reserve(size);
+    auto retSrc = srcFile->pread(src.data(), size, tmpOffset);
+
+    EXPECT_EQ(0, std::memcmp(buf, src.data(), size));
+    EXPECT_EQ(size, retSrc);
+    EXPECT_EQ(size, ret);
+    free(buf);
+
+    if (9900 == i && dirFull) {
+      cachedFile->get_store()->set_quota(0);
+    }
+  }
+  srcFile->close();
+
+  photon::thread_usleep(1000 * 1000ull);
+  ok = ::stat(std::string(root + subDir + "testFile").c_str(), &st);
+  EXPECT_EQ(cacheIsFull || dirFull ? -1 : 0, ok);
+
+  if (enableDirControl) {
+    auto ret = cachePool->evict(std::string(prefix + "/testDir").c_str());
+    EXPECT_EQ(0, ret);
+  }
+
+  delete cachedFile;
+
+  //  test smaller file
+  {
+    auto smallFile = srcFs->open(std::string(prefix + "/testDir/small").c_str(),
+     O_RDWR|O_CREAT|O_TRUNC, 0644);
+    DEFER(delete smallFile);
+    int smallSize = 102;
+    std::vector<char> smallData;
+    for (int i = 0; i != smallSize; ++i) {
+      smallData.push_back(gen.next());
+    }
+    EXPECT_EQ(smallSize, smallFile->pwrite(smallData.data(), smallData.size(), 0));
+
+    auto smallCache = static_cast<ICachedFile*>(roCachedFs->open(
+      std::string(prefix + "/testDir/small").c_str(), 0, 0644));
+    DEFER(delete smallCache);
+
+    void* sBuffer = malloc(kPageSize);
+    DEFER(free(sBuffer));
+    EXPECT_EQ(smallSize, smallCache->pread(sBuffer, kPageSize, 0));
+    EXPECT_EQ(0, std::memcmp(sBuffer, smallData.data(), smallSize));
+
+    memset(sBuffer, 0, kPageSize);
+    EXPECT_EQ(smallSize, smallCache->pread(sBuffer, kPageSize, 0));
+    EXPECT_EQ(0, std::memcmp(sBuffer, smallData.data(), smallSize));
+
+    smallFile->close();
+  }
+
+  //  test refill
+  {
+    auto refillFile = srcFs->open(std::string(prefix + "/testDir/refill").c_str(),
+     O_RDWR|O_CREAT|O_TRUNC, 0644);
+    DEFER(delete refillFile);
+    int refillSize = 4097;
+    std::vector<char> refillData;
+    for (int i = 0; i != refillSize; ++i) {
+      refillData.push_back(gen.next());
+    }
+    EXPECT_EQ(refillSize, refillFile->pwrite(refillData.data(), refillData.size(), 0));
+
+    auto refillCache = static_cast<ICachedFile*>(roCachedFs->open(
+      std::string(prefix + "/testDir/refill").c_str(), 0, 0644));
+    DEFER(delete refillCache);
+
+    void* sBuffer = malloc(kPageSize * 2);
+    DEFER(free(sBuffer));
+    memset(sBuffer, 0, kPageSize * 2);
+    EXPECT_EQ(kPageSize, refillCache->pread(sBuffer, kPageSize, 0));
+    EXPECT_EQ(0, std::memcmp(sBuffer, refillData.data(), kPageSize));
+
+    memset(sBuffer, 0, kPageSize * 2);
+    EXPECT_EQ(refillSize, refillCache->pread(sBuffer, kPageSize * 2, 0));
+    EXPECT_EQ(0, std::memcmp(sBuffer, refillData.data(), refillSize));
+
+    refillFile->close();
+  }
+
+  delete srcFs;
+  delete roCachedFs;
+}
+
+TEST(RoCachedFs, Basic) {
+  commonTest(false, false, false);
+}
+
+TEST(RoCachedFs, BasicCacheFull) {
+  commonTest(true, false, false);
+}
+
+// TEST(RoCachedFs, BasicWithDirControl) {
+//   commonTest(false, true, false);
+// }
+
+// TEST(RoCachedFs, BasicCacheFullWithDirControl) {
+//   commonTest(true, true, false);
+// }
+
+TEST(RoCachedFs, CacheWithOutSrcFile) {
+  std::string root("/tmp/ease/cache/cache_test_no_src/");
+  SetupTestDir(root);
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  DEFER(delete cacheAllocator);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      512, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0);
+  DEFER(delete roCachedFs);
+  auto cachedFile = static_cast<ICachedFile*>(roCachedFs->open(
+      std::string("/testDir/file_1").c_str(), 0, 0644));
+  DEFER(delete cachedFile);
+
+  cachedFile->ftruncate(1024 * 1024);
+  std::vector<char> buf;
+  int len = 8 * 1024;
+  buf.reserve(len);
+  EXPECT_EQ(len, cachedFile->pwrite(buf.data(), len, 4 * 1024));
+  EXPECT_EQ(len / 2, cachedFile->pread(buf.data(), 4 * 1024, 4 * 1024));
+  EXPECT_EQ(-1, cachedFile->pread(buf.data(), len, 0));
+
+  auto writeFile = static_cast<ICachedFile*>(roCachedFs->open(
+      std::string("/testDir/file_2").c_str(), 0, 0644));
+  DEFER(delete writeFile);
+  writeFile->ftruncate(1024 * 1024);
+  buf.assign(len, 'a');
+  EXPECT_EQ(len, writeFile->write(buf.data(), len));
+  EXPECT_EQ(len, writeFile->write(buf.data(), len));
+  std::vector<char> res;
+  res.reserve(len);
+  EXPECT_EQ(len, writeFile->pread(res.data(), len, 0));
+  EXPECT_EQ(0, std::memcmp(buf.data(), res.data(), len));
+  res.assign(len, '0');
+  EXPECT_EQ(len, writeFile->pread(res.data(), len, len));
+  EXPECT_EQ(0, std::memcmp(buf.data(), res.data(), len));
+  EXPECT_EQ(-1, writeFile->pread(res.data(), len, len * 2));
+}
+
+TEST(RoCachedFS, xattr) {
+  std::string root("/tmp/ease/cache/cache_xattr/");
+  SetupTestDir(root);
+
+  auto srcFs = new_localfs_adaptor();
+  auto mediaFs = new_localfs_adaptor(root.c_str());
+  auto roCachedFs = new_full_file_cached_fs(srcFs, mediaFs, 1024 * 1024, 512, 1000 * 1000 * 1,
+                                            128ul * 1024 * 1024, nullptr, 0);
+  DEFER(delete roCachedFs);
+
+  std::string path = "/tmp/ease/cache/cache_xattr/filexattr";
+  auto xttarFile = srcFs->open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0644);
+  DEFER(delete xttarFile);
+  auto xattrFs = dynamic_cast<IFileSystemXAttr*>(roCachedFs);
+  std::string name = "user.testxattr", value = "yes";
+  char key[20], val[20];
+  auto ret = xattrFs->setxattr(path.c_str(), name.c_str(), value.c_str(), value.size(), 0);
+  EXPECT_EQ(0, ret);
+  ret = xattrFs->listxattr(path.c_str(), key, 20);
+  EXPECT_EQ(0, std::memcmp(key, name.data(), ret));
+  ret = xattrFs->getxattr(path.c_str(), key, val, 20);
+  EXPECT_EQ((long int)value.size(), ret);
+  EXPECT_EQ(0, std::memcmp(val, value.data(), ret));
+  ret = xattrFs->removexattr(path.c_str(), key);
+  EXPECT_EQ(0, ret);
+
+  auto cachedFile = static_cast<ICachedFile*>(roCachedFs->open(path.c_str(), 0, 0644));
+  DEFER(delete cachedFile);
+  auto xattrfile = dynamic_cast<IFileXAttr*>(cachedFile);
+  ret = xattrfile->fsetxattr(name.c_str(), value.c_str(), value.size(), 0);
+  EXPECT_EQ(0, ret);
+  ret = xattrfile->flistxattr(key, 20);
+  EXPECT_EQ(0, std::memcmp(key, name.data(), ret));
+  ret = xattrfile->fgetxattr(key, val, 20);
+  EXPECT_EQ((long int)value.size(), ret);
+  EXPECT_EQ(0, std::memcmp(val, value.data(), ret));
+  ret = xattrfile->fremovexattr(key);
+  EXPECT_EQ(0, ret);
+}
+
+void* worker(void* arg) {
+  auto fs = (ICachedFileSystem*)arg;
+  char buffer[1024*1024];
+  char buffersrc[1024*1024];
+  std::vector<off_t> offset;
+  for (auto i = 0; i < 2048; i++) {
+    offset.push_back(i * 1024 * 1024);
+  }
+  auto fd = ::open("/tmp/ease/cache/src_test/huge", O_RDONLY);
+  DEFER(::close(fd));
+  auto f = fs->open("/huge", O_RDONLY);
+  DEFER(delete f);
+  for (int i=0;i<4;i++) {
+  std::shuffle(offset.begin(), offset.end(), std::mt19937(std::random_device()()));
+    for (const auto &x : offset) {
+      EXPECT_EQ((ssize_t)(1UL<<20), ::pread(fd, buffersrc, 1024*1024, x));
+      f->pread(buffer, 1024*1024, x);
+      EXPECT_EQ(0, memcmp(buffer, buffersrc, 1024*1024));
+      fs->get_pool()->evict();
+      photon::thread_yield();
+    }
+  }
+  return nullptr;
+}
+
+TEST(CachedFS, write_while_full) {
+  std::string srcRoot("/tmp/ease/cache/src_test/");
+  SetupTestDir(srcRoot);
+  EXPECT_NE(-1, system("dd if=/dev/urandom of=/tmp/ease/cache/src_test/huge bs=1M count=2048"));
+
+  std::string root("/tmp/ease/cache/cache_test/");
+  SetupTestDir(root);
+  auto srcFs = new_localfs_adaptor(srcRoot.c_str());
+  auto mediaFs = new_localfs_adaptor(root.c_str());
+  auto roCachedFs = new_full_file_cached_fs(srcFs, mediaFs, 1024 * 1024, 1, 100 * 1000 * 1,
+                                            128ul * 1024 * 1024, nullptr, 0);
+
+  std::vector<photon::join_handle*> jhs;
+
+  for (int i=0;i<2;i++) {
+    jhs.emplace_back(photon::thread_enable_join(photon::thread_create(worker, roCachedFs)));
+  }
+  for (auto &x : jhs) {
+    photon::thread_join(x);
+  }
+  delete roCachedFs;
+  delete srcFs;
+}
+
+TEST(CachedFS, fn_trans_func) {
+  std::string srcRoot("/tmp/ease/cache/src_test/");
+  SetupTestDir(srcRoot);
+  EXPECT_NE(-1, system("mkdir /tmp/ease/cache/src_test/path_aaa/"));
+  EXPECT_NE(-1, system("mkdir /tmp/ease/cache/src_test/path_bbb/"));
+  EXPECT_NE(-1, system("dd if=/dev/urandom of=/tmp/ease/cache/src_test/path_aaa/sha256:test bs=1K count=1"));
+  EXPECT_NE(-1, system("cp /tmp/ease/cache/src_test/path_aaa/sha256:test /tmp/ease/cache/src_test/path_bbb/sha256:test"));
+
+  std::string root("/tmp/ease/cache/cache_test/");
+  SetupTestDir(root);
+  auto srcFs = new_localfs_adaptor(srcRoot.c_str());
+  DEFER(delete srcFs);
+  auto mediaFs = new_localfs_adaptor(root.c_str());
+  struct NameTransCB {
+    size_t fn_trans_sha256(std::string_view src, char *dest, size_t size) {
+      auto p = src.find("/sha256:");
+      if (p == std::string_view::npos) {
+        return 0;
+      }
+      size_t len = src.size() - p;
+      if (len > size) {
+        LOG_WARN("filename length ` exceed `", len, size);
+        return 0;
+      }
+      strcpy(dest, src.data() + p);
+      return len;
+    }
+  }cb;
+  auto cachedFs = new_full_file_cached_fs(srcFs, mediaFs, 1024 * 1024, 1, 100 * 1000 * 1,
+                                          128ul * 1024 * 1024, nullptr, 0, {&cb, &NameTransCB::fn_trans_sha256});
+  DEFER(delete cachedFs);
+  char buf1[1024], buf2[1024];
+  auto cachedFile1 = static_cast<ICachedFile*>(cachedFs->open("/path_aaa/sha256:test", 0, 0644));
+  auto cachedFile2 = static_cast<ICachedFile*>(cachedFs->open("/path_bbb/sha256:test", 0, 0644));
+  cachedFile1->read(buf1, 1024);
+  auto cFile = mediaFs->open("/sha256:test", 0, 0644);
+  DEFER(delete cFile);
+  cFile->read(buf2, 1024);
+  EXPECT_EQ(0, memcmp(buf1, buf2, 1024));
+  auto cs1 = cachedFile1->get_store();
+  auto cs2 = cachedFile2->get_store();
+  EXPECT_EQ(cs1, cs2);
+}
+
+TEST(CachePool, evict_file) {
+  std::string root = "/tmp/ease/cache/evict_file_test/";
+  SetupTestDir(root);
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  auto fileName = "/file_to_evict";
+  auto cacheStore = cachePool->open(fileName, O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, cacheStore);
+  
+  const size_t bufSize = 1024 * 1024;
+  IOVector buffer(*cacheAllocator);
+  buffer.push_back(bufSize);
+
+  auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+  EXPECT_EQ(ret, (ssize_t)bufSize);
+
+  ret = cacheStore->do_preadv2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+  EXPECT_EQ(ret, (ssize_t)bufSize);
+
+  struct stat stBefore;
+  std::string fullPath = root + fileName;
+  EXPECT_EQ(0, ::stat(fullPath.c_str(), &stBefore));
+  EXPECT_EQ(stBefore.st_size, (off_t)bufSize);
+
+  EXPECT_EQ(0, cachePool->evict(fileName));
+
+  ret = cacheStore->do_preadv2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+  EXPECT_EQ(ret, 0);
+
+  struct stat stAfter;
+  EXPECT_EQ(0, ::stat(fullPath.c_str(), &stAfter));
+  EXPECT_EQ(stAfter.st_size, 0);
+
+  cacheStore->release();
+
+  cacheStore = cachePool->open(fileName, O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, cacheStore);
+
+  auto tres = cacheStore->try_preadv2(buffer.iovec(), buffer.iovcnt(), bufSize, 0);
+  EXPECT_EQ(tres.refill_offset, (ssize_t)bufSize);
+  EXPECT_EQ(tres.refill_size, bufSize);
+
+  ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+  EXPECT_EQ(ret, (ssize_t)bufSize);
+
+  ret = cacheStore->do_preadv2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+  EXPECT_EQ(ret, (ssize_t)bufSize);
+
+  cacheStore->release();
+}
+
+TEST(CachePool, random_evict_file) {
+  std::string root = "/tmp/ease/cache/random_evict_file_test/";
+  SetupTestDir(root);
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  const size_t bufSize = 1024 * 1024;
+  IOVector buffer(*cacheAllocator);
+  buffer.push_back(bufSize);
+  auto fileName = "/huge_file";
+
+  auto cacheStore = cachePool->open(fileName, O_CREAT | O_RDWR, 0644);
+  cacheStore->set_actual_size(200 * bufSize);
+
+  off_t last_evict_offset = 0;
+  off_t written = 0;
+  auto random_release_evict_open = [&]() {
+    if (rand() % 5 == 0) {
+      cacheStore->release();
+      cacheStore = nullptr;
+    }
+    if (rand() % 3 == 0) {
+      cachePool->evict(fileName);
+      last_evict_offset = written;
+    }
+    if (rand() % 5 == 0 && cacheStore) {
+      cacheStore->release();
+      cacheStore = nullptr;
+    }
+    if (cacheStore == nullptr) {
+      cacheStore = cachePool->open(fileName, O_CREAT | O_RDWR, 0644);
+    }
+  };
+
+  for (int i = 0; i < 100; i++) {
+    random_release_evict_open();
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), written, 0);
+    EXPECT_EQ(ret, (ssize_t)bufSize);
+    written += ret;
+
+    if (rand() % 4 == 0) {
+      // write again
+      random_release_evict_open();
+      auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), written, 0);
+      EXPECT_EQ(ret, (ssize_t)bufSize);
+      written += ret;
+    }
+
+    for (int j = 0; j < 10; j++) {
+      random_release_evict_open();
+      off_t qoffset = (rand() % ((i + 1) * 3)) * bufSize;
+      size_t qsize = (rand() % 10 + 1) * bufSize;
+      auto qres = cacheStore->queryRefillRange(qoffset, qsize);
+      if (qoffset + qsize <= (size_t)last_evict_offset || qoffset >= written ||
+          (qoffset < last_evict_offset && qoffset + qsize > (size_t)written)) {
+        EXPECT_EQ(qres.first, qoffset);
+        EXPECT_EQ(qres.second, qsize);
+      } else if (qoffset < last_evict_offset && qoffset + qsize <= (size_t)written) {
+        EXPECT_EQ(qres.first, qoffset);
+        EXPECT_EQ(qres.second, size_t(last_evict_offset - qoffset));
+      } else if (qoffset >= last_evict_offset && qoffset + qsize > (size_t)written) {
+        EXPECT_EQ(qres.first, written);
+        EXPECT_EQ(qres.second, size_t(qoffset + qsize - written));
+      } else {
+        EXPECT_EQ(qres.second, 0UL);
+        IOVector read_buffer(*cacheAllocator);
+        read_buffer.push_back(qsize);
+        ret = cacheStore->do_preadv2(read_buffer.iovec(), read_buffer.iovcnt(), qoffset, 0);
+        EXPECT_EQ(ret, (ssize_t)qsize);
+      }
+    }
+  }
+
+  if (cacheStore) cacheStore->release();
+}
+
+TEST(CachePool, open_same_file) {
+  std::string root = "/tmp/ease/cache/open_same_file/";
+  SetupTestDir(root);
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  auto fileName = "/testDir/testfile";
+
+  uint64_t written = 0;
+  for (int j = 0; j < 5; j++) {
+    std::vector<ICacheStore*> cacheStores;
+    for (int i = 0; i < 10; i++) {
+      cacheStores.push_back(cachePool->open(fileName, O_CREAT | O_RDWR, 0644));
+      ASSERT_NE(nullptr, cacheStores.back());
+    }
+
+    const size_t bufSize = 1024 * 1024;
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(bufSize);
+
+    for (auto cacheStore : cacheStores) {
+      if (rand() % 2 == 0) {
+        cacheStore->release();
+      } else {
+        auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), written, 0);
+        EXPECT_EQ(ret, (ssize_t)bufSize);
+        written += ret;
+        cacheStore->release();
+      }
+    }
+  }
+}
+
+// Friend accessor — declared as friend in FileCachePool.
+struct FileCachePoolTest {
+  static void set_demote_threshold(FileCachePool *p, uint32_t limit) {
+    p->demoteThreshold_ = limit;
+  }
+  static size_t inuse_size(FileCachePool *p) { return p->lru_.size(); }
+  static size_t idle_size(FileCachePool *p) { return p->idleLru_.size(); }
+  static bool inuse(FileCachePool *p, std::string_view n) {
+    return p->fileIndex_.find(n) != p->fileIndex_.end();
+  }
+  static bool idle(FileCachePool *p, std::string_view n) {
+    return p->idleFileIndex_.find(n) != p->idleFileIndex_.end();
+  }
+};
+
+// Open through the pool then immediately release.
+static bool openClose(ICachePool* pool, const char* name) {
+  auto s = pool->open(name, O_CREAT | O_RDWR, 0644);
+  bool success = (s != nullptr);
+  if (s) s->release();
+  return success;
+}
+
+TEST(CachePool, test_demote_threshold) {
+  std::string root = "/tmp/ease/cache/test_demote_threshold/";
+  SetupTestDir(root);
+  const size_t demoteThreshold = 10;
+  const size_t fileNum = 100;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_demote_threshold(pool, demoteThreshold);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(100);
+    std::string name = "/f" + std::to_string(i);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+  }
+
+  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
+  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+
+  // first fileNum-demoteThreshold files are in idle
+  for (size_t i = 0; i < fileNum - demoteThreshold; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::idle(pool, name));
+    EXPECT_FALSE(T::inuse(pool, name));
+  }
+  // last demoteThreshold files are in hot
+  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::inuse(pool, name));
+    EXPECT_FALSE(T::idle(pool, name));
+  }
+  // re-open /f0 — must promote to hot
+  ASSERT_TRUE(openClose(pool, "/f0"));
+  EXPECT_TRUE(T::inuse(pool, "/f0"));
+  EXPECT_FALSE(T::idle(pool, "/f0"));
+
+  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
+  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+
+  // random access
+  for (size_t i = 0; i < 100; i++) {
+    int r = rand() % fileNum;
+    std::string name = "/f" + std::to_string(r);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+
+    if (rand() % 3 == 0) {
+      EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+    }
+  }
+}
+
+TEST(CachePool, evict_idle_file) {
+  std::string root = "/tmp/ease/cache/evict_idle_file/";
+  SetupTestDir(root);
+  const size_t demoteThreshold = 10;
+  const size_t fileNum = 100;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_demote_threshold(pool, demoteThreshold);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(100);
+    std::string name = "/f" + std::to_string(i);
+    ASSERT_TRUE(openClose(pool, name.c_str()));
+  }
+
+  photon::thread_sleep(1);
+  ASSERT_TRUE(T::idle(pool, "/f0"));
+  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
+  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+
+  ASSERT_EQ(0, pool->evict("/f0"));
+  EXPECT_FALSE(T::idle(pool, "/f0"));
+  EXPECT_FALSE(T::inuse(pool, "/f0"));
+  EXPECT_EQ(T::inuse_size(pool), demoteThreshold);
+  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum - 1);
+
+  std::vector<bool> evicted(fileNum, false);
+  evicted[0] = true;
+  for (size_t i = 0; i < 9; i++) {
+    int index = rand() % fileNum;
+    std::string name = "/f" + std::to_string(index);
+    while (evicted[index] || !T::idle(pool, name)) {
+      index = rand() % fileNum;
+      name = "/f" + std::to_string(index);
+    }
+    ASSERT_EQ(0, pool->evict(name));
+    evicted[index] = true;
+    EXPECT_FALSE(T::idle(pool, name));
+    EXPECT_EQ(T::idle_size(pool), fileNum - demoteThreshold - 2 - i);
+  }
+}
+
+TEST(CachePool, evict_by_size_idle_first) {
+  std::string root = "/tmp/ease/cache/evict_by_size/";
+  SetupTestDir(root);
+  const uint64_t capacityGB = 1;
+  const size_t demoteThreshold = 5;
+  const size_t fileNum = 40;
+  const size_t fileSizeMB = 60;
+  const size_t fileSizeBytes = fileSizeMB * 1024 * 1024;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      capacityGB, 0, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  T::set_demote_threshold(pool, demoteThreshold);
+
+  IOVector buffer(*cacheAllocator);
+  buffer.push_back(fileSizeBytes);
+
+  for (size_t i = 0; i < fileNum; i++) {
+    photon::thread_usleep(1000);
+    std::string name = "/g" + std::to_string(i);
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    store->release();
+  }
+
+  size_t remaining = T::inuse_size(pool) + T::idle_size(pool);
+  EXPECT_LT(remaining, fileNum);
+  EXPECT_LE(T::inuse_size(pool), (size_t)demoteThreshold);
+
+  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+    std::string name = "/g" + std::to_string(i);
+    EXPECT_TRUE(T::inuse(pool, name)) << name << " should still be in hot";
+    EXPECT_FALSE(T::idle(pool, name)) << name << " must not be in idle";
+  }
+
+  // Write a new file to trigger eviction, the idle file should be evicted first
+  std::string name = "/g" + std::to_string(fileNum);
+  auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, store);
+  store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+  store->release();
+  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+    std::string name = "/g" + std::to_string(i);
+    bool existed = T::inuse(pool, name) || T::idle(pool, name);
+    EXPECT_TRUE(existed) << name << " must still exist";
+  }
+}
+
+static int64_t get_physical_memory_KiB() {
+  FILE *file = fopen("/proc/self/status", "r");
+  if (file == NULL) {
+    return -1;
+  }
+
+  int64_t result = -1;
+  char line[128];
+
+  while (fgets(line, 128, file) != nullptr) {
+    if (strncmp(line, "VmRSS:", 6) == 0) {
+      int len = strlen(line);
+
+      const char *p = line;
+      for (; *p && !std::isdigit(*p); ++p) {
+      }
+
+      line[len - 3] = 0;
+      result = atoll(p);
+      break;
+    }
+  }
+
+  fclose(file);
+  return result;
+}
+
+TEST(CachePool, DISABLED_test_mem_usage) {
+  std::string root = "/tmp/ease/cache/test_mem_usage/";
+  SetupTestDir(root);
+  const uint64_t capacityGB = 1;
+  const size_t fileNum = 10'000'000;
+  const size_t inuse = 1'000'000;
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      capacityGB, 0, 128ul * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+  using T = FileCachePoolTest;
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+
+  auto before_mem_usage = get_physical_memory_KiB();
+  LOG_INFO("Physical memory usage before: ` KiB.", before_mem_usage);
+
+  const int fileNameLength = 45;
+  for (size_t i = 0; i < fileNum; i++) {
+    std::string name = "/" + std::to_string(i);
+    name += std::string(fileNameLength - name.length(), 'a');
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->release();
+    if (i % 100'000 == 0) {
+      LOG_INFO("Opened ` files. current: ` KiB.", i+1, get_physical_memory_KiB());
+      LOG_INFO("inuse size `, idle size `", T::inuse_size(pool), T::idle_size(pool));
+    }
+  }
+  EXPECT_EQ(inuse, T::inuse_size(pool));
+  EXPECT_EQ(fileNum - inuse, T::idle_size(pool));
+
+  photon::thread_sleep(10);
+  malloc_trim(0);
+  photon::thread_sleep(10);
+
+  auto after_mem_usage = get_physical_memory_KiB();
+  LOG_INFO("Physical memory usage after: ` KiB.", after_mem_usage);
+  auto diff = after_mem_usage - before_mem_usage;
+  LOG_INFO("Physical memory usage diff: ` KiB.", diff);
+}
+
+static void refillRangeDeterministic(bool useShm) {
+  std::string root = useShm
+      ? "/dev/shm/ease/cache/refill_range_det/"
+      : "/root/tmp/ease/cache/refill_range_det/";
+  if (useShm && !RequireShmAvailable(144ul * 1024 * 1024)) return;
+  SetupTestDir(root);
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, mediaFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  const size_t refillUnit = 1024 * 1024;
+  auto fileName = "/range_det_file";
+  auto cacheStore = cachePool->open(fileName, O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, cacheStore);
+  cacheStore->set_actual_size(200 * refillUnit);
+
+  // Write [0, 1MB)
+  {
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(refillUnit);
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    EXPECT_EQ(ret, (ssize_t)refillUnit);
+  }
+  // Write [2MB, 3MB)
+  {
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(refillUnit);
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 2 * refillUnit, 0);
+    EXPECT_EQ(ret, (ssize_t)refillUnit);
+  }
+  // Write [5MB, 6MB)
+  {
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(refillUnit);
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 5 * refillUnit, 0);
+    EXPECT_EQ(ret, (ssize_t)refillUnit);
+  }
+
+  // queryRefillRange(0, 10MB): outer refill region is [1MB, 10MB);
+  // [0,1MB) is filled so left edge is trimmed, right edge is past last data,
+  // interior gaps are ignored to match fiemap-path semantics.
+  auto r1 = cacheStore->queryRefillRange(0, 10 * refillUnit);
+  EXPECT_EQ(r1.first, (off_t)(1 * refillUnit));
+  EXPECT_EQ(r1.second, (size_t)(9 * refillUnit));
+
+  // queryRefillRange(2MB, 1MB): fully covered
+  auto r2 = cacheStore->queryRefillRange(2 * refillUnit, refillUnit);
+  EXPECT_EQ(r2.first, 0);
+  EXPECT_EQ(r2.second, 0UL);
+
+  // queryRefillRange(3MB, 3MB): first hole is [3MB, 5MB)
+  auto r3 = cacheStore->queryRefillRange(3 * refillUnit, 3 * refillUnit);
+  EXPECT_EQ(r3.first, (off_t)(3 * refillUnit));
+  EXPECT_EQ(r3.second, (size_t)(2 * refillUnit));
+
+  // queryRefillRange(5MB, 1MB): fully covered
+  auto r4 = cacheStore->queryRefillRange(5 * refillUnit, refillUnit);
+  EXPECT_EQ(r4.first, 0);
+  EXPECT_EQ(r4.second, 0UL);
+
+  // queryRefillRange(6MB, 4MB): all hole
+  auto r5 = cacheStore->queryRefillRange(6 * refillUnit, 4 * refillUnit);
+  EXPECT_EQ(r5.first, (off_t)(6 * refillUnit));
+  EXPECT_EQ(r5.second, (size_t)(4 * refillUnit));
+
+  cacheStore->release();
+}
+
+static void refillRangeRandom(bool useShm) {
+  std::string root = useShm
+      ? "/dev/shm/ease/cache/refill_range_rand/"
+      : "/root/tmp/ease/cache/refill_range_rand/";
+  if (useShm && !RequireShmAvailable(240ul * 1024 * 1024)) return;
+  SetupTestDir(root);
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, mediaFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  const size_t refillUnit = 1024 * 1024;
+  const size_t totalBlocks = 100;
+  auto fileName = "/range_rand_file";
+  auto cacheStore = cachePool->open(fileName, O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, cacheStore);
+  cacheStore->set_actual_size(totalBlocks * refillUnit);
+
+  // Track which blocks are filled (by refillUnit granularity)
+  std::vector<bool> filled(totalBlocks, false);
+  std::mt19937 rng(42);
+
+  // Helper: compute outer refill region for [startBlock, startBlock+count).
+  // Matches fiemap-path semantics: trim filled prefix from the left edge and
+  // filled suffix from the right edge; interior gaps are ignored.
+  auto findRefillRange = [&](size_t startBlock, size_t count) -> std::pair<off_t, size_t> {
+    size_t endBlock = startBlock + count;
+    if (endBlock > totalBlocks) endBlock = totalBlocks;
+    if (startBlock >= endBlock) return {0, 0};
+    size_t outLeft = startBlock;
+    size_t outRight = endBlock;
+    while (outLeft < outRight && filled[outLeft]) outLeft++;
+    while (outRight > outLeft && filled[outRight - 1]) outRight--;
+    if (outLeft >= outRight) return {0, 0};
+    return {(off_t)(outLeft * refillUnit), (size_t)((outRight - outLeft) * refillUnit)};
+  };
+
+  for (int iter = 0; iter < 80; iter++) {
+    LOG_INFO("Iter `", iter);
+    // Pick a random unfilled block to write
+    std::vector<size_t> unfilled;
+    for (size_t b = 0; b < totalBlocks; b++) {
+      if (!filled[b]) unfilled.push_back(b);
+    }
+    if (unfilled.empty()) break;
+
+    // Pick start from unfilled blocks
+    size_t startIdx = rng() % unfilled.size();
+    size_t startBlock = unfilled[startIdx];
+    size_t writeCount = 1 + rng() % 3;
+    if (startBlock + writeCount > totalBlocks)
+      writeCount = totalBlocks - startBlock;
+
+    // Write writeCount blocks starting at startBlock
+    for (size_t w = 0; w < writeCount; w++) {
+      LOG_INFO("writeCount `", w);
+      size_t blk = startBlock + w;
+      if (blk >= totalBlocks) break;
+      if (!filled[blk]) {
+        IOVector buffer(*cacheAllocator);
+        buffer.push_back(refillUnit);
+        auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(),
+                                           blk * refillUnit, 0);
+        EXPECT_EQ(ret, (ssize_t)refillUnit);
+        filled[blk] = true;
+      }
+    }
+
+    // Random query and verify
+    size_t qStart = rng() % totalBlocks;
+    size_t qCount = 1 + rng() % 10;
+    if (qStart + qCount > totalBlocks) qCount = totalBlocks - qStart;
+
+    auto expected = findRefillRange(qStart, qCount);
+    auto actual = cacheStore->queryRefillRange(qStart * refillUnit, qCount * refillUnit);
+    EXPECT_EQ(actual.first, expected.first)
+        << "iter=" << iter << " qStart=" << qStart << " qCount=" << qCount;
+    EXPECT_EQ(actual.second, expected.second)
+        << "iter=" << iter << " qStart=" << qStart << " qCount=" << qCount;
+  }
+
+  cacheStore->release();
+}
+
+static void refillRangeEvictWhileOpen(bool useShm) {
+  std::string root = useShm
+      ? "/dev/shm/ease/cache/refill_range_evict/"
+      : "/root/tmp/ease/cache/refill_range_evict/";
+  if (useShm && !RequireShmAvailable(144ul * 1024 * 1024)) return;
+  SetupTestDir(root);
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, mediaFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  const size_t refillUnit = 1024 * 1024;
+  auto fileName = "/range_evict_file";
+  auto cacheStore = cachePool->open(fileName, O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, cacheStore);
+  cacheStore->set_actual_size(20 * refillUnit);
+
+  // Write [0, 1MB) and [1MB, 2MB)
+  {
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(2 * refillUnit);
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    EXPECT_EQ(ret, (ssize_t)(2 * refillUnit));
+  }
+
+  // Write more: [3MB, 4MB), [4MB, 5MB)
+  {
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(2 * refillUnit);
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 3 * refillUnit, 0);
+    EXPECT_EQ(ret, (ssize_t)(2 * refillUnit));
+  }
+
+  // Verify: queryRefillRange(0, 5MB) -> first hole is [2MB, 3MB)
+  auto r1 = cacheStore->queryRefillRange(0, 5 * refillUnit);
+  EXPECT_EQ(r1.first, (off_t)(2 * refillUnit));
+  EXPECT_EQ(r1.second, (size_t)(1 * refillUnit));
+
+  // Verify: queryRefillRange(3MB, 2MB) -> fully covered
+  auto r2 = cacheStore->queryRefillRange(3 * refillUnit, 2 * refillUnit);
+  EXPECT_EQ(r2.first, 0);
+  EXPECT_EQ(r2.second, 0UL);
+
+  // Evict without releasing cacheStore
+  EXPECT_EQ(0, cachePool->evict(fileName));
+
+  // After eviction: all ranges should be holes
+  auto r3 = cacheStore->queryRefillRange(0, 5 * refillUnit);
+  EXPECT_EQ(r3.first, (off_t)0);
+  EXPECT_EQ(r3.second, (size_t)(5 * refillUnit));
+
+  // Re-write [1MB, 2MB)
+  {
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(refillUnit);
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 1 * refillUnit, 0);
+    EXPECT_EQ(ret, (ssize_t)refillUnit);
+  }
+
+  // Verify: queryRefillRange(0, 5MB) -> outer refill region is [0, 5MB);
+  // [1MB, 2MB) is in the middle and is ignored under fiemap-path semantics.
+  auto r4 = cacheStore->queryRefillRange(0, 5 * refillUnit);
+  EXPECT_EQ(r4.first, (off_t)0);
+  EXPECT_EQ(r4.second, (size_t)(5 * refillUnit));
+
+  // Verify: queryRefillRange(1MB, 1MB) -> fully covered
+  auto r5 = cacheStore->queryRefillRange(1 * refillUnit, refillUnit);
+  EXPECT_EQ(r5.first, 0);
+  EXPECT_EQ(r5.second, 0UL);
+
+  // Verify: queryRefillRange(2MB, 3MB) -> [2MB, 5MB) all hole
+  auto r6 = cacheStore->queryRefillRange(2 * refillUnit, 3 * refillUnit);
+  EXPECT_EQ(r6.first, (off_t)(2 * refillUnit));
+  EXPECT_EQ(r6.second, (size_t)(3 * refillUnit));
+
+  cacheStore->release();
+}
+
+static void refillRangeNonAlignedTail(bool useShm) {
+  std::string root = useShm
+      ? "/dev/shm/ease/cache/refill_range_unaligned/"
+      : "/root/tmp/ease/cache/refill_range_unaligned/";
+  if (useShm && !RequireShmAvailable(144ul * 1024 * 1024)) return;
+  SetupTestDir(root);
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, mediaFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ul * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  const size_t refillUnit = 1024 * 1024;
+  const off_t tailSize = 5000;  // not a multiple of 4K (4096)
+  const off_t fileSize = 2 * (off_t)refillUnit + tailSize;
+  auto fileName = "/range_unaligned_file";
+  auto cacheStore = cachePool->open(fileName, O_CREAT | O_RDWR, 0644);
+  ASSERT_NE(nullptr, cacheStore);
+  cacheStore->set_actual_size(fileSize);
+
+  // Fill [0, 2MB): aligned bulk write
+  {
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(2 * refillUnit);
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    EXPECT_EQ(ret, (ssize_t)(2 * refillUnit));
+  }
+  // Fill [2MB, 2MB+5000): non-4K-aligned tail write
+  {
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(tailSize);
+    auto ret = cacheStore->do_pwritev2(buffer.iovec(), buffer.iovcnt(),
+                                       2 * refillUnit, 0);
+    EXPECT_EQ(ret, (ssize_t)tailSize);
+  }
+
+  // Query the exact filled range [0, fileSize) — should be fully covered.
+  // Before the fix, align_up(fileSize, 4K) overshoots EOF and the
+  // beyond-EOF space is misidentified as a hole → returns {2MB, 1MB}.
+  auto r1 = cacheStore->queryRefillRange(0, static_cast<size_t>(fileSize));
+  EXPECT_EQ(r1.first, 0);
+  EXPECT_EQ(r1.second, 0UL);
+
+  // Query the partial-block tail [2MB, 2MB+5000) — should be fully covered.
+  auto r2 = cacheStore->queryRefillRange(2 * refillUnit, tailSize);
+  EXPECT_EQ(r2.first, 0);
+  EXPECT_EQ(r2.second, 0UL);
+
+  // Query the last 4K block straddling the partial tail [2MB-4096, 2MB+5000):
+  // all within the filled region, should be fully covered.
+  auto r3 = cacheStore->queryRefillRange(2 * refillUnit - 4096, 4096 + tailSize);
+  EXPECT_EQ(r3.first, 0);
+  EXPECT_EQ(r3.second, 0UL);
+
+  // Now evict [1MB, 2MB) to create a hole before the tail.
+  EXPECT_EQ(0, cacheStore->evict(1 * refillUnit, refillUnit));
+
+  // Query [1MB, fileSize): first hole is [1MB, 2MB), tail [2MB, 2MB+5000)
+  // is filled.  Outer refill region is exactly [1MB, 2MB).
+  auto r4 = cacheStore->queryRefillRange(1 * refillUnit,
+                                         static_cast<size_t>(fileSize) - 1 * refillUnit);
+  EXPECT_EQ(r4.first, (off_t)(1 * refillUnit));
+  EXPECT_EQ(r4.second, (size_t)(1 * refillUnit));
+
+  cacheStore->release();
+}
+
+TEST(CachePool, refill_range_deterministic) {
+  refillRangeDeterministic(true);
+  refillRangeDeterministic(false);
+}
+
+TEST(CachePool, refill_range_random) {
+  refillRangeRandom(true);
+  refillRangeRandom(false);
+}
+
+TEST(CachePool, refill_range_evict_while_open) {
+  refillRangeEvictWhileOpen(true);
+  refillRangeEvictWhileOpen(false);
+}
+
+TEST(CachePool, refill_range_non_aligned_tail) {
+  refillRangeNonAlignedTail(true);
+  refillRangeNonAlignedTail(false);
+}
+
+}
+}
+int main(int argc, char** argv) {
+  log_output_level = ALOG_ERROR;
+  // photon::vcpu_init();
+  ::testing::InitGoogleTest(&argc, argv);
+
+  photon::init();
+  DEFER(photon::fini());
+
+  auto ret = RUN_ALL_TESTS();
+
+  // photon::vcpu_fini();
+
+  return ret;
+}


### PR DESCRIPTION
> fix(cache): skip 4K alignment for map path in queryRefillRange (#1353) (#1361)

queryRefillRange was applying 4K block alignment to the query range
for both fiemap and map paths. For the map path (filledRanges_),
which tracks exact byte ranges, this alignment could extend the
query past EOF on files whose size is not a 4K multiple. The
beyond-EOF space, not present in filledRanges_, would then be
misidentified as a hole, causing already-cached tail data to be
redundantly re-fetched from the source.

Move the 4K alignment into the fiemap-only branch; the map path
now passes the original offset/size directly to queryRefillRangeByMap.

Also refactor the range_map tests into helper functions parameterized
by useShm (true = /dev/shm = map path, false = /root/tmp = fiemap path)
so both code paths are exercised, and add a new non-aligned tail test.

Co-authored-by: Xiaoyang Lu <luxiaoyang.lxy@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.