### PR TITLE
[Backport][0.7 to 0.6] | Fix SubFile pwritev offset and path buffer overflow (#1279) (#1357) (#1360) (#1390) 

### DIFF
--- a/fs/path.cpp
+++ b/fs/path.cpp
@@ -98,6 +98,9 @@ namespace fs
         if (len == 0) return 0;
 
         char path[PATH_MAX];
+        if (len >= PATH_MAX - 1) {
+            LOG_ERROR_RETURN(ENAMETOOLONG, -1, "pathname too long");
+        }
         if (pathname[0] != '/') {
             *path = '/';
             memcpy(path + 1, pathname.begin(), len);
@@ -284,6 +287,8 @@ namespace fs
         auto len0 = m_path_len;
         auto len1 = s.length();
         assert(len0 + len1 < sizeof(m_path_buffer) - 1);
+        if (len0 + len1 >= sizeof(m_path_buffer) - 1)
+            return;
         memcpy(m_path_buffer + len0, s.data(), len1 + 1);
         m_path_len = len0 + len1;
     }

--- a/fs/subfs.cpp
+++ b/fs/subfs.cpp
@@ -328,7 +328,7 @@ namespace fs
                 return 0;
             IOVector iovs(iov, iovcnt);
             iovs.shrink_to(m_length - offset);
-            return m_file->pwritev(iovs.iovec(), iovs.iovcnt(), offset);
+            return m_file->pwritev(iovs.iovec(), iovs.iovcnt(), offset + m_offset);
         }
     };
 


### PR DESCRIPTION
> Fix SubFile pwritev offset and path buffer overflow (#1279) (#1357) (#1360) (#1390)

* Fix SubFile pwritev offset and path buffer overflow checks

* Address review: use LOG_ERROR_RETURN for path length check

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.