### PR TITLE
[Backport][0.7 to 0.6] | Cap HTTP client retry backoff at 5 seconds (#1250) (#1329) (#1377) (#1407) 

### DIFF
--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -238,8 +238,8 @@ public:
             if (ret == ROUNDTRIP_SUCCESS || ret == ROUNDTRIP_FAILED) break;
             switch (ret) {
                 case ROUNDTRIP_NEED_RETRY:
-                    photon::thread_usleep(sleep_interval * 1000UL);
-                    sleep_interval = (sleep_interval + 500) * 2;
+                    photon::thread_usleep(std::min(sleep_interval, tmo.timeout()));
+                    sleep_interval = (sleep_interval + 500'000UL) * 2;
                     ++retry;
                     break;
                 case ROUNDTRIP_REDIRECT:


### PR DESCRIPTION
> Cap HTTP client retry backoff at 5 seconds (#1250) (#1329) (#1377) (#1407)

* Cap HTTP client retry backoff at 5 seconds

The exponential backoff formula (sleep_interval + 500) * 2 grows
unbounded, reaching 30+ seconds after a few retries. Cap at 5s to
prevent excessive tail latency on transient failures.



* Address review: bound retry backoff by remaining timeout

Per maintainer feedback: instead of an arbitrary 5s cap, clamp each
backoff sleep to the remaining operation timeout (tmo.timeout()). This
prevents a single backoff from overshooting the deadline regardless of
how the exponential interval grows, and removes the magic constant.



* Address review: use microseconds for sleep_interval directly

Per maintainer feedback: define sleep_interval in microseconds from
the start, eliminating the * 1000 conversion. Both thread_usleep()
and tmo.timeout() use microseconds, so this is cleaner.



---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.