### PR TITLE
ci(backport): strip cascading [Backport]/[Pick] prefixes from PR title

### DIFF
--- a/.github/workflows/auto-pr-backport.yml
+++ b/.github/workflows/auto-pr-backport.yml
@@ -237,9 +237,11 @@ jobs:
             const lines = droppedFiles.split('\n').filter(Boolean).map(f => `- ${f}`).join('\n');
             body += `\n\n## Dropped new files\n\nThe following new files introduced by cherry-pick were dropped because they don't exist in \`${{steps.branch_info.outputs.PREV_BRANCH}}\`:\n\n${lines}`;
           }
+          // Strip accumulated [Backport][...] and [Pick][...] prefixes from cascading backports
+          const rawTitle = (process.env.TITLE || '').replace(/\[(?:Backport|Pick)\]\[[^\]]*\]\s*/g, '').trim();
           const { data: pr } = await github.rest.pulls.create({
             ...context.repo,
-            title: `[Backport][${{steps.branch_info.outputs.CURRENT_VERSION}} to ${{steps.branch_info.outputs.PREV_VERSION}}] ` + process.env.TITLE,
+            title: `[Backport][${{steps.branch_info.outputs.CURRENT_VERSION}} to ${{steps.branch_info.outputs.PREV_VERSION}}] ` + rawTitle,
             head: `${{steps.create_branch.outputs.PRBRANCH}}`,
             base: `${{steps.branch_info.outputs.PREV_BRANCH}}`,
             body,


### PR DESCRIPTION
## Problem

When backport PRs cascade downward (main → 0.9 → 0.8 → 0.7), the merge commit subject accumulates `[Backport][X to Y]` prefixes at each level, producing titles like:

```
[Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix swapped sscanf arguments...
```

## Fix

Strip all existing `[Backport][...]` and `[Pick][...]` prefixes from the TITLE before prepending the new one, ensuring the title is always clean with a single prefix:

```
[Backport][0.8 to 0.7] | Fix swapped sscanf arguments...
```

## Changes

- `.github/workflows/auto-pr-backport.yml` — add regex strip before `pulls.create`