### PR TITLE
[Backport][0.8 to 0.7] | Fix iouring eventfd double-close on repeated fini() (#1268) (#1318) (#1384) 

### DIFF
--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -66,6 +66,7 @@ public:
         }
         if (m_eventfd >= 0) {
             close(m_eventfd);
+            m_eventfd = -1;
         }
         if (m_ring != nullptr) {
             io_uring_queue_exit(m_ring);


### PR DESCRIPTION
> Fix iouring eventfd double-close on repeated fini() (#1268) (#1318) (#1384)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.