### PR TITLE
[Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) (#1412) 

### DIFF
--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -265,15 +265,13 @@ size_t Message::body_size() const {
     if (it != headers.end()) return estring_view(it.second()).to_uint64();
     // or calc from Content-Range
     it = headers.find("Content-Range");
-    if (it != headers.end()) {
-        size_t start, end;
-        if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
-            return end-start+1;
-        }
-        if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
-            return end;
-        }
-        return 0;
+    if (it == headers.end()) return 0;
+    size_t start, end;
+    if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
+        return end-start+1;
+    }
+    if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
+        return end;
     }
     return 0;
 }

--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -265,6 +265,7 @@ size_t Message::body_size() const {
     if (it != headers.end()) return estring_view(it.second()).to_uint64();
     // or calc from Content-Range
     it = headers.find("Content-Range");
+<<<<<<< HEAD
     if (it == headers.end()) return 0;
     size_t start, end;
     if (sscanf("bytes %lu-%lu", it.second().data(), &start, &end) == 2) {
@@ -272,6 +273,17 @@ size_t Message::body_size() const {
     }
     if (sscanf("bytes */%lu", it.second().data(), &end) == 1) {
         return end;
+=======
+    if (it != headers.end()) {
+        size_t start, end;
+        if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
+            return end-start+1;
+        }
+        if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
+            return end;
+        }
+        return 0;
+>>>>>>> 67a99c6 ([Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) (#1412))
     }
     return 0;
 }

--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -265,15 +265,6 @@ size_t Message::body_size() const {
     if (it != headers.end()) return estring_view(it.second()).to_uint64();
     // or calc from Content-Range
     it = headers.find("Content-Range");
-<<<<<<< HEAD
-    if (it == headers.end()) return 0;
-    size_t start, end;
-    if (sscanf("bytes %lu-%lu", it.second().data(), &start, &end) == 2) {
-        return end-start+1;
-    }
-    if (sscanf("bytes */%lu", it.second().data(), &end) == 1) {
-        return end;
-=======
     if (it != headers.end()) {
         size_t start, end;
         if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
@@ -283,7 +274,6 @@ size_t Message::body_size() const {
             return end;
         }
         return 0;
->>>>>>> 67a99c6 ([Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) (#1412))
     }
     return 0;
 }


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) (#1412)

* Fix swapped sscanf arguments in Content-Range parsing (#1262)



* Update message.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.