### PR TITLE
[Backport][0.9 to 0.8] | [Backport][main to 0.9] | Fix critical bugs in work-stealing and thread-pool (#1246)  (#1331) 

### DIFF
--- a/thread/thread-pool.cpp
+++ b/thread/thread-pool.cpp
@@ -27,7 +27,7 @@ namespace photon
     }
 
     void set_bypass_threadpool(bool flag) {
-        __bypass_threadpool = true;
+        __bypass_threadpool = flag;
     }
 
     TPControl* ThreadPoolBase::thread_create_ex(thread_entry start, void* arg, bool joinable)

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1866,6 +1866,82 @@ R"(
     void reset_master_event_engine_default() {
         CURRENT->get_vcpu()->reset_master_event_engine_default();
     }
+<<<<<<< HEAD
+=======
+    inline __attribute__((always_inline))
+    thread* ws_scan_q(vcpu_t* v, thread* first, bool possibly_running) {
+        // the first must be unstealable
+        assert(!first->allow_work_stealing());
+        thread_list stolen;
+        uint64_t count = 0;
+        auto th = first->next();
+        while(th != first) {
+            SCOPED_LOCK(th->lock);
+            if ((possibly_running && th->state == states::RUNNING) ||
+                                    !th->allow_work_stealing()) {
+                th = th->next();
+            } else {
+                auto next = th->remove_from_list();
+                stolen.push_back(th); count++;
+                th->vcpu->nthreads--;
+                th->vcpu = v;
+                v->nthreads++;
+                th = next;
+            }
+        }
+        (void)count;
+        return stolen.eject_whole();
+    }
+    inline __attribute__((always_inline))
+    thread* ws_scan_standbyq(vcpu_t* v, vcpu_t* u) {
+        auto& q = u->standbyq;
+        if (q.empty()) return nullptr;
+        SCOPED_LOCK(q.lock);
+        if (q.empty()) return nullptr;
+        if (!q.front()->allow_work_stealing())
+            return ws_scan_q(v, q.front(), false);
+
+        thread_list stolen;
+        do {
+            SCOPED_LOCK(q.front()->lock);
+            auto th = q.pop_front();
+            stolen.push_back(th);
+            th->vcpu->nthreads--;
+            th->vcpu = v;
+            v->nthreads++;
+        } while (!q.empty() && q.front()->allow_work_stealing());
+        return stolen.eject_whole();
+    }
+    inline __attribute__((always_inline))
+    thread* ws_scan_runq(vcpu_t* v, vcpu_t* u) {
+        if (!u->runq_lock.background_try_lock()) return 0;
+        DEFER(u->runq_lock.background_unlock());
+        return ws_scan_q(v, u->idle_worker, true);
+    }
+    static bool try_work_stealing(vcpu_t* vcpu) {
+        assert(CURRENT->get_vcpu() == vcpu);
+        assert(CURRENT == vcpu->idle_worker);
+        if (0 == (vcpu->flags & VCPU_ENABLE_ACTIVE_WORK_STEALING))
+            return false;
+        scoped_rwlock _(vcpu_list_rwlock, RLOCK);
+        auto u = vcpu->next;
+        while (u != vcpu) {
+            if (0 == (u->flags & VCPU_ENABLE_PASSIVE_WORK_STEALING)) {
+                SCOPED_LOCK(vcpu_list_lock);
+                u = u->next;
+                continue;
+            }
+            thread* th;
+            if ((th = ws_scan_standbyq(vcpu, u)) || (th = ws_scan_runq(vcpu, u))) {
+                vcpu->idle_worker->insert_list_tail(th);
+                return true;
+            }
+            SCOPED_LOCK(vcpu_list_lock);
+            u = u->next;
+        }
+        return false;
+    }
+>>>>>>> 6860ea8 ([Backport][main to 0.9] | Fix critical bugs in work-stealing and thread-pool (#1246)  (#1331))
     static void* idler(void*) {
         RunQ rq;
         auto last_idle = now;


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix critical bugs in work-stealing and thread-pool (#1246)  (#1331)

* Fix critical bugs in work-stealing and thread-pool (#1246)

1. Fix infinite loop in try_work_stealing(): the `continue` on the
   passive-work-stealing check skipped iterator advancement, causing
   the idle worker to spin forever when encountering a vCPU without
   VCPU_ENABLE_PASSIVE_WORK_STEALING.

2. Fix null pointer dereference in ws_scan_standbyq(): the do-while
   condition called q.front()->allow_work_stealing() without checking
   q.empty() first, crashing when all stealable threads were popped.

3. Fix set_bypass_threadpool() ignoring its parameter: the function
   always set __bypass_threadpool = true regardless of the flag argument.

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

* Update thread.cpp

* Update thread.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.