### PR TITLE
[Pick][0.7 to 0.8] | [Backport][0.8 to 0.7] | Fix macOS sendfile source/dest argument order (#1306) (#1334) (#1375)  (#1404) 

### DIFF
--- a/net/basic_socket.cpp
+++ b/net/basic_socket.cpp
@@ -146,8 +146,14 @@ ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count,
                  Timeout timeout) {
 #ifdef __APPLE__
     off_t len = count;
+<<<<<<< HEAD
     ssize_t ret = DOIO_ONCE(::sendfile(in_fd, out_fd, *offset, &len, nullptr, 0),
                   wait_for_fd_writable(out_fd, timeout));
+=======
+    ssize_t ret =
+        doio(LAMBDA(::sendfile(in_fd, out_fd, *offset, &len, nullptr, 0)),
+             LAMBDA_TIMEOUT(wait_for_fd_writable(out_fd, timeout)));
+>>>>>>> 840ef02 ([Backport][0.8 to 0.7] | Fix macOS sendfile source/dest argument order (#1306) (#1334) (#1375)  (#1404))
     return (ret == 0) ? len : (int)ret;
 #else
     return DOIO_ONCE(::sendfile(out_fd, in_fd, offset, count),


### PR DESCRIPTION
> [Backport][0.8 to 0.7] | Fix macOS sendfile source/dest argument order (#1306) (#1334) (#1375)  (#1404)

* Fix macOS sendfile source/dest argument order (#1306) (#1334) (#1375)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

* Update basic_socket.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits