### PR TITLE
[Backport][0.7 to 0.6] | Fix Base64Encode underflow on empty input (#1266) (#1321) (#1386) (#1436) 

### DIFF
--- a/net/utils.cpp
+++ b/net/utils.cpp
@@ -113,6 +113,7 @@ inline __attribute__((always_inline)) void base64_translate_3to4(const char *in,
                         (tbl[x.c] << 8) + (tbl[x.d] << 0));
 }
 void Base64Encode(std::string_view in, std::string &out) {
+    if (in.empty()) { out.clear(); return; }
     auto main = in.size() / 3;
     auto remain = in.size() % 3;
     if (0 == remain) {


### PR DESCRIPTION
> Fix Base64Encode underflow on empty input (#1266) (#1321) (#1386) (#1436)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.