### PR TITLE
[Backport][0.8 to 0.7] | try_goto: insert target before current to reduce runq reordering (#1316) (#1351) (#1383) 

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -621,7 +621,7 @@ namespace photon
         Switch try_goto(thread* th) const {
             assert(th->vcpu == vcpu);
             th->remove_from_list();
-            current->insert_after(th);
+            current->insert_before(th);
             return _do_goto(th);
         }
         bool single() const {


### PR DESCRIPTION
> try_goto: insert target before current to reduce runq reordering (#1316) (#1351) (#1383)

* try_goto: insert target before current to reduce runq reordering

Using insert_before instead of insert_after minimizes the disturbance to runq order on yield_to, keeping scheduling more uniform. The common thread_create + yield_to case (th == current->prev()) becomes a no-op.

* Makes workpoll yield to target thread directly so that local task variable will surely available

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.