### PR TITLE
[Pick][0.7 to 0.8] | [Backport][0.8 to 0.7] | extfs: add resize_extfs interface with compile switch and fix extfs_close (#1276) (#1346) (#1364)  (#1397) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,12 @@ option(PHOTON_ENABLE_MIMIC_VDSO "enable mimic vdso" OFF)
 option(PHOTON_ENABLE_FSTACK_DPDK "Use f-stack + DPDK as the event engine" OFF)
 option(PHOTON_ENABLE_EXTFS "enable extfs" OFF)
 option(PHOTON_ENABLE_RESIZE "enable resize_extfs (requires external resize_fs)" OFF)
+<<<<<<< HEAD
 option(PHOTON_ENABLE_ECOSYSTEM "enable ecosystem" OFF)
 option(PHOTON_ENABLE_LIBCURL "enable libcurl" ON)
 set(PHOTON_DEFAULT_LOG_LEVEL "0" CACHE STRING "default log level")
+=======
+>>>>>>> 7bd9ba9 ([Backport][0.8 to 0.7] | extfs: add resize_extfs interface with compile switch and fix extfs_close (#1276) (#1346) (#1364)  (#1397))
 
 option(PHOTON_BUILD_DEPENDENCIES "" OFF)
 set(PHOTON_AIO_SOURCE "https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz" CACHE STRING "")


### PR DESCRIPTION
> [Backport][0.8 to 0.7] | extfs: add resize_extfs interface with compile switch and fix extfs_close (#1276) (#1346) (#1364)  (#1397)

* extfs: add resize_extfs interface with compile switch and fix extfs_close (#1276) (#1346) (#1364)

Co-authored-by: OsentryO <75356449+OsentryO@users.noreply.github.com>

* Update CMakeLists.txt

* Update CMakeLists.txt

---------

Co-authored-by: OsentryO <75356449+OsentryO@users.noreply.github.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits