### PR TITLE
[Pick][0.9 to main] | [Backport][main to 0.9] | Fix crash in threads_create_join on partial failure (#1252)  (#1328) 

### DIFF
--- a/thread/thread.h
+++ b/thread/thread.h
@@ -605,6 +605,7 @@ namespace photon
         bool m_locked;
     };
 
+<<<<<<< HEAD
     // High-performance rwlock without starvation prevention.
     // Optimized for read-heavy workloads using lock-free atomic operations
     // for the read lock fast path.
@@ -717,6 +718,8 @@ namespace photon
         }
     };
 
+=======
+>>>>>>> 4652030 ([Backport][main to 0.9] | Fix crash in threads_create_join on partial failure (#1252)  (#1328))
     // create `n` threads to run `start(arg)`, then get joined;
     // returns the number of threads actually created (< n if
     // thread_create() failed partway), which is the number joined.


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix crash in threads_create_join on partial failure (#1252)  (#1328)

* Fix crash in threads_create_join on partial failure (#1252)

* Fix crash in threads_create_join on partial failure

When thread_create() fails mid-loop, only join threads that were
actually created. Previously the join loop iterated all n slots,
calling thread_join on uninitialized pointers (stack array case)
or nullptr (vector case), causing a segfault.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

* Address review: return # of threads created, use created++ index

Per maintainer feedback:
- threads_create_join now returns the actual number of threads created
  (< n on partial failure), so callers can detect partial failure.
- Use pthreads[created++] = th instead of a separate created++ line.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

* Update thread.h

* Update thread.h

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits