### PR TITLE
[Pick][0.9 to main] | [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) 

### DIFF
--- a/common/expirecontainer.cpp
+++ b/common/expirecontainer.cpp
@@ -167,4 +167,8 @@ void* ObjectCacheBase::release(const Item& key_item, bool recycle,
         item = *it;
     }
     return ref_release(item, recycle, destroy);
+<<<<<<< HEAD
+=======
+
+>>>>>>> fce4975 ([Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339))
 }

--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -317,8 +317,13 @@ protected:
     using Base::idx;
     using Base::tail;  // write_tail
 
+<<<<<<< HEAD
     alignas(CPUCacheLine::SIZE) std::atomic<size_t> write_head{0};
     alignas(CPUCacheLine::SIZE) std::atomic<size_t> read_tail{0};
+=======
+    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> write_head{0};
+    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> read_tail{0};
+>>>>>>> fce4975 ([Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339))
 
     T slots[Base::SLOTS_NUM];
     explicit LockfreeBatchMPMCRingQueue(size_t c) : Base(c) {}


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339)

* Fix lockfree queue init and ObjectCache move/lock bugs (#1284)

* Refactor release method in ObjectCacheBase

* Update lockfree_queue.h

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits