### PR TITLE
[Backport][0.8 to 0.7] | Fix OOB access in event engines when fd is 0 (#1265) (#1322) (#1387) 

### DIFF
--- a/io/epoll.cpp
+++ b/io/epoll.cpp
@@ -121,7 +121,7 @@ public:
         if (unlikely(!e.interests))
             return 0;
         if (unlikely((size_t)e.fd >= _inflight_events.size()))
-            _inflight_events.resize(e.fd * 2);
+            _inflight_events.resize(e.fd * 2 + 2);
 
         e.interests &= EVENT_RWEO;
         auto& entry = _inflight_events[e.fd];

--- a/io/kqueue.cpp
+++ b/io/kqueue.cpp
@@ -140,7 +140,7 @@ public:
         if (e.fd < 0)
             LOG_ERROR_RETURN(EINVAL, -1, "invalid file descriptor ", e.fd);
         if ((size_t)e.fd >= _inflight_events.size())
-            _inflight_events.resize(e.fd * 2);
+            _inflight_events.resize(e.fd * 2 + 2);
         auto& entry = _inflight_events[e.fd];
         if (e.interests & entry.interests) {
             if (((e.interests & entry.interests & EVENT_READ) &&


### PR DESCRIPTION
> Fix OOB access in event engines when fd is 0 (#1265) (#1322) (#1387)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.