### PR TITLE
[Backport][0.8 to 0.7] | Fix resource leak in photon::init() on partial failure (#1254) (#1327) (#1398) 

### DIFF
--- a/photon.cpp
+++ b/photon.cpp
@@ -27,6 +27,13 @@ limitations under the License.
 #include "net/curl.h"
 #include "net/socket.h"
 #include "fs/exportfs.h"
+<<<<<<< HEAD
+=======
+#include "common/alog.h"
+#include "common/callback.h"
+#include "common/utility.h"
+#include <vector>
+>>>>>>> d834e6f (Fix resource leak in photon::init() on partial failure (#1254) (#1327) (#1398))
 
 namespace photon {
 
@@ -58,7 +65,15 @@ int __photon_init(uint64_t event_engine, uint64_t io_engine) {
     if (vcpu_init() < 0)
         return -1;
 
+<<<<<<< HEAD
     const uint64_t ALL_ENGINES = INIT_EVENT_EPOLL  |
+=======
+    bool ok = false;
+    DEFER(if (!ok) fini());
+
+    const uint64_t ALL_ENGINES =
+            INIT_EVENT_EPOLL   | INIT_EVENT_EPOLL_NG |
+>>>>>>> d834e6f (Fix resource leak in photon::init() on partial failure (#1254) (#1327) (#1398))
             INIT_EVENT_IOURING | INIT_EVENT_KQUEUE |
             INIT_EVENT_SELECT  | INIT_EVENT_IOCP;
     if (event_engine & ALL_ENGINES) {
@@ -93,6 +108,7 @@ int __photon_init(uint64_t event_engine, uint64_t io_engine) {
         LOG_DEBUG("reset_all_handle registed ", VALUE(getpid()));
         reset_handle_registed = true;
     }
+    ok = true;
     return 0;
 }
 
@@ -101,6 +117,15 @@ int init(uint64_t event_engine, uint64_t io_engine) {
 }
 
 int fini() {
+<<<<<<< HEAD
+=======
+    if (!CURRENT)
+        return -1;
+    for (auto h : get_hook_vector()) {
+        h.fire();
+    }
+    get_hook_vector().clear();
+>>>>>>> d834e6f (Fix resource leak in photon::init() on partial failure (#1254) (#1327) (#1398))
 #ifdef __linux__
     FINI_IO(LIBAIO, libaio_wrapper)
     FINI_IO(SOCKET_EDGE_TRIGGER, et_poller)


### PR DESCRIPTION
> Fix resource leak in photon::init() on partial failure (#1254) (#1327) (#1398)

* Fix resource leak in photon::init() on partial failure

Previously, if any step after vcpu_init() failed (event engine,
signal, or IO engine init), the function returned -1 without
cleaning up already-initialized resources (vcpu, event engine,
signal fd, earlier IO engines).

Track successfully initialized engines incrementally via g_event_engine
and g_io_engine, and call fini() on failure to clean up exactly the
resources that were initialized.



* Guard fini() against double-call after failed init

If init() fails, it now calls fini() internally. A user calling
fini() again would crash because CURRENT is nullptr after
vcpu_fini(). Add an early return at the top of fini() when
CURRENT is null to make it idempotent.



* Address review: use DEFER + ok pattern instead of goto fail

Per maintainer suggestion, replaced the goto fail + INIT_IO_OR_FAIL
macro approach with the DEFER(if (!ok) fini()) pattern. This is
cleaner and reuses the existing INIT_IO macro unchanged.



* Address review: revert to goto next, move assignments back

Per maintainer feedback:
- Removed engine_ok bool, restored original goto next structure
- Moved g_event_engine/g_io_engine assignments back to the success
  path (before ok=true). fini() only needs vcpu_fini + fd_events_fini
  on early failures since the IO globals are still 0 at that point.



---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.