### PR TITLE
[Backport][0.8 to 0.7] | Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372) 

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -309,17 +309,9 @@ public:
         if (!workth) return;
         auto th = workth;
         workth = nullptr;
-<<<<<<< HEAD
-        if (waiting) {
-            thread_interrupt(th);
-            if (!m_block)
-                thread_join((join_handle*)th);
-        }
-=======
         thread_interrupt(th);
         if (!m_block_serv)
             thread_join((join_handle*)th);
->>>>>>> 250a556 (Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372))
     }
 
     ISocketServer* set_handler(Handler handler) override {

--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -310,7 +310,7 @@ public:
         auto th = workth;
         workth = nullptr;
         thread_interrupt(th);
-        if (!m_block_serv)
+        if (!m_block)
             thread_join((join_handle*)th);
     }
 

--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -309,11 +309,17 @@ public:
         if (!workth) return;
         auto th = workth;
         workth = nullptr;
+<<<<<<< HEAD
         if (waiting) {
             thread_interrupt(th);
             if (!m_block)
                 thread_join((join_handle*)th);
         }
+=======
+        thread_interrupt(th);
+        if (!m_block_serv)
+            thread_join((join_handle*)th);
+>>>>>>> 250a556 (Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372))
     }
 
     ISocketServer* set_handler(Handler handler) override {


### PR DESCRIPTION
> Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.