### PR TITLE
[Backport][0.8 to 0.7] | Fix UDP recv waiting on writable instead of readable (#1261) (#1326) (#1396) 

### DIFF
--- a/net/datagram_socket.cpp
+++ b/net/datagram_socket.cpp
@@ -100,9 +100,14 @@ public:
             .msg_iovlen = (decltype(msghdr::msg_iovlen))iovcnt,
             .msg_control = nullptr, .msg_controllen = 0, .msg_flags = flags,
         };
+<<<<<<< HEAD
         auto ret =
             doio([&] { return ::recvmsg(fd, &hdr, MSG_DONTWAIT | flags); },
                  [&] { return photon::wait_for_fd_readable(fd); });
+=======
+        auto ret = DOIO_ONCE(::recvmsg(fd, &hdr, MSG_DONTWAIT | flags),
+                         wait_for_fd_readable(fd));
+>>>>>>> 0771526 (Fix UDP recv waiting on writable instead of readable (#1261) (#1326) (#1396))
         if (addrlen) *addrlen = hdr.msg_namelen;
         return ret;
     }


### PR DESCRIPTION
> Fix UDP recv waiting on writable instead of readable (#1261) (#1326) (#1396)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.