### PR TITLE
[Backport][0.9 to 0.8] | Fix UDP recv waiting on writable instead of readable (#1261) (#1326) 

### DIFF
--- a/net/datagram_socket.cpp
+++ b/net/datagram_socket.cpp
@@ -105,7 +105,7 @@ public:
             .msg_flags = 0,
         };
         auto ret = DOIO_ONCE(::recvmsg(fd, &hdr, MSG_DONTWAIT | flags),
-                         wait_for_fd_writable(fd));
+                         wait_for_fd_readable(fd));
         if (addrlen) *addrlen = hdr.msg_namelen;
         return ret;
     }


### PR DESCRIPTION
> Fix UDP recv waiting on writable instead of readable (#1261) (#1326)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.