### PR TITLE
Fix null pointer dereference in sorted_map deserialize

### DIFF
--- a/rpc/serialize.h
+++ b/rpc/serialize.h
@@ -506,6 +506,7 @@ namespace rpc
                 iov.push_back(s.addr(), s.size());
                 DeserializerIOV deserializer;
                 auto* t = deserializer.deserialize<V>(&iov);
+                if (!t) return;  // deserialize failed (e.g. truncated/corrupt input)
 
                 m_pair.first = m_ptr->first | *m_base_buffer;
                 m_pair.second = *t;


### PR DESCRIPTION
## Summary
Split out from #1289 (uncontroversial part).

In the sorted_map `Iterator::deserialize`, `deserialize<V>()` can return nullptr on truncated/corrupt RPC input (extract_back/checksum/nested-extract failure), but the code dereferenced it unconditionally (`m_pair.second = *t`). Added a null check before the dereference.

## Impact
Guards a null deref on network-controlled RPC input (DoS via crafted/truncated message).

## Verification
- Code review: APPROVED
- Compilation: verified (Debug, URING=OFF)