### PR TITLE
[Backport][0.9 to 0.8] | Fix resource leak in photon::init() on partial failure (#1254) (#1327) 

### DIFF
--- a/photon.cpp
+++ b/photon.cpp
@@ -34,6 +34,7 @@ limitations under the License.
 #include "fs/exportfs.h"
 #include "common/alog.h"
 #include "common/callback.h"
+#include "common/utility.h"
 #include <vector>
 
 namespace photon {
@@ -73,6 +74,9 @@ int __photon_init(uint64_t event_engine, uint64_t io_engine, const PhotonOptions
     if (vcpu_init() < 0)
         return -1;
 
+    bool ok = false;
+    DEFER(if (!ok) fini());
+
     const uint64_t ALL_ENGINES =
             INIT_EVENT_EPOLL   | INIT_EVENT_EPOLL_NG |
             INIT_EVENT_IOURING | INIT_EVENT_KQUEUE |
@@ -111,6 +115,7 @@ int __photon_init(uint64_t event_engine, uint64_t io_engine, const PhotonOptions
         LOG_DEBUG("reset_all_handle registed ", VALUE(getpid()));
         reset_handle_registed = true;
     }
+    ok = true;
     return 0;
 }
 
@@ -128,6 +133,8 @@ void fini_hook(Delegate<void> handler) {
 }
 
 int fini() {
+    if (!CURRENT)
+        return -1;
     for (auto h : get_hook_vector()) {
         h.fire();
     }


### PR DESCRIPTION
> Fix resource leak in photon::init() on partial failure (#1254) (#1327)

* Fix resource leak in photon::init() on partial failure

Previously, if any step after vcpu_init() failed (event engine,
signal, or IO engine init), the function returned -1 without
cleaning up already-initialized resources (vcpu, event engine,
signal fd, earlier IO engines).

Track successfully initialized engines incrementally via g_event_engine
and g_io_engine, and call fini() on failure to clean up exactly the
resources that were initialized.



* Guard fini() against double-call after failed init

If init() fails, it now calls fini() internally. A user calling
fini() again would crash because CURRENT is nullptr after
vcpu_fini(). Add an early return at the top of fini() when
CURRENT is null to make it idempotent.



* Address review: use DEFER + ok pattern instead of goto fail

Per maintainer suggestion, replaced the goto fail + INIT_IO_OR_FAIL
macro approach with the DEFER(if (!ok) fini()) pattern. This is
cleaner and reuses the existing INIT_IO macro unchanged.



* Address review: revert to goto next, move assignments back

Per maintainer feedback:
- Removed engine_ok bool, restored original goto next structure
- Moved g_event_engine/g_io_engine assignments back to the success
  path (before ok=true). fini() only needs vcpu_fini + fd_events_fini
  on early failures since the IO globals are still 0 at that point.



---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.