### PR TITLE
[Backport][0.9 to 0.8] | Fix chunked encoding 64-bit size truncation to 32-bit (#1263) (#1324) 

### DIFF
--- a/net/http/body.cpp
+++ b/net/http/body.cpp
@@ -288,8 +288,8 @@ public:
     }
 
     virtual ssize_t write(const void *buf, size_t count) override {
-        char chunk_size[10];
-        auto size = snprintf(chunk_size, sizeof(chunk_size), "%x\r\n", (unsigned)count);
+        char chunk_size[20];
+        auto size = snprintf(chunk_size, sizeof(chunk_size), "%zx\r\n", count);
         if (size <= 0) return -1;
         struct iovec iov[3] = {{chunk_size, (size_t)size}, {(void*)buf, count}, {&chunk_size[size - 2], 2}};
         ssize_t total = size + count + 2;
@@ -298,9 +298,9 @@ public:
     }
 
     virtual ssize_t writev(const struct iovec *iov, int iovcnt) override {
-        char chunk_size[10];
+        char chunk_size[20];
         ssize_t count = iovector_view((struct iovec*)iov, iovcnt).sum();
-        auto size = snprintf(chunk_size, sizeof(chunk_size), "%x\r\n", (unsigned)count);
+        auto size = snprintf(chunk_size, sizeof(chunk_size), "%zx\r\n", (size_t)count);
         if (m_stream->write(chunk_size, size) != size) return -1;
         if (m_stream->writev(iov, iovcnt) != count) return -1;
         if (m_stream->write(&chunk_size[size - 2], 2) != 2) return -1;


### PR DESCRIPTION
> Fix chunked encoding 64-bit size truncation to 32-bit (#1263) (#1324)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.