### PR TITLE
ci: harden backport autopr with bugfix label gate, conflict handling, and CI skip

### DIFF
--- a/.github/workflows/auto-pr-backport.yml
+++ b/.github/workflows/auto-pr-backport.yml
@@ -61,24 +61,57 @@ jobs:
         echo "SOURCE_BRANCH=$SOURCE_BRANCH" >> $GITHUB_OUTPUT
         echo "resolved: COMMIT=$COMMIT RANGE_START=$RANGE_START SOURCE_BRANCH=$SOURCE_BRANCH"
 
-    - name: detect merge source
+    - name: detect source pr
       id: detect
-      run: |
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          # Manual trigger: user explicitly requested it, never skip
-          echo "SKIP=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        MERGE_BRANCH=$(git show -s --format=%B ${{ steps.inputs.outputs.COMMIT }} | grep -oE 'from [^ ]+' | head -n 1 | cut -d' ' -f2) || true
-        echo "MERGE_BRANCH=$MERGE_BRANCH"
-        if echo "$MERGE_BRANCH" | grep -qE '^(auto-pr-[a-f0-9]+-)'; then
-          echo "SKIP=true" >> $GITHUB_OUTPUT
-        else
-          echo "SKIP=false" >> $GITHUB_OUTPUT
-        fi
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.AUTOPR_SECRET }}
+        script: |
+          const isManual = '${{ github.event_name }}' === 'workflow_dispatch';
+          const commit = '${{ steps.inputs.outputs.COMMIT }}';
+          if (isManual) {
+            core.info('Manual trigger: bypassing source PR / bugfix label checks');
+            core.setOutput('SKIP', 'false');
+            core.setOutput('SOURCE_HEAD_REF', '');
+            core.setOutput('HAS_BUGFIX', 'true');
+            return;
+          }
+          const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            ...context.repo,
+            commit_sha: commit,
+          });
+          const merged = prs
+            .filter(p => p.merged_at)
+            .sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at));
+          if (merged.length === 0) {
+            core.info(`no merged PR associated with ${commit}; skipping backport`);
+            core.setOutput('SKIP', 'true');
+            core.setOutput('SOURCE_HEAD_REF', '');
+            core.setOutput('HAS_BUGFIX', 'false');
+            return;
+          }
+          const pr = merged[0];
+          const headRef = (pr.head && pr.head.ref) ? pr.head.ref : '';
+          const labels = (pr.labels || []).map(l => l.name);
+          const hasBugfix = labels.includes('bugfix');
+          core.info(`source PR #${pr.number}, head=${headRef}, labels=[${labels.join(', ')}]`);
+          core.setOutput('SOURCE_HEAD_REF', headRef);
+          core.setOutput('HAS_BUGFIX', hasBugfix ? 'true' : 'false');
+          if (/^auto-pr-[a-f0-9]+-/.test(headRef)) {
+            core.info('source PR head is auto-pr-* (precise); skipping backport to avoid loop');
+            core.setOutput('SKIP', 'true');
+            return;
+          }
+          if (!hasBugfix) {
+            core.info('source PR lacks bugfix label; skipping backport');
+            core.setOutput('SKIP', 'true');
+            return;
+          }
+          core.setOutput('SKIP', 'false');
 
     - name: check branch names
       id: branch_info
+      if: steps.detect.outputs.SKIP != 'true'
       run: |
         RELEASE_VERSIONS=$(git branch -r | grep 'origin/release/' | cut -d '/' -f 3 | sort -V)
         CURRENT_BRANCH="${{ steps.inputs.outputs.SOURCE_BRANCH }}"
@@ -106,17 +139,19 @@ jobs:
 
     - name: create pr branch
       id: create_branch
-      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
+      if: steps.detect.outputs.SKIP != 'true' && steps.branch_info.outputs.HAS_PREV == 'true'
       run: |
         PRBRANCH=backport-pr-${{steps.inputs.outputs.COMMIT}}-${{steps.branch_info.outputs.PREV_VERSION}}
         echo "PRBRANCH=$PRBRANCH" >> $GITHUB_OUTPUT
 
     - name: Cherry-pick commits into ${{steps.branch_info.outputs.PREV_BRANCH}}
       id: merge-changes
-      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
+      if: steps.detect.outputs.SKIP != 'true' && steps.branch_info.outputs.HAS_PREV == 'true'
       run: |
         set -x
         git checkout ${{steps.branch_info.outputs.PREV_BRANCH}}
+        PREV_BRANCH_TIP=$(git rev-parse HEAD)
+        echo "PREV_BRANCH_TIP=$PREV_BRANCH_TIP"
         git checkout -b ${{steps.create_branch.outputs.PRBRANCH}}
         RANGE_START=${{ steps.inputs.outputs.RANGE_START }}
         COMMIT=${{ steps.inputs.outputs.COMMIT }}
@@ -129,28 +164,91 @@ jobs:
         echo "__AUTOPR_EOF" >> $GITHUB_OUTPUT
         cat $GITHUB_OUTPUT
         REVS=$(git rev-list --reverse ${RANGE_START}~..${COMMIT})
-        for rev in "$REVS"; do
-          if ! git cherry-pick ${rev} ; then
-            git add -u
-            git -c core.editor=true cherry-pick --continue
+        HAS_CONFLICT=false
+        CONFLICT_NOTE=""
+        for rev in $REVS; do
+          set +e
+          git cherry-pick "$rev"
+          rc=$?
+          set -e
+          if [ $rc -eq 0 ]; then
+            continue
           fi
+          # Conflict: capture unmerged paths, stage everything (incl. conflict markers), then continue
+          HAS_CONFLICT=true
+          CONFLICTED=$(git diff --name-only --diff-filter=U | tr '\n' ',' | sed 's/,$//')
+          CONFLICT_NOTE+="- ${rev}: ${CONFLICTED}"$'\n'
+          git add -A
+          set +e
+          git -c core.editor=true cherry-pick --continue
+          set -e
         done
+
+        # Drop new files that don't exist in PREV_BRANCH (relative to PREV_BRANCH_TIP)
+        DROPPED_FILES=$(git diff --name-only --diff-filter=A "$PREV_BRANCH_TIP"..HEAD)
+        if [ -n "$DROPPED_FILES" ]; then
+          echo "Dropping new files not present in ${{steps.branch_info.outputs.PREV_BRANCH}}:"
+          echo "$DROPPED_FILES"
+          echo "$DROPPED_FILES" | xargs -r git rm -f
+          git -c core.editor=true commit -m "chore: drop files not present in ${{steps.branch_info.outputs.PREV_VERSION}}"
+        fi
+
+        # If nothing remains to backport after cleanup, abort gracefully
+        if git diff --quiet "$PREV_BRANCH_TIP"..HEAD; then
+          echo "::warning::nothing to backport after dropping new files"
+          echo "EMPTY=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        echo "EMPTY=false" >> $GITHUB_OUTPUT
+        echo "HAS_CONFLICT=$HAS_CONFLICT" >> $GITHUB_OUTPUT
+        echo "CONFLICT_NOTE<<__AUTOPR_EOF" >> $GITHUB_OUTPUT
+        printf "%s" "$CONFLICT_NOTE" >> $GITHUB_OUTPUT
+        echo "__AUTOPR_EOF" >> $GITHUB_OUTPUT
+        echo "DROPPED_FILES<<__AUTOPR_EOF" >> $GITHUB_OUTPUT
+        printf "%s" "$DROPPED_FILES" >> $GITHUB_OUTPUT
+        echo "" >> $GITHUB_OUTPUT
+        echo "__AUTOPR_EOF" >> $GITHUB_OUTPUT
+
         git push -d origin ${{steps.create_branch.outputs.PRBRANCH}} || true
         git push -u origin ${{steps.create_branch.outputs.PRBRANCH}}
 
     - uses: actions/github-script@v7
       name: Open backport PR to ${{steps.branch_info.outputs.PREV_BRANCH}}
-      if: steps.branch_info.outputs.HAS_PREV == 'true' && steps.detect.outputs.SKIP != 'true'
+      if: steps.detect.outputs.SKIP != 'true' && steps.branch_info.outputs.HAS_PREV == 'true' && steps.merge-changes.outputs.EMPTY != 'true'
       env:
           TITLE: ${{steps.merge-changes.outputs.TITLE}}
           MESSAGE: ${{steps.merge-changes.outputs.MESSAGE}}
+          HAS_CONFLICT: ${{steps.merge-changes.outputs.HAS_CONFLICT}}
+          CONFLICT_NOTE: ${{steps.merge-changes.outputs.CONFLICT_NOTE}}
+          DROPPED_FILES: ${{steps.merge-changes.outputs.DROPPED_FILES}}
       with:
         github-token: ${{ secrets.AUTOPR_SECRET }}
         script: |
-          await github.rest.pulls.create({
+          const hasConflict = process.env.HAS_CONFLICT === 'true';
+          const conflictNote = process.env.CONFLICT_NOTE || '';
+          const droppedFiles = (process.env.DROPPED_FILES || '').trim();
+          let body = process.env.MESSAGE +
+            `\nGenerated by Backport Auto PR, by cherry-pick related commits.` +
+            `\n\nPlease review and decide whether to merge or close this backport PR.`;
+          if (hasConflict) {
+            body += `\n\n## Conflicts\n\nCherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.\n\n${conflictNote}`;
+          }
+          if (droppedFiles) {
+            const lines = droppedFiles.split('\n').filter(Boolean).map(f => `- ${f}`).join('\n');
+            body += `\n\n## Dropped new files\n\nThe following new files introduced by cherry-pick were dropped because they don't exist in \`${{steps.branch_info.outputs.PREV_BRANCH}}\`:\n\n${lines}`;
+          }
+          const { data: pr } = await github.rest.pulls.create({
             ...context.repo,
             title: `[Backport][${{steps.branch_info.outputs.CURRENT_VERSION}} to ${{steps.branch_info.outputs.PREV_VERSION}}] ` + process.env.TITLE,
             head: `${{steps.create_branch.outputs.PRBRANCH}}`,
             base: `${{steps.branch_info.outputs.PREV_BRANCH}}`,
-            body: process.env.MESSAGE + `\nGenerated by Backport Auto PR, by cherry-pick related commits.\n\nPlease review and decide whether to merge or close this backport PR.`,
+            body,
+            draft: hasConflict,
+          });
+          const labels = ['bugfix'];
+          if (hasConflict) labels.push('needs-manual-merge');
+          await github.rest.issues.addLabels({
+            ...context.repo,
+            issue_number: pr.number,
+            labels,
           });

--- a/.github/workflows/auto-pr-precise.yml
+++ b/.github/workflows/auto-pr-precise.yml
@@ -22,16 +22,36 @@ jobs:
         git config --global --add safe.directory "${{ github.workspace }}"
         git config -l
 
-    - name: detect merge source
+    - name: detect source pr
       id: detect
-      run: |
-        MERGE_BRANCH=$(git show -s --format=%B ${{ github.event.after }} | grep -oE 'from [^ ]+' | head -n 1 | cut -d' ' -f2) || true
-        echo "MERGE_BRANCH=$MERGE_BRANCH"
-        if echo "$MERGE_BRANCH" | grep -qE '^(backport-pr-[a-f0-9]+-)'; then
-          echo "SKIP=true" >> $GITHUB_OUTPUT
-        else
-          echo "SKIP=false" >> $GITHUB_OUTPUT
-        fi
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.AUTOPR_SECRET }}
+        script: |
+          const commit = '${{ github.event.after }}';
+          const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            ...context.repo,
+            commit_sha: commit,
+          });
+          const merged = prs
+            .filter(p => p.merged_at)
+            .sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at));
+          if (merged.length === 0) {
+            core.info(`no merged PR associated with ${commit}; proceeding with precise auto-pr`);
+            core.setOutput('SKIP', 'false');
+            core.setOutput('SOURCE_HEAD_REF', '');
+            return;
+          }
+          const pr = merged[0];
+          const headRef = (pr.head && pr.head.ref) ? pr.head.ref : '';
+          core.info(`source PR #${pr.number}, head=${headRef}`);
+          core.setOutput('SOURCE_HEAD_REF', headRef);
+          if (/^backport-pr-[a-f0-9]+-/.test(headRef)) {
+            core.info('source PR head is backport-pr-* ; skipping precise auto-pr to avoid loop');
+            core.setOutput('SKIP', 'true');
+            return;
+          }
+          core.setOutput('SKIP', 'false');
 
     - name: check branch names
       id: branch_info

--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -2,10 +2,12 @@ name: Linux ARM
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, unlabeled]
     branches: [ "main", "release/*" ]
 
 jobs:
   arm-linux-build-and-test:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-24.04-arm
 
     container:
@@ -117,6 +119,7 @@ jobs:
           pkill redis-server
 
   debug-build-from-source:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-24.04-arm
     container:
       image: almalinux:8

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -2,10 +2,12 @@ name: Linux x86_64
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, unlabeled]
     branches: [ "main", "release/*" ]
 
 jobs:
   gcc850:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -47,6 +49,7 @@ jobs:
           pkill redis-server
 
   gcc921:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -89,6 +92,7 @@ jobs:
           pkill redis-server
 
   gcc1031:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -131,6 +135,7 @@ jobs:
           pkill redis-server
 
   gcc1121:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -173,6 +178,7 @@ jobs:
           pkill redis-server
 
   gcc1211:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -215,6 +221,7 @@ jobs:
           pkill redis-server
 
   gcc13:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -257,6 +264,7 @@ jobs:
           pkill redis-server
 
   gcc14:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -299,6 +307,7 @@ jobs:
           pkill redis-server
 
   fstack:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-fstack:latest
@@ -313,6 +322,7 @@ jobs:
           cmake --build build -j $(nproc) -t fstack-dpdk-demo
 
   RocksDB:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: almalinux:8

--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -2,10 +2,12 @@ name: macOS ARM
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, unlabeled]
     branches: [ "main", "release/*" ]
 
 jobs:
   macOS14-arm:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: macos-15
 
     steps:

--- a/.github/workflows/ci.macos.x86_64.yml
+++ b/.github/workflows/ci.macos.x86_64.yml
@@ -2,10 +2,12 @@ name: macOS x86_64
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, unlabeled]
     branches: [ "main", "release/*" ]
 
 jobs:
   macOS13-x86:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: macos-15
 
     steps:


### PR DESCRIPTION
## Summary

Harden the backport auto-PR workflow to address several issues:

1. **Fix re-trigger loop** (issue 1): Replace commit message parsing with GitHub API (`listPullRequestsAssociatedWithCommit`) to reliably detect source PR head ref regardless of merge strategy (rebase/squash/merge commit).

2. **Bugfix label gate** (new design): Only backport commits from PRs carrying the `bugfix` label. Backport PRs also get the `bugfix` label for consistency. Manual `workflow_dispatch` bypasses this check.

3. **Cherry-pick conflict handling** (issue 2): When cherry-pick conflicts, stage conflict markers and create a **draft** PR with `needs-manual-merge` label, instead of silently resolving with `git add -u`.

4. **Auto-drop new files** (issue 3): After cherry-pick, automatically remove files that don't exist in the target branch and note them in the PR body.

5. **CI skip for conflict PRs**: All 4 CI workflows skip jobs when `needs-manual-merge` label is present. Supports `unlabeled` event to re-trigger CI after the label is removed (no empty commit needed).

6. **Symmetric fix for precise workflow**: `auto-pr-precise.yml` also uses the API-based detection to avoid loop when `backport-pr-*` branches are merged via squash/rebase.

## Files changed

- `.github/workflows/auto-pr-backport.yml` — major rewrite
- `.github/workflows/auto-pr-precise.yml` — detect step replaced
- `.github/workflows/ci.linux.x86_64.yml` — types + if gate
- `.github/workflows/ci.linux.arm.yml` — types + if gate
- `.github/workflows/ci.macos.x86_64.yml` — types + if gate
- `.github/workflows/ci.macos.arm.yml` — types + if gate