### PR TITLE
[Backport][0.8 to 0.7] | Fix iovector push_back/push_front allocating before capacity check (#1298) (#1349) (#1362) 

### DIFF
--- a/common/iovector.h
+++ b/common/iovector.h
@@ -365,6 +365,7 @@ public:
     // note that the buffer may be constituted by multiple iovec elements;
     size_t push_front(size_t bytes)
     {
+        if (iov_begin == 0) return 0;
         auto v = new_iovec(bytes);
         IF_ASSERT_RETURN(v.iov_len, 0);
         if (push_front(v) == bytes)
@@ -390,6 +391,7 @@ public:
     // note that the buffer may constitute multiple iovec elements;
     size_t push_back(size_t bytes)
     {
+        if (iov_end >= capacity) return 0;
         auto v = new_iovec(bytes);
         IF_ASSERT_RETURN(v.iov_len, 0);
         if (push_back(v) == bytes)


### PR DESCRIPTION
> Fix iovector push_back/push_front allocating before capacity check (#1298) (#1349) (#1362)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.