### PR TITLE
[Backport][0.9 to 0.8] | [Backport][main to 0.9] | Fix alog snprintf overflow and iovector slice/iterator bugs (#1283)  (#1382) 

### DIFF
--- a/common/alog.h
+++ b/common/alog.h
@@ -262,6 +262,7 @@ protected:
     {
         int ret = ::snprintf(buf.ptr, buf.size, fmt, x);
         if (ret < 0) return;
+        if ((size_t)ret > buf.size) ret = buf.size;
         buf.consume(ret);
     }
 

--- a/common/iovector.cpp
+++ b/common/iovector.cpp
@@ -77,28 +77,50 @@ ssize_t iovector_view::slice(size_t count, off_t offset, iovector_view* /*OUT*/ 
         // empty iov, takes as no useable nested iovec to store the result
         return -1;
     }
+    if (unlikely(count == 0)) {
+        iov->iovcnt = 0;
+        return 0;
+    }
     int cnt = 0;
-    off_t pos = 0;
     auto ptr = iov->iov;
     ssize_t ret = 0;
-    for (auto &p : *this) {
-        if (count && (pos + (off_t)p.iov_len > offset)) {
-            if (offset > pos) {
-                ptr[cnt].iov_base = (char*)p.iov_base + (offset - pos);
-                ptr[cnt].iov_len = p.iov_len - (offset - pos);
-            } else {
-                ptr[cnt].iov_base = p.iov_base;
-                ptr[cnt].iov_len = p.iov_len;
-            }
-            if (count < ptr[cnt].iov_len)
-                ptr[cnt].iov_len = count;
-            pos += p.iov_len;
-            ret += ptr[cnt].iov_len;
-            count -= ptr[cnt].iov_len;
-            cnt ++;
-            if (cnt == iov->iovcnt)
-                break;
+    auto it = begin();
+    auto e = end();
+    // skip iovec elements before offset
+    off_t pos = 0;
+    for (; it != e; ++it) {
+        if (pos + (off_t)it->iov_len > offset)
+            break;
+        pos += it->iov_len;
+    }
+    // process the first element (may be partial due to offset)
+    if (it != e) {
+        ptr[cnt].iov_base = (char*)it->iov_base + (offset - pos);
+        ptr[cnt].iov_len = it->iov_len - (offset - pos);
+        if (count <= ptr[cnt].iov_len) {
+            ptr[cnt].iov_len = count;
+            ret += count;
+            iov->iovcnt = cnt + 1;
+            return ret;
         }
+        ret += ptr[cnt].iov_len;
+        count -= ptr[cnt].iov_len;
+        cnt++;
+        ++it;
+    }
+    // process remaining full elements
+    for (; it != e && cnt < iov->iovcnt; ++it) {
+        ptr[cnt].iov_base = it->iov_base;
+        ptr[cnt].iov_len = it->iov_len;
+        if (count <= ptr[cnt].iov_len) {
+            ptr[cnt].iov_len = count;
+            ret += count;
+            iov->iovcnt = cnt + 1;
+            return ret;
+        }
+        ret += ptr[cnt].iov_len;
+        count -= ptr[cnt].iov_len;
+        cnt++;
     }
     iov->iovcnt = cnt;
     return ret;


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix alog snprintf overflow and iovector slice/iterator bugs (#1283)  (#1382)

* Fix alog snprintf overflow and iovector slice/iterator bugs (#1283)

* Fix log buffer overflow and iovector slice/iterator bugs

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

* Address review: refactor slice to process first element before loop

- Skip loop only skips complete iovec elements
- Process first (potentially partial) element separately
- Main loop only handles full elements, no branching

---------

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

* Update iovector.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.