### PR TITLE
[Backport][0.7 to 0.6] | Fix iouring eventfd double-close on repeated fini() (#1268) (#1318) (#1384) (#1420) 

### DIFF
--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -61,14 +61,8 @@ public:
             if (io_uring_unregister_eventfd(m_ring) != 0) {
                 LOG_ERROR("iouring: failed to unregister cascading event fd");
             }
-<<<<<<< HEAD
             close(m_cascading_event_fd);
-=======
-        }
-        if (m_eventfd >= 0) {
-            close(m_eventfd);
-            m_eventfd = -1;
->>>>>>> 207babf (Fix iouring eventfd double-close on repeated fini() (#1268) (#1318) (#1384) (#1420))
+            m_cascading_event_fd = -1;
         }
         if (m_ring != nullptr) {
             io_uring_queue_exit(m_ring);

--- a/io/iouring-wrapper.cpp
+++ b/io/iouring-wrapper.cpp
@@ -61,7 +61,14 @@ public:
             if (io_uring_unregister_eventfd(m_ring) != 0) {
                 LOG_ERROR("iouring: failed to unregister cascading event fd");
             }
+<<<<<<< HEAD
             close(m_cascading_event_fd);
+=======
+        }
+        if (m_eventfd >= 0) {
+            close(m_eventfd);
+            m_eventfd = -1;
+>>>>>>> 207babf (Fix iouring eventfd double-close on repeated fini() (#1268) (#1318) (#1384) (#1420))
         }
         if (m_ring != nullptr) {
             io_uring_queue_exit(m_ring);


### PR DESCRIPTION
> Fix iouring eventfd double-close on repeated fini() (#1268) (#1318) (#1384) (#1420)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.