### PR TITLE
[Backport][0.9 to 0.8] | Fix zerocopy counter increment on sendmsg failure (#1264) (#1323) 

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -498,6 +498,8 @@ protected:
 
     ssize_t do_sendmsg(int sockfd, const struct msghdr* message, int flags, Timeout timeout) override {
         ssize_t n = photon::net::sendmsg(sockfd, message, flags | ZEROCOPY_FLAG, timeout);
+        if (n < 0)
+            return n;
         m_num_calls++;
         auto ret = zerocopy_confirm(sockfd, m_num_calls - 1, timeout);
         if (ret < 0)


### PR DESCRIPTION
> Fix zerocopy counter increment on sendmsg failure (#1264) (#1323)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.