### PR TITLE
Fix rsocket read/write not advancing buffer on partial I/O

### DIFF
--- a/net/rsocket/rsocket.cpp
+++ b/net/rsocket/rsocket.cpp
@@ -145,19 +145,6 @@ struct RSockFD {
         return 0;
     }
 
-    template <int EVENT, typename FUNC, typename... ARGS>
-    ssize_t do_io_fully_action(uint64_t t, FUNC f, size_t n, ARGS... args) {
-        Timeout tmo(t);
-        ssize_t x = 0;
-        while (x < (ssize_t)n) {
-            auto ret = do_io_action<EVENT>(tmo.timeout(), f, args...);
-            if (ret < 0) return ret;
-            if (ret == 0) return x;
-            x += ret;
-        }
-        return x;
-    }
-
     ssize_t recv(uint64_t timeout, void* buf, size_t count, int flags = 0) {
         return do_io_action<POLLIN>(timeout, rrecv, buf, count, flags);
     }
@@ -167,13 +154,18 @@ struct RSockFD {
         return do_io_action<POLLIN>(timeout, rrecvmsg, msg, flags);
     }
     ssize_t read(uint64_t timeout, void* buf, size_t count) {
-        return do_io_fully_action<POLLIN>(timeout, rrecv, count, buf, count, 0);
+        Timeout tmo(timeout);
+        return DOIO_LOOP(
+            do_io_action<POLLIN>(tmo.timeout(), rrecv, buf, count, 0),
+            BufStep(buf, count));
     }
     ssize_t readv(uint64_t timeout, const struct iovec* iov, int iovcnt) {
-        iovector_view viov{(iovec*)iov, iovcnt};
-        tmp_msg_hdr msg(viov);
-        return do_io_fully_action<POLLIN>(timeout, rrecvmsg, viov.sum(), msg,
-                                          0);
+        SmartCloneIOV<8> clone(iov, iovcnt);
+        iovector_view view(clone.ptr, iovcnt);
+        Timeout tmo(timeout);
+        return DOIO_LOOP(
+            do_io_action<POLLIN>(tmo.timeout(), rrecvmsg, tmp_msg_hdr(view), 0),
+            BufStepV(view));
     }
     ssize_t send(uint64_t timeout, const void* buf, size_t count,
                  int flags = 0) {
@@ -185,14 +177,18 @@ struct RSockFD {
         return do_io_action<POLLOUT>(timeout, rsendmsg, msg, flags);
     }
     ssize_t write(uint64_t timeout, const void* buf, size_t count) {
-        return do_io_fully_action<POLLOUT>(timeout, rsend, count, buf, count,
-                                           0);
+        Timeout tmo(timeout);
+        return DOIO_LOOP(
+            do_io_action<POLLOUT>(tmo.timeout(), rsend, buf, count, 0),
+            BufStep((void*&)buf, count));
     }
     ssize_t writev(uint64_t timeout, const struct iovec* iov, int iovcnt) {
-        iovector_view viov{(iovec*)iov, iovcnt};
-        tmp_msg_hdr msg(viov);
-        return do_io_fully_action<POLLOUT>(timeout, rsendmsg, viov.sum(), msg,
-                                           0);
+        SmartCloneIOV<8> clone(iov, iovcnt);
+        iovector_view view(clone.ptr, iovcnt);
+        Timeout tmo(timeout);
+        return DOIO_LOOP(
+            do_io_action<POLLOUT>(tmo.timeout(), rsendmsg, tmp_msg_hdr(view), 0),
+            BufStepV(view));
     }
     int shutdown(ShutdownHow how) {
         return rshutdown(fd, static_cast<int>(how));


### PR DESCRIPTION
## Summary
Reworked from #1289 per @Coldwings review feedback.

The original `do_io_fully_action` template forwarded the same `args...` (buf, count, 0) on every retry, so on a partial transfer it never advanced the buffer nor shrank the count: a partial read overwrites the buffer head and over-counts (falsely reporting a full read), a partial write re-sends the head and drops the tail. The fd is O_NONBLOCK and rsend/rrecv can return short counts, so this is reachable — just masked when the first call transfers everything.

## Changes
- **Delete** `do_io_fully_action` entirely (addresses the 4-copies-of-the-loop concern by removing the template, not duplicating it)
- Re-implement `read/write/readv/writev` with `DOIO_LOOP` + `BufStep`/`BufStepV` (the same machinery `KernelSocketStream` uses, net/kernel_socket.cpp:98-116)
- `readv/writev` clone the caller iov with `SmartCloneIOV<8>` **before** looping, so the const-promised caller iovec is never mutated by `extract_front`
- `recv/send` (single-shot POSIX semantics) unchanged
- Timeout return-value change from #1289 dropped (out of scope)

## Why read/write must advance (not single-shot)
In Photon's `ISocketStream`, `read/readv/write/writev` are the full-transfer family (stream.h: "photon-safe atomic operation"; `readv` takes `const iovec*`), while `recv/send` are single-shot. Every other implementation follows this — `KernelSocketStream` read/write use `DOIO_LOOP + BufStep`.

## Verification
- Structural review: 2 independent reviewers, APPROVED
- Compilation: rsocket.cpp is gated behind `PHOTON_ENABLE_RSOCKET` (OFF by default) and needs librdmacm, which is not available in our build env. Verified via `-fsyntax-only` against real photon headers with a librdmacm stub. The change is byte-for-byte the kernel_socket.cpp idiom, which IS in the default build.
- **E2E not done**: rsocket data-transfer test needs an RDMA-capable (or soft-RoCE/rxe) device, which our env lacks. Behavior correctness argued from the diff + kernel_socket.cpp precedent.

Replaces #1289.