### PR TITLE
[Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix crash in threads_create_join on partial failure (#1252)  (#1328) (#1393) 

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1435,10 +1435,10 @@ R"(
         return 0;
     }
 
-    void threads_create_join(uint64_t n,
+    uint64_t threads_create_join(uint64_t n,
         thread_entry start, void* arg, uint64_t stack_size)
     {
-        if (n == 0) return;
+        if (n == 0) return 0;
         thread* threads[32];
         thread** pthreads = threads;
         std::vector<thread*> _threads;
@@ -1447,16 +1447,18 @@ R"(
             _threads.resize(n);
             pthreads = &_threads[0];
         }
+        uint64_t created = 0;
         for (uint64_t i = 0; i < n; ++i)
         {
             auto th = thread_create(start, arg, stack_size);
             if (!th) break;
             thread_enable_join(th);
-            pthreads[i] = th;
+            pthreads[created++] = th;
         }
-        for (uint64_t i = 0; i < n; ++i) {
+        for (uint64_t i = 0; i < created; ++i) {
             thread_join(pthreads[i]);
         }
+        return created;
     }
 
     void Timer::stub()

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -439,8 +439,10 @@ namespace photon
         bool m_locked;
     };
 
-    // create `n` threads to run `start(arg)`, then get joined
-    void threads_create_join(uint64_t n, thread_entry start, void* arg,
+    // create `n` threads to run `start(arg)`, then get joined;
+    // returns the number of threads actually created (< n if
+    // thread_create() failed partway), which is the number joined.
+    uint64_t threads_create_join(uint64_t n, thread_entry start, void* arg,
                           uint64_t stack_size = DEFAULT_STACK_SIZE);
 
     bool is_master_event_engine_default();


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix crash in threads_create_join on partial failure (#1252)  (#1328) (#1393)

* Fix crash in threads_create_join on partial failure (#1252)

* Fix crash in threads_create_join on partial failure

When thread_create() fails mid-loop, only join threads that were
actually created. Previously the join loop iterated all n slots,
calling thread_join on uninitialized pointers (stack array case)
or nullptr (vector case), causing a segfault.



* Address review: return # of threads created, use created++ index

Per maintainer feedback:
- threads_create_join now returns the actual number of threads created
  (< n on partial failure), so callers can detect partial failure.
- Use pthreads[created++] = th instead of a separate created++ line.



---------



* Update thread.h

* Update thread.h

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.