### PR TITLE
[Pick][0.9 to main] | [Backport][main to 0.9] | Fix critical bugs in work-stealing and thread-pool (#1246)  (#1331) 

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -2051,8 +2051,13 @@ insert_list:
         auto u = vcpu->next();
         while (u != vcpu) {
             if (0 == (u->flags & VCPU_ENABLE_PASSIVE_WORK_STEALING)) {
+<<<<<<< HEAD
                 SCOPED_LOCK(vcpu_t::vcpu_list_lock);
                 u = u->next();
+=======
+                SCOPED_LOCK(vcpu_list_lock);
+                u = u->next;
+>>>>>>> 6860ea8 ([Backport][main to 0.9] | Fix critical bugs in work-stealing and thread-pool (#1246)  (#1331))
                 continue;
             }
             thread* th;


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix critical bugs in work-stealing and thread-pool (#1246)  (#1331)

* Fix critical bugs in work-stealing and thread-pool (#1246)

1. Fix infinite loop in try_work_stealing(): the `continue` on the
   passive-work-stealing check skipped iterator advancement, causing
   the idle worker to spin forever when encountering a vCPU without
   VCPU_ENABLE_PASSIVE_WORK_STEALING.

2. Fix null pointer dereference in ws_scan_standbyq(): the do-while
   condition called q.front()->allow_work_stealing() without checking
   q.empty() first, crashing when all stealable threads were popped.

3. Fix set_bypass_threadpool() ignoring its parameter: the function
   always set __bypass_threadpool = true regardless of the flag argument.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

* Update thread.cpp

* Update thread.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits