### PR TITLE
[Pick][0.9 to main] | [Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) 

### DIFF
--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -270,10 +270,10 @@ size_t Message::body_size() const {
     it = headers.find("Content-Range");
     if (it != headers.end()) {
         size_t start, end;
-        if (sscanf("bytes %lu-%lu", it.second().data(), &start, &end) == 2) {
+        if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
             return end-start+1;
         }
-        if (sscanf("bytes */%lu", it.second().data(), &end) == 1) {
+        if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
             return end;
         }
         return 0;


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325)

* Fix swapped sscanf arguments in Content-Range parsing (#1262)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

* Update message.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits