### PR TITLE
[Backport][0.7 to 0.6] | Fix IdentityPoolBase::do_scale reading shared state outside lock (#1300) (#1335) (#1374) (#1403) 

### DIFF
--- a/common/identity-pool.cpp
+++ b/common/identity-pool.cpp
@@ -56,9 +56,9 @@ void IdentityPoolBase::put(void* obj)
 
 uint64_t IdentityPoolBase::do_scale()
 {
+    SCOPED_LOCK(m_mtx);
     auto des_n = (min_size_in_interval + 1) / 2;
     assert(des_n <= m_size);
-    SCOPED_LOCK(m_mtx);
     while (m_size > 0 && des_n-- > 0) {
         auto x = --m_size;
         m_mtx.unlock();


### PR DESCRIPTION
> Fix IdentityPoolBase::do_scale reading shared state outside lock (#1300) (#1335) (#1374) (#1403)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.