### PR TITLE
[Backport][main to 0.9] | Fix alog snprintf overflow and iovector slice/iterator bugs (#1283) 

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -263,6 +263,7 @@ protected:
     {
         int ret = ::snprintf(buf.ptr, buf.size, fmt, x);
         if (ret < 0) return;
+        if ((size_t)ret > buf.size) ret = buf.size;
         buf.consume(ret);
     }
 

--- a/common/iovector.cpp
+++ b/common/iovector.cpp
@@ -262,7 +262,6 @@ ssize_t iovector_view::extract_back(size_t bytes, iovector_view* iov)
 }
 #undef _this
 
-<<<<<<< HEAD
 size_t iovector_view::memcpy_to(void* buf, size_t size)
 {
     auto buf0 = buf;
@@ -277,37 +276,6 @@ size_t iovector_view::memcpy_to(void* buf, size_t size)
         size -= len;
         if (size == 0)
             break;
-=======
-inline void operator+=(iovec& v, size_t nbytes) {
-    (char*&)v.iov_base += nbytes;
-    v.iov_len -= nbytes;
-}
-
-class iov_iterator {
-    const iovec* _iov;
-    iovec _v;
-    int _iovcnt;
-public:
-    iov_iterator(iov_iterator&&) = default;
-    iov_iterator(const iov_iterator&) = default;
-    iov_iterator(iovector_view v) : _iov(v.iov), _v(v.iov[0]), _iovcnt(v.iovcnt) { }
-    bool empty() const { return _iovcnt == 0; }
-    iovec front() const { return _v; }
-    iov_iterator& operator += (size_t n) {
-        assert(_iovcnt);
-        assert(n <= _v.iov_len);
-        if (n < _v.iov_len) { _v += n; }
-        else {
-            if (--_iovcnt > 0) {
-                _v = *++_iov;
-            } else {
-                ++_iov;
-                _v = {};
-            }
-            assert(_iovcnt == 0 || _v.iov_base);
-        }
-        return *this;
->>>>>>> 96d8213 (Fix alog snprintf overflow and iovector slice/iterator bugs (#1283))
     }
     return (char*)buf - (char*)buf0;
 }

--- a/common/iovector.cpp
+++ b/common/iovector.cpp
@@ -77,28 +77,50 @@ ssize_t iovector_view::slice(size_t count, off_t offset, iovector_view* /*OUT*/ 
         // empty iov, takes as no useable nested iovec to store the result
         return -1;
     }
+    if (unlikely(count == 0)) {
+        iov->iovcnt = 0;
+        return 0;
+    }
     int cnt = 0;
-    off_t pos = 0;
     auto ptr = iov->iov;
     ssize_t ret = 0;
-    for (auto &p : *this) {
-        if (count && (pos + (off_t)p.iov_len > offset)) {
-            if (offset > pos) {
-                ptr[cnt].iov_base = (char*)p.iov_base + (offset - pos);
-                ptr[cnt].iov_len = p.iov_len - (offset - pos);
-            } else {
-                ptr[cnt].iov_base = p.iov_base;
-                ptr[cnt].iov_len = p.iov_len;
-            }
-            if (count < ptr[cnt].iov_len)
-                ptr[cnt].iov_len = count;
-            pos += p.iov_len;
-            ret += ptr[cnt].iov_len;
-            count -= ptr[cnt].iov_len;
-            cnt ++;
-            if (cnt == iov->iovcnt)
-                break;
+    auto it = begin();
+    auto e = end();
+    // skip iovec elements before offset
+    off_t pos = 0;
+    for (; it != e; ++it) {
+        if (pos + (off_t)it->iov_len > offset)
+            break;
+        pos += it->iov_len;
+    }
+    // process the first element (may be partial due to offset)
+    if (it != e) {
+        ptr[cnt].iov_base = (char*)it->iov_base + (offset - pos);
+        ptr[cnt].iov_len = it->iov_len - (offset - pos);
+        if (count <= ptr[cnt].iov_len) {
+            ptr[cnt].iov_len = count;
+            ret += count;
+            iov->iovcnt = cnt + 1;
+            return ret;
         }
+        ret += ptr[cnt].iov_len;
+        count -= ptr[cnt].iov_len;
+        cnt++;
+        ++it;
+    }
+    // process remaining full elements
+    for (; it != e && cnt < iov->iovcnt; ++it) {
+        ptr[cnt].iov_base = it->iov_base;
+        ptr[cnt].iov_len = it->iov_len;
+        if (count <= ptr[cnt].iov_len) {
+            ptr[cnt].iov_len = count;
+            ret += count;
+            iov->iovcnt = cnt + 1;
+            return ret;
+        }
+        ret += ptr[cnt].iov_len;
+        count -= ptr[cnt].iov_len;
+        cnt++;
     }
     iov->iovcnt = cnt;
     return ret;
@@ -240,6 +262,7 @@ ssize_t iovector_view::extract_back(size_t bytes, iovector_view* iov)
 }
 #undef _this
 
+<<<<<<< HEAD
 size_t iovector_view::memcpy_to(void* buf, size_t size)
 {
     auto buf0 = buf;
@@ -254,6 +277,37 @@ size_t iovector_view::memcpy_to(void* buf, size_t size)
         size -= len;
         if (size == 0)
             break;
+=======
+inline void operator+=(iovec& v, size_t nbytes) {
+    (char*&)v.iov_base += nbytes;
+    v.iov_len -= nbytes;
+}
+
+class iov_iterator {
+    const iovec* _iov;
+    iovec _v;
+    int _iovcnt;
+public:
+    iov_iterator(iov_iterator&&) = default;
+    iov_iterator(const iov_iterator&) = default;
+    iov_iterator(iovector_view v) : _iov(v.iov), _v(v.iov[0]), _iovcnt(v.iovcnt) { }
+    bool empty() const { return _iovcnt == 0; }
+    iovec front() const { return _v; }
+    iov_iterator& operator += (size_t n) {
+        assert(_iovcnt);
+        assert(n <= _v.iov_len);
+        if (n < _v.iov_len) { _v += n; }
+        else {
+            if (--_iovcnt > 0) {
+                _v = *++_iov;
+            } else {
+                ++_iov;
+                _v = {};
+            }
+            assert(_iovcnt == 0 || _v.iov_base);
+        }
+        return *this;
+>>>>>>> 96d8213 (Fix alog snprintf overflow and iovector slice/iterator bugs (#1283))
     }
     return (char*)buf - (char*)buf0;
 }


### PR DESCRIPTION
> Fix alog snprintf overflow and iovector slice/iterator bugs (#1283)

* Fix log buffer overflow and iovector slice/iterator bugs

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

* Address review: refactor slice to process first element before loop

- Skip loop only skips complete iovec elements
- Process first (potentially partial) element separately
- Main loop only handles full elements, no branching

---------

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.