### PR TITLE
[Backport][0.8 to 0.7] | Fix Base64Encode underflow on empty input (#1266) (#1321) (#1386) 

### DIFF
--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -127,6 +127,7 @@ void base64_translate_3to4(const char *in, char *out)  {
 }
 
 void Base64Encode(std::string_view in, std::string &out) {
+    if (in.empty()) { out.clear(); return; }
     auto main = in.size() / 3;
     auto remain = in.size() % 3;
     if (0 == remain) {


### PR DESCRIPTION
> Fix Base64Encode underflow on empty input (#1266) (#1321) (#1386)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.