### PR TITLE
[Backport][0.8 to 0.7] | Add maximum RPC request size to prevent OOM from wire (#1307) (#1348) (#1363) 

### DIFF
--- a/rpc/rpc.cpp
+++ b/rpc/rpc.cpp
@@ -184,6 +184,8 @@ namespace rpc {
         return new StubImpl(stream, ownership);
     }
 
+    static constexpr uint32_t MAX_RPC_MESSAGE_SIZE = 64 * 1024 * 1024; // 64MB
+
     class SkeletonImpl final: public Skeleton
     {
     public:
@@ -268,6 +270,8 @@ namespace rpc {
                     LOG_ERROR_RETURN(ENOSYS, -1, "unable to find function service for ID ", header.function.function);
 
                 func = it->second;
+                if (header.size > MAX_RPC_MESSAGE_SIZE)
+                    LOG_ERROR_RETURN(EMSGSIZE, -1, "RPC message too large: ", header.size);
                 ret = request.push_back(header.size);
                 if (ret != header.size) {
                     LOG_ERRNO_RETURN(ENOMEM, -1, "Failed to allocate iov");


### PR DESCRIPTION
> Add maximum RPC request size to prevent OOM from wire (#1307) (#1348) (#1363)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.