### PR TITLE
[Backport][0.9 to 0.8] | [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) 

### DIFF
--- a/common/expirecontainer.cpp
+++ b/common/expirecontainer.cpp
@@ -151,8 +151,15 @@ void* ObjectCacheBase::ref_release(ItemPtr item, bool recycle, bool destroy) {
 }
 
 // the argument `key` plays the roles of (type-erased) key
-void* ObjectCacheBase::release(const Item& key_item, bool recycle, bool destroy) {
-    auto item = ExpireContainerBase::TypedIterator<Item>(Base::find(key_item));
-    if (item == end()) return nullptr;
-    return ref_release(*item, recycle, destroy);
+void* ObjectCacheBase::release(const Item& key_item, bool recycle,
+                               bool destroy) {
+    ItemPtr item;
+    {
+        SCOPED_LOCK(_lock);
+        auto it = ExpireContainerBase::TypedIterator<Item>(Base::__find_prelock(key_item));
+        if (it == end()) return nullptr;
+        item = *it;
+    }
+    return ref_release(item, recycle, destroy);
+
 }

--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -272,8 +272,8 @@ protected:
     using Base::idx;
     using Base::tail;  // write_tail
 
-    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> write_head;
-    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> read_tail;
+    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> write_head{0};
+    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> read_tail{0};
 
     T slots[Base::capacity];
 

--- a/common/objectcachev2.h
+++ b/common/objectcachev2.h
@@ -148,11 +148,38 @@ public:
             _box->acquire();
         }
 
-        Borrow(Borrow&& rhs) : _reader(nullptr) { *this = std::move(rhs); }
+        Borrow(Borrow&& rhs) : _reader(nullptr) {
+            _oc = rhs._oc;
+            _box = rhs._box;
+            _reader = std::move(rhs._reader);
+            _recycle = rhs._recycle;
+            rhs._oc = nullptr;
+            rhs._box = nullptr;
+        }
 
-        Borrow& operator=(Borrow&& rhs) = default;
+        Borrow& operator=(Borrow&& rhs) {
+            if (this != &rhs) {
+                if (_box) {
+                    if (_recycle) _box->reset();
+                    _box->release();
+                    if (_box->rc == 0) {
+                        SCOPED_LOCK(_oc->maplock);
+                        _oc->lru_list.pop(_box);
+                        _oc->lru_list.push_back(_box);
+                    }
+                }
+                _oc = rhs._oc;
+                _box = rhs._box;
+                _reader = std::move(rhs._reader);
+                _recycle = rhs._recycle;
+                rhs._oc = nullptr;
+                rhs._box = nullptr;
+            }
+            return *this;
+        }
 
         ~Borrow() {
+            if (!_box) return;
             if (_recycle) {
                 _box->reset();
             }


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339)

* Fix lockfree queue init and ObjectCache move/lock bugs (#1284)

* Refactor release method in ObjectCacheBase

* Update lockfree_queue.h

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.