### PR TITLE
Fix FIEMAP extent flags check and probeFiemap reliability

### DIFF
--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -19,6 +19,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel   \
@@ -61,6 +68,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-9/enable
@@ -104,6 +118,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-10/enable
@@ -147,6 +168,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-11/enable
@@ -190,6 +218,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-12/enable
@@ -233,6 +268,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-13/enable
@@ -276,6 +318,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-14/enable

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -90,11 +90,27 @@ void FileCachePool::probeFiemap() {
     if (!preExists) mediaFs_->unlink(probePath);
   });
 
-  fiemap_t<1> fie(0, 1);
-  fie.fm_mapped_extents = 0;
-  if (probe->fiemap(&fie) != 0) {
+  // Write data before probing; an empty-file probe falsely succeeds on tmpfs.
+  char buf[4096] = {};
+  if (probe->pwrite(buf, sizeof(buf), 0) != (ssize_t)sizeof(buf)) {
     fiemapSupported_ = false;
-    LOG_INFO("Call fiemap failed, errno `", ERRNO());
+    LOG_INFO("fiemap probe write failed, errno `", ERRNO());
+    return;
+  }
+
+  fiemap_t<1> fie(0, sizeof(buf));
+  fie.fm_mapped_extents = 0;
+  if (probe->fiemap(&fie) != 0 || fie.fm_mapped_extents == 0) {
+    fiemapSupported_ = false;
+    LOG_INFO("fiemap not supported on this filesystem, errno `", ERRNO());
+    return;
+  }
+
+  // Overlayfs returns extents with FIEMAP_EXTENT_UNKNOWN, which are skipped
+  // by queryRefillRange. Detect and fall back to in-memory range tracking.
+  if (fie.fm_extents[0].fe_flags & FIEMAP_EXTENT_UNKNOWN) {
+    fiemapSupported_ = false;
+    LOG_INFO("fiemap returns UNKNOWN extents, falling back to range tracking");
   }
 }
 

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -82,7 +82,6 @@ void FileCachePool::probeFiemap() {
   bool preExists = (mediaFs_->stat(probePath, &st) == 0);
   auto probe = mediaFs_->open(probePath, O_CREAT | O_RDWR, 0600);
   if (!probe) {
-    fiemapSupported_ = false;
     LOG_ERRNO_RETURN(0, void(), "fiemap probe file open failed");
   }
   DEFER({
@@ -90,10 +89,8 @@ void FileCachePool::probeFiemap() {
     if (!preExists) mediaFs_->unlink(probePath);
   });
 
-  // Write data before probing; an empty-file probe falsely succeeds on tmpfs.
   char buf[4096] = {};
   if (probe->pwrite(buf, sizeof(buf), 0) != (ssize_t)sizeof(buf)) {
-    fiemapSupported_ = false;
     LOG_INFO("fiemap probe write failed, errno `", ERRNO());
     return;
   }
@@ -101,7 +98,6 @@ void FileCachePool::probeFiemap() {
   fiemap_t<1> fie(0, sizeof(buf));
   fie.fm_mapped_extents = 0;
   if (probe->fiemap(&fie) != 0 || fie.fm_mapped_extents == 0) {
-    fiemapSupported_ = false;
     LOG_INFO("fiemap not supported on this filesystem, errno `", ERRNO());
     return;
   }
@@ -109,9 +105,11 @@ void FileCachePool::probeFiemap() {
   // Overlayfs returns extents with FIEMAP_EXTENT_UNKNOWN, which are skipped
   // by queryRefillRange. Detect and fall back to in-memory range tracking.
   if (fie.fm_extents[0].fe_flags & FIEMAP_EXTENT_UNKNOWN) {
-    fiemapSupported_ = false;
     LOG_INFO("fiemap returns UNKNOWN extents, falling back to range tracking");
+    return;
   }
+
+  fiemapSupported_ = true;
 }
 
 ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t mode) {

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -150,7 +150,7 @@ protected:
 
     bool isFull_;
 
-    bool fiemapSupported_ = true;
+    bool fiemapSupported_ = false;
     void probeFiemap();
 
     virtual bool afterFtrucate(FileNameMap::iterator iter);

--- a/fs/cache/full_file_cache/cache_store.cpp
+++ b/fs/cache/full_file_cache/cache_store.cpp
@@ -152,7 +152,7 @@ std::pair<off_t, size_t> FileCacheStore::queryRefillRange(off_t offset, size_t s
 
   for (ssize_t i = (ssize_t)(fie.fm_mapped_extents) - 1; i >= 0; i--) {
     auto& extent = fie.fm_extents[i];
-    if ((extent.fe_flags == FIEMAP_EXTENT_UNKNOWN) || (extent.fe_flags == FIEMAP_EXTENT_UNWRITTEN)) continue;
+    if (extent.fe_flags & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_UNWRITTEN)) continue;
       if (extent.fe_logical < holeEnd){
         if (extent.fe_logical_end() >= holeEnd){
           holeEnd = extent.fe_logical;
@@ -162,7 +162,7 @@ std::pair<off_t, size_t> FileCacheStore::queryRefillRange(off_t offset, size_t s
 
   for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
     auto& extent = fie.fm_extents[i];
-    if ((extent.fe_flags == FIEMAP_EXTENT_UNKNOWN) || (extent.fe_flags == FIEMAP_EXTENT_UNWRITTEN)) continue;
+    if (extent.fe_flags & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_UNWRITTEN)) continue;
       if (extent.fe_logical_end() > holeStart){
         if (extent.fe_logical <= holeStart){
           holeStart = extent.fe_logical_end();

--- a/fs/cache/persistent_cache/persistent_cache.cpp
+++ b/fs/cache/persistent_cache/persistent_cache.cpp
@@ -323,8 +323,7 @@ std::pair<off_t, size_t> PersistentCacheStore::query_refill_range(off_t offset, 
 
     for (auto i = fie.fm_mapped_extents - 1; i < fie.fm_mapped_extents; i--) {
         auto &extent = fie.fm_extents[i];
-        if ((extent.fe_flags == FIEMAP_EXTENT_UNKNOWN) ||
-            (extent.fe_flags == FIEMAP_EXTENT_UNWRITTEN))
+        if (extent.fe_flags & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_UNWRITTEN))
             continue;
         if (extent.fe_logical < hole_end) {
             if (extent.fe_logical_end() >= hole_end) {
@@ -336,8 +335,7 @@ std::pair<off_t, size_t> PersistentCacheStore::query_refill_range(off_t offset, 
 
     for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
         auto &extent = fie.fm_extents[i];
-        if ((extent.fe_flags == FIEMAP_EXTENT_UNKNOWN) ||
-            (extent.fe_flags == FIEMAP_EXTENT_UNWRITTEN))
+        if (extent.fe_flags & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_UNWRITTEN))
             continue;
         if (extent.fe_logical_end() > hole_start) {
             if (extent.fe_logical <= hole_start) {


### PR DESCRIPTION
## Summary

- **Fix bitmask check in `queryRefillRange`**: `fe_flags` is a bitmask where multiple `FIEMAP_EXTENT_*` flags can be set simultaneously (e.g. `FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_LAST`). Using `==` only matches exact values, missing extents with additional flags. Changed to bitwise `&` in both `cache_store.cpp` and `persistent_cache.cpp`.

- **Fix `probeFiemap` false positives**: The probe used an empty file, which falsely succeeds on tmpfs (ioctl returns 0 with no extents instead of failing). On overlayfs, fiemap returns extents with `FIEMAP_EXTENT_UNKNOWN` that `queryRefillRange` skips, making the fiemap path useless. Now writes data before probing and verifies the returned extents are usable (non-zero count, no UNKNOWN flag). When detection fails, falls back to in-memory range tracking via `RangeModule`.

- **CI: add ext4 loopback for fiemap tests**: The CI container uses overlayfs which does not support reliable fiemap. Mounts a 256MB ext4 loopback at `/root/tmp` so `cache_test` exercises both the fiemap path (ext4) and the `RangeModule` fallback path (tmpfs).

## Test plan
- [x] All 16 `cache_test` tests pass locally (including `refill_range_*` on both tmpfs and ext4)
- [x] CI passes with ext4 loopback mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)