### PR TITLE
HTTP client: CONNECT tunnel support

### DIFF
--- a/ecosystem/test/test_oss_custom_headers.cpp
+++ b/ecosystem/test/test_oss_custom_headers.cpp
@@ -79,7 +79,7 @@ class OssCustomHeaderTest : public ::testing::Test {
 
   ClientOptions make_opts() {
     ClientOptions opts;
-    opts.endpoint = "oss-test.example.com";
+    opts.endpoint = "http://oss-test.example.com";
     opts.bucket = "test-bucket";
     opts.proxy = estring().appends("http://127.0.0.1:",
                                    tcp_server->getsockname().port);

--- a/net/http/client.cpp
+++ b/net/http/client.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 #include <algorithm>
 #include <random>
 #include <photon/common/alog-stdstring.h>
+#include <photon/common/estring.h>
 #include <photon/common/iovector.h>
 #include <photon/common/string_view.h>
 #include <photon/net/socket.h>
@@ -37,9 +38,9 @@ class PooledDialer {
 public:
     net::TLSContext* tls_ctx = nullptr;
     std::unique_ptr<ISocketClient> tcpsock;
-    std::unique_ptr<ISocketClient> tlssock;
     std::unique_ptr<ISocketClient> udssock;
     std::unique_ptr<Resolver> resolver;
+    std::unique_ptr<ISocketPool> tcp_pool;
     photon::mutex init_mtx;
     bool initialized = false;
     bool tls_ctx_ownership = false;
@@ -61,20 +62,18 @@ public:
             tls_ctx = new_tls_context(nullptr, nullptr, nullptr);
             tls_ctx->set_verify_mode(VerifyMode::PEER);  // act like curl
         }
-        auto tcp_cli = new_tcp_socket_client(src_ips.data(), src_ips.size());
-        auto tls_cli = new_tls_client(tls_ctx, new_tcp_socket_client(src_ips.data(), src_ips.size()), true);
-        tcpsock.reset(new_tcp_socket_pool(tcp_cli, -1, true));
-        tlssock.reset(new_tcp_socket_pool(tls_cli, -1, true));
+        tcpsock.reset(new_tcp_socket_client(src_ips.data(), src_ips.size()));
         udssock.reset(new_uds_client());
+        tcp_pool.reset(new_tcp_socket_pool(nullptr, -1ULL, false));
         resolver.reset(new_default_resolver(kDNSCacheLife));
         initialized = true;
         return 0;
     }
 
     void at_photon_fini() {
+        tcp_pool.reset();
         resolver.reset();
         udssock.reset();
-        tlssock.reset();
         tcpsock.reset();
         if (tls_ctx_ownership)
             delete tls_ctx;
@@ -82,52 +81,153 @@ public:
         tls_ctx_ownership = false;
     }
 
-    ISocketStream* dial(std::string_view host, uint16_t port, bool secure,
-                             uint64_t timeout = -1ULL);
+    // Single entry point: choose dial method based on Operation proxy config.
+    ISocketStream* dial(Client::Operation* op, Timeout tmo);
 
-    template <typename T>
-    ISocketStream* dial(const T& x, uint64_t timeout = -1ULL) {
-        return dial(x.host_no_port(), x.port(), x.secure(), timeout);
+    ISocketStream* dial(std::string_view host, uint16_t port, bool secure, uint64_t timeout);
+
+private:
+    // Key format for pool connection grouping:
+    //   direct/proxy: <host>:<port>:<0|1>  (0=TCP, 1=TLS)
+    //   tunnel:       <proxy_host>:<proxy_port>:<s|p>:<target_host>:<target_port>[:<auth>]
+    static std::string make_key(std::string_view host, uint16_t port, bool secure) {
+        return estring().appends(host, ":", port, ":", secure ? "1" : "0");
     }
 
-    ISocketStream* dial(std::string_view uds_path, uint64_t timeout = -1ULL);
+    static std::string make_tunnel_key(const StoredURL& proxy, std::string_view target_host,
+                                       uint16_t target_port, const Headers* headers) {
+        auto auth = headers ? headers->get_value("Proxy-Authorization") : std::string_view{};
+        auto phost = proxy.host_no_port();
+        return estring().appends(phost, ":", proxy.port(), ":", proxy.secure() ? "s" : "p",
+                                 ":", target_host, ":", target_port,
+                                 estring::make_conditional_cat_list(!auth.empty(), ":", auth));
+    }
+
+    // Factory: DNS resolve -> TCP connect -> optional TLS wrap with SNI.
+    // Discards the resolved IP from cache on connection failure.
+    ISocketStream* make_stream(std::string_view host, uint16_t port, bool secure, uint64_t timeout) {
+        auto ip = resolver->resolve(host);
+        if (ip.undefined())
+            LOG_ERROR_RETURN(ENOENT, nullptr, "DNS resolve failed, name=`", host);
+        EndPoint ep(ip, port);
+        tcpsock->timeout(timeout);
+        auto stream = tcpsock->connect(ep);
+        if (!stream) {
+            resolver->discard_cache(host, ip);
+            LOG_ERROR_RETURN(0, nullptr, "connection failed, ep=` host=` secure=`", ep, host, secure);
+        }
+        if (secure) {
+            stream = new_tls_stream(tls_ctx, stream, SecurityRole::Client, true);
+            if (!stream)
+                LOG_ERRNO_RETURN(0, nullptr, "TLS handshake failed, host=`", host);
+            tls_stream_set_hostname(stream, std::string(host).c_str());
+        }
+        LOG_DEBUG("Connected ` ssl:` host:`", ep, secure, host);
+        return stream;
+    }
+
+    // Factory: full CONNECT tunnel handshake sequence.
+    // DNS resolve proxy -> TCP -> [TLS to proxy] -> CONNECT handshake -> TLS to target.
+    ISocketStream* make_tunnel_stream(const StoredURL& proxy_url, std::string_view target_host,
+                                      uint16_t target_port, const Headers* headers, uint64_t timeout) {
+        auto proxy_ip = resolver->resolve(proxy_url.host_no_port());
+        if (proxy_ip.undefined())
+            LOG_ERROR_RETURN(ENOENT, nullptr, "CONNECT tunnel: DNS resolve failed for proxy `", proxy_url.host_no_port());
+        EndPoint proxy_ep(proxy_ip, proxy_url.port());
+        tcpsock->timeout(timeout);
+        auto stream = tcpsock->connect(proxy_ep);
+        if (!stream) {
+            resolver->discard_cache(proxy_url.host_no_port(), proxy_ip);
+            LOG_ERRNO_RETURN(0, nullptr, "CONNECT tunnel: failed to connect to proxy");
+        }
+        stream->timeout(timeout);
+        if (proxy_url.secure()) {
+            auto tls = new_tls_stream(tls_ctx, stream, SecurityRole::Client, true);
+            if (!tls) {
+                delete stream;
+                LOG_ERRNO_RETURN(0, nullptr, "CONNECT tunnel: TLS to proxy failed");
+            }
+            stream = tls;
+            tls_stream_set_hostname(stream, std::string(proxy_url.host_no_port()).c_str());
+        }
+        if (do_connect_handshake(stream, target_host, target_port, headers, timeout) != 0) {
+            delete stream;
+            return nullptr;
+        }
+        auto tls = new_tls_stream(tls_ctx, stream, SecurityRole::Client, true);
+        if (!tls) {
+            delete stream;
+            LOG_ERRNO_RETURN(0, nullptr, "CONNECT tunnel: TLS to target failed");
+        }
+        stream = tls;
+        tls_stream_set_hostname(stream, std::string(target_host).c_str());
+        return stream;
+    }
+
+    // Send CONNECT request and verify 2xx response.
+    int do_connect_handshake(ISocketStream* stream, std::string_view target_host,
+                             uint16_t target_port, const Headers* headers, uint64_t timeout) {
+        char buf[4096];
+        estring authority;
+        authority.appends(target_host, ":", target_port);
+        Request req(buf, (uint16_t)sizeof(buf), Verb::CONNECT, authority);
+        if (headers) {
+            for (auto it = headers->begin(); it != headers->end(); ++it)
+                req.headers.insert(it.first(), it.second());
+        }
+        if (req.send_header(stream) < 0)
+            LOG_ERRNO_RETURN(0, -1, "CONNECT tunnel: failed to send CONNECT request");
+
+        // Response needs room for receive_bytes' MAX_TRANSFER_BYTES + RESERVED_INDEX_SIZE.
+        char rbuf[8192];
+        Response resp(rbuf, (uint16_t)sizeof(rbuf));
+        resp.reset(stream, false);
+        if (resp.receive_header(timeout) != 0)
+            LOG_ERRNO_RETURN(0, -1, "CONNECT tunnel: failed to read proxy response");
+        auto sc = resp.status_code();
+        if (sc < 200 || sc >= 300)
+            LOG_ERROR_RETURN(EINVAL, -1, "CONNECT tunnel: proxy returned status `", sc);
+        return 0;
+    }
 };
 
-ISocketStream* PooledDialer::dial(std::string_view host, uint16_t port, bool secure, uint64_t timeout) {
-    LOG_DEBUG("Dialing to `:`", host, port);
-    auto ipaddr = resolver->resolve(host);
-    if (ipaddr.undefined()) {
-        LOG_ERROR_RETURN(ENOENT, nullptr, "DNS resolve failed, name = `", host)
+ISocketStream* PooledDialer::dial(Client::Operation* op, Timeout tmo) {
+    auto* proxy = op->get_active_proxy();
+
+    // HTTPS target + proxy: CONNECT tunnel.
+    if (proxy && op->req.secure()) {
+        auto key = make_tunnel_key(*proxy, op->req.host_no_port(), op->req.port(), &op->proxy_header);
+        return tcp_pool->connect(key, [&]() -> ISocketStream* {
+            return make_tunnel_stream(*proxy, op->req.host_no_port(), op->req.port(), &op->proxy_header, tmo.timeout());
+        });
     }
 
-    EndPoint ep(ipaddr, port);
-    LOG_DEBUG("Connecting ` ssl: `", ep, secure);
-    ISocketStream *sock = nullptr;
-    if (secure) {
-        tlssock->timeout(timeout);
-        sock = tlssock->connect(ep);
-        tls_stream_set_hostname(sock, estring_view(host).extract_c_str());
-    } else {
-        tcpsock->timeout(timeout);
-        sock = tcpsock->connect(ep);
+    // HTTP proxy: connect to proxy endpoint.
+    if (proxy) {
+        auto key = make_key(proxy->host_no_port(), proxy->port(), proxy->secure());
+        return tcp_pool->connect(key, [&]() -> ISocketStream* {
+            return make_stream(proxy->host_no_port(), proxy->port(), proxy->secure(), tmo.timeout());
+        });
     }
-    if (sock) {
-        LOG_DEBUG("Connected ` ", ep, VALUE(host), VALUE(secure));
-        return sock;
+
+    // Unix domain socket.
+    if (!op->uds_path.empty()) {
+        udssock->timeout(tmo.timeout());
+        return udssock->connect(op->uds_path.data());
     }
-    LOG_ERROR("connection failed, ssl : ` ep : `  host : `", secure, ep, host);
-    // When failed, remove resolved result from dns cache so that following retries can try
-    // different ips.
-    resolver->discard_cache(host, ipaddr);
-    return nullptr;
+
+    // Direct TCP/TLS connection.
+    auto key = make_key(op->req.host_no_port(), op->req.port(), op->req.secure());
+    return tcp_pool->connect(key, [&]() -> ISocketStream* {
+        return make_stream(op->req.host_no_port(), op->req.port(), op->req.secure(), tmo.timeout());
+    });
 }
 
-ISocketStream* PooledDialer::dial(std::string_view uds_path, uint64_t timeout) {
-    udssock->timeout(timeout);
-    auto stream = udssock->connect(uds_path.data());
-    if (!stream)
-        LOG_ERRNO_RETURN(0, nullptr, "failed to dial to unix socket `", uds_path);
-    return stream;
+ISocketStream* PooledDialer::dial(std::string_view host, uint16_t port, bool secure, uint64_t timeout) {
+    auto key = make_key(host, port, secure);
+    return tcp_pool->connect(key, [&]() -> ISocketStream* {
+        return make_stream(host, port, secure, timeout);
+    });
 }
 
 constexpr uint64_t code3xx() { return 0; }
@@ -141,19 +241,6 @@ constexpr static std::bitset<10>
 
 static constexpr size_t kMinimalHeadersSize = 8 * 1024 - 1;
 
-void Client::set_proxy(std::string_view proxy) {
-    m_proxy_url.from_string(proxy);
-    m_proxy = true;
-    auto ui = m_proxy_url.user_passwd();
-    if (!ui.empty()) {
-        std::string encoded;
-        Base64Encode(ui, encoded);
-        m_proxy_auth = "Basic " + encoded;
-    } else {
-        m_proxy_auth.clear();
-    }
-}
-
 enum RoundtripStatus {
     ROUNDTRIP_SUCCESS,
     ROUNDTRIP_FAILED,
@@ -166,6 +253,7 @@ enum RoundtripStatus {
 class ClientImpl : public Client {
 public:
     CommonHeaders<> m_common_headers;
+    CommonHeaders<> m_proxy_headers;
     TLSContext *m_tls_ctx;
     ICookieJar *m_cookie_jar;
     ClientImpl(ICookieJar *cookie_jar, TLSContext *tls_ctx) :
@@ -202,7 +290,7 @@ public:
                 "invalid 3xx status code: ", op->status_code);
         }
 
-        if (op->req.redirect(v, location, op->enable_proxy) < 0) {
+        if (op->req.redirect(v, location, op->get_active_proxy() != nullptr) < 0) {
             LOG_ERRNO_RETURN(0, ROUNDTRIP_FAILED, "redirect failed");
         }
         return ROUNDTRIP_REDIRECT;
@@ -213,15 +301,7 @@ public:
         if (tmo.timeout() == 0)
             LOG_ERROR_RETURN(ETIMEDOUT, ROUNDTRIP_FAILED, "connection timedout");
         auto &req = op->req;
-        ISocketStream* s;
-        if (op->enable_proxy && !op->proxy_url.empty())
-            s = get_dialer().dial(op->proxy_url, tmo.timeout());
-        else if (op->enable_proxy && !m_proxy_url.empty())
-            s = get_dialer().dial(m_proxy_url, tmo.timeout());
-        else if (!op->uds_path.empty())
-            s = get_dialer().dial(op->uds_path, tmo.timeout());
-        else
-            s = get_dialer().dial(req, tmo.timeout());
+        ISocketStream* s = get_dialer().dial(op, tmo);
         if (!s) {
             if (errno == ECONNREFUSED || errno == ENOENT) {
                 LOG_ERROR_RETURN(0, ROUNDTRIP_FAST_RETRY, "connection refused")
@@ -304,10 +384,33 @@ public:
         op->req.headers.insert("User-Agent", m_user_agent.empty() ? std::string_view(USERAGENT)
                                                                   : std::string_view(m_user_agent));
         op->req.headers.insert("Connection", "keep-alive");
-        if (op->enable_proxy && !m_proxy_auth.empty())
-            op->req.headers.insert("Proxy-Authorization", m_proxy_auth);
         if (m_cookie_jar && m_cookie_jar->set_cookies_to_headers(&op->req) != 0)
             LOG_ERROR_RETURN(0, -1, "set_cookies_to_headers failed");
+
+        // Proxy header assembly: op proxy_header <- client proxy_headers <- URL auth
+        auto proxy = op->get_active_proxy();
+        if (proxy) {
+            op->proxy_header.merge(m_proxy_headers);
+            if (!proxy->user_passwd().empty()) {
+                std::string encoded;
+                Base64Encode(proxy->user_passwd(), encoded);
+                op->proxy_header.insert("Proxy-Authorization", "Basic " + encoded);
+            }
+        }
+
+        // Rebuild request line if necessary (absolute URI for HTTP proxy)
+        auto need_abs = proxy && !op->req.secure();
+        auto is_abs = what_protocol(estring_view(op->req.target())) != 0;
+        if (need_abs != is_abs) {
+            op->req.redirect(op->req.verb(), op->req.target(), need_abs);
+        }
+
+        // For HTTP/1.1 proxy: merge proxy_header into req.headers (sent with the request).
+        // For HTTPS proxy: proxy_header stays separate (used by CONNECT handshake only).
+        if (proxy && !op->req.secure()) {
+            op->req.headers.merge(op->proxy_header);
+        }
+
         Timeout tmo(std::min(op->timeout.timeout(), m_timeout));
         int retry = 0, followed = 0, ret = 0;
         uint64_t sleep_interval = 0;
@@ -345,6 +448,10 @@ public:
 
     CommonHeaders<>* common_headers() override {
         return &m_common_headers;
+    }
+
+    CommonHeaders<>* proxy_headers() override {
+        return &m_proxy_headers;
     }
 };
 

--- a/net/http/client.h
+++ b/net/http/client.h
@@ -69,6 +69,10 @@ public:
         using BodyWriter = Delegate<ssize_t, Request*>;
         BodyWriter body_writer = {};
 
+        // For HTTP/1.1 proxy: merge proxy_header into req.headers (sent with the request).
+        // For HTTPS proxy: proxy_header stays separate (used by CONNECT handshake only).
+        CommonHeaders<> proxy_header;
+
         static Operation* create(Client* c, Verb v, std::string_view url,
                             uint16_t buf_size = 64 * 1024 - 1) {
             auto ptr = malloc(sizeof(Operation) + buf_size);
@@ -85,23 +89,29 @@ public:
         void set_enable_proxy(bool enable) {
             enable_proxy = enable;
         }
-        // Set per-operation proxy URL, takes precedence over client-level proxy.
-        // Automatically enables proxy and rebuilds request line to absolute URI format.
+        // Set per-operation proxy URL and enable proxy. Takes precedence over client-level proxy.
+        // Clears proxy_header (old proxy's auth is no longer valid).
         void set_proxy(std::string_view proxy) {
             proxy_url.from_string(proxy);
-            if (!enable_proxy) {
-                // redirect() handles scheme+host completion and absolute URI rebuild
-                req.redirect(req.verb(), req.target(), true);
-                enable_proxy = true;
-            }
+            enable_proxy = true;
+            proxy_header.reset();
         }
-        const StoredURL* get_proxy() {
+        // Returns the active proxy URL: per-op URL if set, else client-level URL.
+        StoredURL* get_proxy() {
+            if (!proxy_url.empty()) return &proxy_url;
+            if (_client) return _client->get_proxy();
             return &proxy_url;
         }
         // Clear per-operation proxy, fall back to client-level proxy.
         // Does not change enable_proxy or request line format.
         void clear_proxy() {
-            proxy_url.clear();
+            set_proxy("");
+        }
+        // Returns active proxy URL if proxy is enabled AND URL is non-empty; nullptr otherwise.
+        StoredURL* get_active_proxy() {
+            if (!enable_proxy) return nullptr;
+            auto* p = get_proxy();
+            return p->empty() ? nullptr : p;
         }
         int call() {
             if (!_client) return -1;
@@ -159,8 +169,14 @@ public:
     virtual int call(Operation* /*IN, OUT*/ op) = 0;
     // get common headers, to manipulate
     virtual Headers* common_headers() = 0;
+    // get proxy headers (client-level proxy headers, inherited by operations at call() time)
+    virtual Headers* proxy_headers() = 0;
 
-    void set_proxy(std::string_view proxy);
+    void set_proxy(std::string_view proxy) {
+        m_proxy_url.from_string(proxy);
+        m_proxy = true;
+        proxy_headers()->reset();
+    }
     void set_user_agent(std::string_view user_agent) {
         m_user_agent = std::string(user_agent);
     }
@@ -188,7 +204,7 @@ public:
 
     /**
      * @brief Connect to a WebSocket server
-     * 
+     *
      * @param url Full URL for the WebSocket endpoint (e.g., "http://example.com/ws")
      * @param timeout Timeout in microseconds (-1 for infinite)
      * @return Pointer to IWebSocketStream on success, nullptr on failure
@@ -197,7 +213,6 @@ public:
 
 protected:
     StoredURL m_proxy_url;
-    std::string m_proxy_auth;
     std::string m_user_agent;
     uint64_t m_timeout = -1ULL;
     bool m_proxy = false;

--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -305,17 +305,28 @@ void Request::make_request_line(Verb v, const URL& u, bool enable_proxy) {
     buf_append(buf, verbstr[v]);
     buf_append(buf, " ");
     uint16_t target_disp = buf - m_buf;
-    m_target = {uint16_t(buf - m_buf), u.target().size()};
-    if (enable_proxy) {
-        m_target = {uint16_t(buf - m_buf), full_url_size(u)};
-        buf_append(buf, u.secure() ? https_url_scheme : http_url_scheme);
-        buf_append(buf, u.host_port());
+    if (v == Verb::CONNECT) {
+        // authority-form (RFC 7231 S4.3.6): host:port with an explicit port,
+        // since host_port() would drop the scheme's default port.
+        char* target_begin = buf;
+        buf_append(buf, u.host());
+        buf_append(buf, ":");
+        buf_append(buf, u.port());
+        m_target = {target_disp, uint16_t(buf - target_begin)};
+        m_path = m_query = {};
+    } else {
+        m_target = {uint16_t(buf - m_buf), u.target().size()};
+        if (enable_proxy) {
+            m_target = {uint16_t(buf - m_buf), full_url_size(u)};
+            buf_append(buf, u.secure() ? https_url_scheme : http_url_scheme);
+            buf_append(buf, u.host_port());
+        }
+        buf_append(buf, u.target());
+        uint16_t path_offset = (uint16_t)(u.path().data() - u.target().data()) + target_disp;
+        m_path = {path_offset, u.path().size()};
+        uint16_t query_offset = (uint16_t)(u.query().data() - u.target().data()) + target_disp;
+        m_query = {query_offset, u.query().size()};
     }
-    buf_append(buf, u.target());
-    uint16_t path_offset = (uint16_t)(u.path().data() - u.target().data()) + target_disp;
-    m_path = {path_offset, u.path().size()};
-    uint16_t query_offset = (uint16_t)(u.query().data() - u.target().data()) + target_disp;
-    m_query = {query_offset, u.query().size()};
     buf_append(buf, " HTTP/1.1\r\n");
     m_buf_size = buf - m_buf;
 }
@@ -337,8 +348,9 @@ int Request::reset(Verb v, std::string_view url, bool enable_proxy) {
     make_request_line(v, u, enable_proxy);
     headers.reset(m_buf + m_buf_size, m_buf_capacity - m_buf_size);
 
-    // Host is always the first header
-    headers.insert("Host", u.host_port());
+    // Host is always the first header. For CONNECT use the request-target
+    // (host:port with explicit port); host_port() may drop a default port.
+    headers.insert("Host", v == Verb::CONNECT ? target() : u.host_port());
     return 0;
 }
 

--- a/net/http/message.h
+++ b/net/http/message.h
@@ -153,6 +153,7 @@ protected:
 
     friend class HTTPServerImpl;
     friend class ClientImpl;
+    friend class PooledDialer;
 };
 
 class URL;

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -23,10 +23,12 @@ limitations under the License.
 #include <cstring>
 #include <cstdlib>
 #include <string>
+#include <thread>
 
+#include <photon/common/alog-stdstring.h>
 #include <photon/net/socket.h>
 #include <photon/common/alog.h>
-#include "../client.cpp"
+#include "../client.h"
 #include "../server.h"
 #include <photon/io/fd-events.h>
 #include <photon/thread/thread11.h>
@@ -833,98 +835,90 @@ TEST(url, user_passwd) {
     EXPECT_EQ(u4.query(), "email=a@b.com");
 }
 
-TEST(http_client, set_proxy_with_auth) {
+// Covers: client/op set_proxy (with and without user:pass), enable/disable toggle,
+// get_proxy() op->client fallback, get_active_proxy() enable+URL gating.
+TEST(http_client_proxy, proxy_url_and_toggle) {
     auto client = new_http_client();
     DEFER(delete client);
+
+    // Client: set_proxy with user:pass → full URL preserved
     client->set_proxy("http://root:password@123.123.1.1:3123");
     EXPECT_TRUE(client->has_proxy());
-    auto proxy = client->get_proxy();
-    EXPECT_EQ(proxy->host(), "123.123.1.1");
-    EXPECT_EQ(proxy->port(), 3123);
+    EXPECT_EQ(client->get_proxy()->to_string(), "http://root:password@123.123.1.1:3123");
 
-    // set_proxy without userinfo should clear auth
+    // set_proxy again: URL updates, old auth gone
     client->set_proxy("http://10.0.0.1:8080");
-    EXPECT_TRUE(client->has_proxy());
-    EXPECT_EQ(client->get_proxy()->host(), "10.0.0.1");
-    EXPECT_EQ(client->get_proxy()->port(), 8080);
-}
+    EXPECT_EQ(client->get_proxy()->to_string(), "http://10.0.0.1:8080");
 
-// Verify that Operation::set_proxy/clear_proxy manage operation-level proxy state
-TEST(http_client, operation_set_clear_proxy) {
-    // Client without proxy
-    auto client = new_http_client();
-    DEFER(delete client);
+    // disable/enable toggle: new ops inherit client proxy state
+    client->disable_proxy();
+    auto op1 = client->new_operation(Verb::GET, "http://example.com/path");
+    DEFER(client->destroy_operation(op1));
+    EXPECT_FALSE(op1->enable_proxy);
 
+    client->enable_proxy();
     auto op = client->new_operation(Verb::GET, "http://example.com/path");
     DEFER(client->destroy_operation(op));
-
-    EXPECT_TRUE(op->get_proxy()->empty());
-    EXPECT_FALSE(op->enable_proxy);
-
-    // Operation::set_proxy should enable proxy at operation level
-    op->set_proxy("http://proxy1:8080");
-    EXPECT_FALSE(op->get_proxy()->empty());
-    EXPECT_EQ(op->get_proxy()->host(), "proxy1");
-    EXPECT_EQ(op->get_proxy()->port(), 8080);
     EXPECT_TRUE(op->enable_proxy);
 
-    // clear_proxy should clear operation-level proxy but keep enable_proxy
-    op->clear_proxy();
-    EXPECT_TRUE(op->get_proxy()->empty());
-    EXPECT_TRUE(op->enable_proxy);
+    // Op inherits client proxy URL (no op URL set)
+    client->set_proxy("http://client-proxy:8080");
+    EXPECT_EQ(op->get_proxy()->to_string(), "http://client-proxy:8080");
+
+    // Op-level set_proxy with user:pass → op URL wins
+    op->set_proxy("http://user:pass@op-proxy:9090");
+    EXPECT_EQ(op->get_proxy()->to_string(), "http://user:pass@op-proxy:9090");
+
+    // get_active_proxy: enabled + URL set → active
+    ASSERT_NE(op->get_active_proxy(), nullptr);
+    EXPECT_EQ(op->get_active_proxy()->to_string(), "http://user:pass@op-proxy:9090");
+
+    // Disabled → nullptr
+    op->set_enable_proxy(false);
+    EXPECT_EQ(op->get_active_proxy(), nullptr);
+
+    // Re-enabled → active again
+    op->set_enable_proxy(true);
+    EXPECT_NE(op->get_active_proxy(), nullptr);
+
+    // No proxy configured at all → nullptr
+    auto client2 = new_http_client();
+    DEFER(delete client2);
+    auto op2 = client2->new_operation(Verb::GET, "http://example.com/path");
+    DEFER(client2->destroy_operation(op2));
+    EXPECT_EQ(op2->get_active_proxy(), nullptr);
 }
 
-// Verify set_proxy/clear_proxy keep request line unchanged when enable_proxy is already true
-TEST(http_client, operation_set_clear_proxy_no_rebuild) {
+
+// call() rewrites request line: absolute URI when proxy enabled, path-only otherwise.
+TEST(http_client_proxy, request_line_rebuild) {
     auto client = new_http_client();
     DEFER(delete client);
-    client->set_proxy("http://default-proxy:8080");
 
-    auto op = client->new_operation(Verb::GET, "http://example.com/path");
-    DEFER(client->destroy_operation(op));
+    // No proxy at construction → path-only
+    auto op1 = client->new_operation(Verb::GET, "http://example.com/path?query=1");
+    DEFER(client->destroy_operation(op1));
+    op1->retry = 0;
+    op1->timeout = 100UL * 1000;
+    EXPECT_EQ(op1->req.target(), "/path?query=1");
 
-    // Client-level proxy is set, so enable_proxy is already true
-    EXPECT_TRUE(op->enable_proxy);
-    auto target_before = std::string(op->req.target());
+    // set_proxy after construction → call() rebuilds to absolute
+    op1->set_proxy("http://myproxy:3128");
+    op1->call();
+    EXPECT_EQ(op1->req.target(), "http://example.com/path?query=1");
 
-    // Set operation-level proxy; should not rebuild request line
-    op->set_proxy("http://op-proxy:9090");
-    EXPECT_EQ(op->req.target(), target_before);
-    EXPECT_FALSE(op->get_proxy()->empty());
-    EXPECT_EQ(op->get_proxy()->host(), "op-proxy");
-    EXPECT_EQ(op->get_proxy()->port(), 9090);
+    // Proxy at construction → absolute target
+    client->set_proxy("http://myproxy:3128");
+    auto op2 = client->new_operation(Verb::GET, "http://example.com/path?query=1");
+    DEFER(client->destroy_operation(op2));
+    op2->retry = 0;
+    op2->timeout = 100UL * 1000;
+    EXPECT_EQ(op2->req.target(), "http://example.com/path?query=1");
 
-    // Clear operation-level proxy; request line still unchanged
-    op->clear_proxy();
-    EXPECT_TRUE(op->get_proxy()->empty());
-    EXPECT_EQ(op->req.target(), target_before);
-    EXPECT_TRUE(op->enable_proxy);
-}
-
-// Verify set_proxy/clear_proxy rebuild request line between relative and absolute URI
-TEST(http_client, operation_set_proxy_rebuilds_request_line) {
-    auto client = new_http_client();
-    DEFER(delete client);
-    // No client-level proxy
-
-    auto op = client->new_operation(Verb::GET, "http://example.com/path?query=1");
-    DEFER(client->destroy_operation(op));
-
-    // Before set_proxy: request line should be relative path
-    EXPECT_FALSE(op->enable_proxy);
-    EXPECT_EQ(op->req.target(), "/path?query=1");
-
-    // After set_proxy: request line should be absolute URI
-    op->set_proxy("http://myproxy:3128");
-    EXPECT_TRUE(op->enable_proxy);
-    EXPECT_EQ(op->req.target(), "http://example.com/path?query=1");
-
-    // After clear_proxy: enable_proxy still true (request line unchanged),
-    // but no proxy is configured
-    op->clear_proxy();
-    EXPECT_TRUE(op->enable_proxy);
-    EXPECT_EQ(op->req.target(), "http://example.com/path?query=1");
-    EXPECT_TRUE(op->get_proxy()->empty());
+    // Disable proxy → call() rebuilds to path-only
+    op2->set_enable_proxy(false);
+    op2->call();
+    EXPECT_EQ(op2->req.target(), "/path?query=1");
 }
 
 // E2E test: different operations use different proxies through the same client
@@ -969,7 +963,7 @@ int op_proxy_echo_handler(void*, Request& req, Response& resp, std::string_view)
 }
 } // anonymous namespace
 
-TEST(http_client, operation_level_proxy_e2e) {
+TEST(http_client_proxy, operation_level_e2e) {
     //--------start source server ------------
     auto source_server = new_tcp_socket_server();
     source_server->timeout(1000ULL*1000);
@@ -1083,19 +1077,76 @@ TEST(http_client, operation_level_proxy_e2e) {
     EXPECT_EQ(std::string_view(buf3, ret3), body3);
 }
 
-// Only for manual test
-// TEST(http_client, proxy) {
-//     auto client = new_http_client();
-//     DEFER(delete client);
-//     client->set_proxy("http://localhost:8899/");
-//     auto op = client->new_operation(Verb::delete_, "https://domain:1234/targetName");
-//     DEFER(op->destroy());
-//     LOG_DEBUG(VALUE(op->req.whole()));
-//     op->req.redirect(Verb::GET, "baidu.com", true);
-//     LOG_DEBUG(VALUE(op->req.whole()));
-//     op->call();
-//     EXPECT_EQ(200, op->status_code);
-// }
+// Proxy-Authorization priority: op->proxy_header > client->proxy_headers() > URL auth > empty.
+// These tests use HTTP/1.1 proxy (connection fails but headers are set up before dial).
+
+TEST(http_client_proxy, auth_from_op_proxy_header) {
+    auto client = new_http_client();
+    DEFER(delete client);
+    client->set_proxy("http://user:pass@127.0.0.1:19999");
+
+    auto op = client->new_operation(Verb::GET, "http://example.com/path");
+    DEFER(client->destroy_operation(op));
+    op->retry = 0;
+    op->timeout = 100UL * 1000;
+
+    // Manually set Proxy-Authorization on op's proxy_header BEFORE call()
+    op->proxy_header.insert("Proxy-Authorization", "Bearer manual-token");
+    op->call();
+
+    // op->proxy_header must NOT be overwritten by proxy URL credentials.
+    EXPECT_EQ(op->req.headers["Proxy-Authorization"], "Bearer manual-token");
+}
+
+TEST(http_client_proxy, auth_from_client_proxy_header) {
+    auto client = new_http_client();
+    DEFER(delete client);
+    client->set_proxy("http://user:pass@127.0.0.1:19999");
+    // Set Proxy-Authorization in client-level proxy headers.
+    client->proxy_headers()->insert("Proxy-Authorization", "Bearer from-proxy-header");
+
+    auto op = client->new_operation(Verb::GET, "http://example.com/path");
+    DEFER(client->destroy_operation(op));
+    op->retry = 0;
+    op->timeout = 100UL * 1000;
+    op->call();
+
+    // client proxy_headers wins over URL auth.
+    EXPECT_EQ(op->req.headers["Proxy-Authorization"], "Bearer from-proxy-header");
+}
+
+TEST(http_client_proxy, auth_from_url) {
+    auto client = new_http_client();
+    DEFER(delete client);
+    client->set_proxy("http://user:pass@127.0.0.1:19999");
+
+    auto op = client->new_operation(Verb::GET, "http://example.com/path");
+    DEFER(client->destroy_operation(op));
+    op->retry = 0;
+    op->timeout = 100UL * 1000;
+    EXPECT_TRUE(op->req.headers["Proxy-Authorization"].empty());
+
+    op->call();
+
+    // No manual headers → URL auth is inserted as Basic.
+    auto auth = op->req.headers["Proxy-Authorization"];
+    EXPECT_FALSE(auth.empty());
+    EXPECT_TRUE(auth.substr(0, 6) == "Basic ");
+}
+
+// No proxy configured → no Proxy-Authorization inserted.
+TEST(http_client_proxy, auth_not_inserted_without_proxy) {
+    auto client = new_http_client();
+    DEFER(delete client);
+
+    auto op = client->new_operation(Verb::GET, "http://127.0.0.1:19999/path");
+    DEFER(client->destroy_operation(op));
+    op->retry = 0;
+    op->timeout = 100UL * 1000;
+    op->call();
+
+    EXPECT_TRUE(op->req.headers["Proxy-Authorization"].empty());
+}
 
 // Helpers/tests for issue #1256 -- HTTP/1.0 close-delimited responses
 static std::string g_close_delim_payload;

--- a/net/http/test/client_tls_test.cpp
+++ b/net/http/test/client_tls_test.cpp
@@ -16,12 +16,14 @@ limitations under the License.
 
 #include <openssl/ssl.h>
 
+#include <atomic>
 #include <thread>
 
 #include <photon/photon.h>
 #include <photon/common/alog.h>
 #include <photon/common/alog-stdstring.h>
 #include <photon/thread/thread.h>
+#include <photon/thread/thread11.h>
 #include <photon/net/socket.h>
 #include <photon/net/security-context/tls-stream.h>
 #include <photon/net/http/message.h>
@@ -53,10 +55,10 @@ int idiot_handler(void*, net::http::Request &req, net::http::Response &resp, std
     return 0;
 }
 
+net::TLSContext *tls_ctx;
+
 TEST(client_tls, basic) {
-    auto ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
-    DEFER(delete ctx);
-    auto tcpserver = net::new_tls_server(ctx, net::new_tcp_socket_server(), true);
+    auto tcpserver = net::new_tls_server(tls_ctx, net::new_tcp_socket_server(), true);
     DEFER(delete tcpserver);
     tcpserver->timeout(1000ULL*1000);
     int r = tcpserver->bind_v4localhost();
@@ -72,7 +74,7 @@ TEST(client_tls, basic) {
     tcpserver->set_handler(server->get_connection_handler());
     tcpserver->start_loop();
 
-    auto client = net::http::new_http_client(nullptr, ctx);
+    auto client = net::http::new_http_client(nullptr, tls_ctx);
     DEFER(delete client);
     auto op = client->new_operation(net::http::Verb::GET, to_surl(tcpserver, "/test"));
     DEFER(client->destroy_operation(op));
@@ -84,6 +86,618 @@ TEST(client_tls, basic) {
     auto ret = op->resp.read(buf, 4096);
     EXPECT_EQ(exp_len, ret);
     EXPECT_EQ("test", op->resp.headers["Test_Handle"]);
+}
+
+int echo_target_handler(void*, net::http::Request &req, net::http::Response &resp, std::string_view) {
+    auto target = req.target();
+    resp.set_result(200);
+    resp.headers.content_length(target.size());
+    resp.write(target.data(), target.size());
+    return 0;
+}
+
+// Runs a forward-proxy HTTP server on its own OS thread (its own photon vCPU).
+//
+// Rationale: the HTTP client caches a PooledDialer in thread-local storage.
+// If the proxy shared a vCPU with the test client, the proxy's internal
+// forward client and the test client would use the same dialer / connection
+// pool, and the proxy's bidirectional tunnel_copy loops would interleave with
+// the client on the same cooperative scheduler. Under macOS/kqueue wakeup
+// ordering this can stall the tunnel and hang the test. Running the proxy on
+// a dedicated vCPU mirrors the real-world topology (a proxy is a separate
+// process) and keeps the two dialers independent.
+class ForwardProxyThread {
+public:
+    // handler == nullptr → a default forward proxy handler is created and
+    // owned internally. Otherwise ownership of `handler` is transferred here;
+    // it is destroyed on the proxy vCPU during teardown.
+    explicit ForwardProxyThread(net::http::HTTPHandler* handler = nullptr) {
+        os_thread_ = std::thread([this, handler] { run(handler); });
+        sem_ready_.wait(1);
+    }
+    ~ForwardProxyThread() {
+        stop_.store(true);
+        os_thread_.join();
+    }
+    uint16_t port() const { return port_; }
+
+private:
+    void run(net::http::HTTPHandler* handler) {
+        photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+        DEFER(photon::fini());
+
+        auto proxy_tcp = net::new_tcp_socket_server();
+        auto proxy_http = net::http::new_http_server();
+        proxy_tcp->timeout(1000UL * 1000);
+        if (proxy_tcp->bind_v4localhost() != 0 || proxy_tcp->listen() != 0) {
+            delete proxy_tcp;
+            delete proxy_http;
+            sem_ready_.signal(1);
+            return;
+        }
+        auto* owned = handler ? handler : net::http::new_default_forward_proxy_handler();
+        proxy_http->add_handler(owned, false);
+        proxy_tcp->set_handler(proxy_http->get_connection_handler());
+        proxy_tcp->start_loop();
+        port_ = proxy_tcp->getsockname().port;
+        sem_ready_.signal(1);
+
+        while (!stop_.load())
+            photon::thread_usleep(10 * 1000);
+
+        delete proxy_tcp;   // stops server, joins connection threads
+        delete proxy_http;  // safe: no threads reference handler now
+        delete owned;
+    }
+
+    std::thread os_thread_;
+    photon::semaphore sem_ready_;
+    std::atomic<bool> stop_{false};
+    uint16_t port_ = 0;
+};
+
+TEST(client_proxy, connect_tunnel) {
+    auto tls_svr = net::new_tls_server(tls_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tls_svr);
+    tls_svr->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tls_svr->bind_v4localhost());
+    ASSERT_EQ(0, tls_svr->listen());
+
+    auto target_http = net::http::new_http_server();
+    DEFER(delete target_http);
+    target_http->add_handler({nullptr, &echo_target_handler});
+    tls_svr->set_handler(target_http->get_connection_handler());
+    tls_svr->start_loop();
+    auto target_port = tls_svr->getsockname().port;
+
+    ForwardProxyThread proxy;
+    auto proxy_port = proxy.port();
+
+    auto client = net::http::new_http_client(nullptr, tls_ctx);
+    DEFER({ delete client; photon::thread_usleep(50 * 1000); });
+    char proxy_url[128];
+    snprintf(proxy_url, sizeof(proxy_url), "http://127.0.0.1:%u", proxy_port);
+    client->set_proxy(proxy_url);
+
+    char target_url[128];
+    snprintf(target_url, sizeof(target_url), "https://127.0.0.1:%u/test-tunnel", target_port);
+    auto op = client->new_operation(net::http::Verb::GET, target_url);
+    DEFER(client->destroy_operation(op));
+    op->req.headers.content_length(0);
+    op->retry = 0;
+    int ret = op->call();
+    ASSERT_EQ(0, ret);
+    EXPECT_EQ(200, op->resp.status_code());
+
+    char buf[4096];
+    auto n = op->resp.read(buf, op->resp.headers.content_length());
+    ASSERT_GT(n, 0);
+    buf[n] = '\0';
+    EXPECT_STREQ("/test-tunnel", buf);
+}
+
+// Handler that captures CONNECT request headers for verification,
+// then delegates to the default forward proxy handler for tunneling.
+//
+// Runs on the proxy vCPU while assertions read its fields on the main vCPU.
+// `connect_count` is atomic and incremented last within the CONNECT branch,
+// so its release ordering publishes the captured_* strings written before it;
+// tests read connect_count first, which acquires those writes.
+class HeaderCapturingProxyHandler : public net::http::HTTPHandler {
+public:
+    std::string captured_user_agent;
+    std::string captured_custom_header;
+    std::string captured_target;  // CONNECT request-line target (host:port)
+    std::string captured_proxy_auth;  // Proxy-Authorization header value
+    std::atomic<int> connect_count{0};
+
+    int handle_request(net::http::Request &req, net::http::Response &resp,
+                       std::string_view prefix) override {
+        if (req.verb() == net::http::Verb::CONNECT) {
+            captured_target = std::string(req.target());
+            auto ua = req.headers["User-Agent"];
+            if (!ua.empty()) captured_user_agent = std::string(ua);
+            auto custom = req.headers["X-Test-Header"];
+            if (!custom.empty()) captured_custom_header = std::string(custom);
+            auto auth = req.headers["Proxy-Authorization"];
+            if (!auth.empty()) captured_proxy_auth = std::string(auth);
+            connect_count++;
+        }
+        return inner_->handle_request(req, resp, prefix);
+    }
+
+    HeaderCapturingProxyHandler() {
+        inner_.reset(net::http::new_default_forward_proxy_handler());
+    }
+private:
+    std::unique_ptr<net::http::HTTPHandler> inner_;
+};
+
+TEST(client_proxy, connect_tunnel_inherits_headers) {
+    // TLS target server
+    auto tls_svr = net::new_tls_server(tls_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tls_svr);
+    tls_svr->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tls_svr->bind_v4localhost());
+    ASSERT_EQ(0, tls_svr->listen());
+    auto target_http = net::http::new_http_server();
+    DEFER(delete target_http);
+    target_http->add_handler({nullptr, &echo_target_handler});
+    tls_svr->set_handler(target_http->get_connection_handler());
+    tls_svr->start_loop();
+    auto target_port = tls_svr->getsockname().port;
+
+    // Proxy server (own vCPU) with header-capturing handler
+    auto* cap_handler = new HeaderCapturingProxyHandler();
+    ForwardProxyThread proxy(cap_handler);
+    auto proxy_port = proxy.port();
+
+    // Client with proxy headers (used for CONNECT handshake)
+    auto client = net::http::new_http_client(nullptr, tls_ctx);
+    DEFER({ delete client; photon::thread_usleep(50 * 1000); });
+    char proxy_url[128];
+    snprintf(proxy_url, sizeof(proxy_url), "http://127.0.0.1:%u", proxy_port);
+    client->set_proxy(proxy_url);
+    // Use proxy_headers() for headers that should appear in CONNECT request
+    client->proxy_headers()->insert("User-Agent", "TestClient/1.0");
+    client->proxy_headers()->insert("X-Test-Header", "hello-proxy");
+
+    char target_url[128];
+    snprintf(target_url, sizeof(target_url), "https://127.0.0.1:%u/test-headers", target_port);
+    auto op = client->new_operation(net::http::Verb::GET, target_url);
+    DEFER(client->destroy_operation(op));
+    op->req.headers.content_length(0);
+    op->retry = 0;
+    int ret = op->call();
+    ASSERT_EQ(0, ret);
+    EXPECT_EQ(200, op->resp.status_code());
+
+    // Verify CONNECT request received the proxy headers
+    EXPECT_EQ(1, cap_handler->connect_count.load());
+    EXPECT_EQ("TestClient/1.0", cap_handler->captured_user_agent);
+    EXPECT_EQ("hello-proxy", cap_handler->captured_custom_header);
+    // Verify CONNECT target is in host:port format (RFC 7231 §4.3.6)
+    char expected_target[64];
+    snprintf(expected_target, sizeof(expected_target), "127.0.0.1:%u", target_port);
+    EXPECT_EQ(expected_target, cap_handler->captured_target);
+}
+
+TEST(client_proxy, connect_tunnel_multiple_requests) {
+    auto tls_svr = net::new_tls_server(tls_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tls_svr);
+    tls_svr->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tls_svr->bind_v4localhost());
+    ASSERT_EQ(0, tls_svr->listen());
+
+    auto target_http = net::http::new_http_server();
+    DEFER(delete target_http);
+    target_http->add_handler({nullptr, &echo_target_handler});
+    tls_svr->set_handler(target_http->get_connection_handler());
+    tls_svr->start_loop();
+    auto target_port = tls_svr->getsockname().port;
+
+    ForwardProxyThread proxy;
+    auto proxy_port = proxy.port();
+
+    auto client = net::http::new_http_client(nullptr, tls_ctx);
+    DEFER({ delete client; photon::thread_usleep(50 * 1000); });
+    char proxy_url[128];
+    snprintf(proxy_url, sizeof(proxy_url), "http://127.0.0.1:%u", proxy_port);
+    client->set_proxy(proxy_url);
+
+    for (int i = 0; i < 3; i++) {
+        char target_url[128];
+        snprintf(target_url, sizeof(target_url), "https://127.0.0.1:%u/req-%d", target_port, i);
+        auto op = client->new_operation(net::http::Verb::GET, target_url);
+        DEFER(client->destroy_operation(op));
+        op->req.headers.content_length(0);
+        op->retry = 0;
+        int ret = op->call();
+        ASSERT_EQ(0, ret);
+        EXPECT_EQ(200, op->resp.status_code());
+
+        char buf[4096];
+        auto n = op->resp.read(buf, op->resp.headers.content_length());
+        ASSERT_GT(n, 0);
+        buf[n] = '\0';
+        char expected[64];
+        snprintf(expected, sizeof(expected), "/req-%d", i);
+        EXPECT_STREQ(expected, buf);
+    }
+}
+
+// Proxy handler that rejects every CONNECT with a non-2xx status, so the
+// tunnel handshake never completes. Used to verify the client surfaces the
+// failure instead of proceeding as if the tunnel were established.
+class RejectingConnectProxyHandler : public net::http::HTTPHandler {
+public:
+    std::atomic<int> connect_count{0};
+    RejectingConnectProxyHandler() {
+        inner_.reset(net::http::new_default_forward_proxy_handler());
+    }
+    int handle_request(net::http::Request &req, net::http::Response &resp,
+                       std::string_view prefix) override {
+        if (req.verb() == net::http::Verb::CONNECT) {
+            connect_count++;
+            resp.set_result(403, "Forbidden");
+            resp.headers.content_length(0);
+            resp.keep_alive(false);
+            return 0;
+        }
+        return inner_->handle_request(req, resp, prefix);
+    }
+private:
+    std::unique_ptr<net::http::HTTPHandler> inner_;
+};
+
+TEST(client_proxy, connect_tunnel_proxy_rejects) {
+    // Proxy answers CONNECT with 403; no tunnel is established.
+    auto* rej_handler = new RejectingConnectProxyHandler();
+    ForwardProxyThread proxy(rej_handler);
+    auto proxy_port = proxy.port();
+
+    auto client = net::http::new_http_client(nullptr, tls_ctx);
+    DEFER({ delete client; photon::thread_usleep(50 * 1000); });
+    char proxy_url[128];
+    snprintf(proxy_url, sizeof(proxy_url), "http://127.0.0.1:%u", proxy_port);
+    client->set_proxy(proxy_url);
+
+    // Target need not exist: the proxy rejects before any tunnel is set up.
+    auto op = client->new_operation(net::http::Verb::GET, "https://127.0.0.1:1/never");
+    DEFER(client->destroy_operation(op));
+    op->req.headers.content_length(0);
+    op->retry = 0;
+    int ret = op->call();
+    EXPECT_NE(0, ret);
+    EXPECT_EQ(-1, op->status_code);
+    EXPECT_EQ(1, rej_handler->connect_count.load());
+}
+
+TEST(client_proxy, connect_tunnel_concurrent_reuse) {
+    auto tls_svr = net::new_tls_server(tls_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tls_svr);
+    tls_svr->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tls_svr->bind_v4localhost());
+    ASSERT_EQ(0, tls_svr->listen());
+
+    auto target_http = net::http::new_http_server();
+    DEFER(delete target_http);
+    target_http->add_handler({nullptr, &echo_target_handler});
+    tls_svr->set_handler(target_http->get_connection_handler());
+    tls_svr->start_loop();
+    auto target_port = tls_svr->getsockname().port;
+
+    ForwardProxyThread proxy;
+    auto proxy_port = proxy.port();
+
+    auto client = net::http::new_http_client(nullptr, tls_ctx);
+    DEFER({ delete client; photon::thread_usleep(50 * 1000); });
+    char proxy_url[128];
+    snprintf(proxy_url, sizeof(proxy_url), "http://127.0.0.1:%u", proxy_port);
+    client->set_proxy(proxy_url);
+
+    // Concurrent requests through the same tunnel pool.
+    // All target the same host:port so they should reuse a single tunnel.
+    constexpr int N = 5;
+    photon::semaphore sem(0);
+    int success_count = 0;
+
+    for (int i = 0; i < N; i++) {
+        auto fn = [&, i] {
+            char target_url[128];
+            snprintf(target_url, sizeof(target_url),
+                     "https://127.0.0.1:%u/concurrent-%d", target_port, i);
+            auto op = client->new_operation(net::http::Verb::GET, target_url);
+            DEFER(client->destroy_operation(op));
+            op->req.headers.content_length(0);
+            op->retry = 0;
+            int ret = op->call();
+            if (ret == 0 && op->resp.status_code() == 200) {
+                char buf[4096];
+                auto n = op->resp.read(buf, op->resp.headers.content_length());
+                if (n > 0) {
+                    buf[n] = '\0';
+                    char expected[64];
+                    snprintf(expected, sizeof(expected), "/concurrent-%d", i);
+                    EXPECT_STREQ(expected, buf);
+                    success_count++;
+                }
+            }
+            sem.signal(1);
+        };
+        photon::thread_create11(fn);
+    }
+    sem.wait(N);
+    EXPECT_EQ(N, success_count);
+}
+
+// Proxy handler that counts CONNECT requests for verification.
+// connect_count is atomic: written on the proxy vCPU, read on the main vCPU.
+class ConnectCountingProxyHandler : public net::http::HTTPHandler {
+public:
+    std::atomic<int> connect_count{0};
+    ConnectCountingProxyHandler() {
+        inner_.reset(net::http::new_default_forward_proxy_handler());
+    }
+    int handle_request(net::http::Request &req, net::http::Response &resp,
+                       std::string_view prefix) override {
+        if (req.verb() == net::http::Verb::CONNECT)
+            connect_count++;
+        return inner_->handle_request(req, resp, prefix);
+    }
+private:
+    std::unique_ptr<net::http::HTTPHandler> inner_;
+};
+
+// Helper: set up proxy (own vCPU) + target servers, return proxy/target ports.
+struct TunnelTestEnv {
+    net::http::HTTPServer* target_http = nullptr;
+    net::ISocketServer* tls_svr = nullptr;
+    ForwardProxyThread* proxy = nullptr;
+    net::TLSContext* ctx = nullptr;
+    uint16_t target_port = 0;
+    uint16_t proxy_port = 0;
+};
+
+static void setup_tunnel_test(TunnelTestEnv& env,
+                               ConnectCountingProxyHandler* counter = nullptr) {
+    env.ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+
+    env.tls_svr = net::new_tls_server(env.ctx, net::new_tcp_socket_server(), true);
+    env.tls_svr->timeout(1000UL * 1000);
+    ASSERT_EQ(0, env.tls_svr->bind_v4localhost());
+    ASSERT_EQ(0, env.tls_svr->listen());
+
+    env.target_http = net::http::new_http_server();
+    env.target_http->add_handler({nullptr, &echo_target_handler});
+    env.tls_svr->set_handler(env.target_http->get_connection_handler());
+    env.tls_svr->start_loop();
+    env.target_port = env.tls_svr->getsockname().port;
+
+    // Proxy runs on its own vCPU (see ForwardProxyThread rationale).
+    env.proxy = new ForwardProxyThread(counter);
+    env.proxy_port = env.proxy->port();
+}
+
+static void teardown_tunnel_test(TunnelTestEnv& env) {
+    delete env.proxy;       // stops proxy vCPU, joins its connection threads
+    delete env.tls_svr;
+    delete env.target_http;
+    delete env.ctx;
+}
+
+// Verifies Proxy-Authorization from proxy URL is forwarded in the CONNECT handshake.
+TEST(client_proxy, connect_tunnel_auth) {
+    // TLS target server
+    auto tls_svr = net::new_tls_server(tls_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tls_svr);
+    tls_svr->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tls_svr->bind_v4localhost());
+    ASSERT_EQ(0, tls_svr->listen());
+    auto target_http = net::http::new_http_server();
+    DEFER(delete target_http);
+    target_http->add_handler({nullptr, &echo_target_handler});
+    tls_svr->set_handler(target_http->get_connection_handler());
+    tls_svr->start_loop();
+    auto target_port = tls_svr->getsockname().port;
+
+    // Proxy server (own vCPU) with header-capturing handler
+    auto* cap_handler = new HeaderCapturingProxyHandler();
+    ForwardProxyThread proxy(cap_handler);
+    auto proxy_port = proxy.port();
+
+    // Client with proxy URL containing user:pass credentials
+    auto client = net::http::new_http_client(nullptr, tls_ctx);
+    DEFER({ delete client; photon::thread_usleep(50 * 1000); });
+    char proxy_url[128];
+    snprintf(proxy_url, sizeof(proxy_url), "http://user:pass@127.0.0.1:%u", proxy_port);
+    client->set_proxy(proxy_url);
+
+    char target_url[128];
+    snprintf(target_url, sizeof(target_url),
+             "https://127.0.0.1:%u/auth-check", target_port);
+    auto op = client->new_operation(net::http::Verb::GET, target_url);
+    DEFER(client->destroy_operation(op));
+    op->req.headers.content_length(0);
+    op->retry = 0;
+    int ret = op->call();
+    ASSERT_EQ(0, ret);
+    EXPECT_EQ(200, op->resp.status_code());
+
+    // CONNECT must carry Proxy-Authorization: Basic base64(user:pass)
+    EXPECT_EQ(1, cap_handler->connect_count.load());
+    EXPECT_FALSE(cap_handler->captured_proxy_auth.empty());
+    EXPECT_TRUE(cap_handler->captured_proxy_auth.substr(0, 6) == "Basic ");
+}
+
+// After the target server closes the connection, the tunnel pool should
+// detect the dead fd and create a new CONNECT tunnel on the next request.
+TEST(client_proxy, connect_tunnel_server_close) {
+    TunnelTestEnv env;
+    auto counter = new ConnectCountingProxyHandler();
+    setup_tunnel_test(env, counter);
+
+    auto client = net::http::new_http_client(nullptr, env.ctx);
+    char proxy_url[128];
+    snprintf(proxy_url, sizeof(proxy_url), "http://127.0.0.1:%u", env.proxy_port);
+    client->set_proxy(proxy_url);
+
+    char target_url[128];
+    snprintf(target_url, sizeof(target_url),
+             "https://127.0.0.1:%u/req-1", env.target_port);
+
+    // Request 1: creates a new tunnel.
+    auto op = client->new_operation(net::http::Verb::GET, target_url);
+    op->req.headers.content_length(0);
+    op->retry = 0;
+    ASSERT_EQ(0, op->call());
+    EXPECT_EQ(200, op->resp.status_code());
+    // Drain response body so the stream is clean for return-to-pool.
+    char buf[4096];
+    while (op->resp.read(buf, sizeof(buf)) > 0) {}
+    EXPECT_EQ(1, counter->connect_count.load());
+
+    // Brief yield to let the target server finish closing the connection.
+    photon::thread_usleep(10 * 1000);
+
+    // Request 2: old tunnel's fd should be detected as dead (EOF).
+    // Pool misses → creates a new CONNECT.
+    snprintf(target_url, sizeof(target_url),
+             "https://127.0.0.1:%u/req-2", env.target_port);
+    auto op2 = client->new_operation(net::http::Verb::GET, target_url);
+    op2->req.headers.content_length(0);
+    op2->retry = 0;
+    ASSERT_EQ(0, op2->call());
+    EXPECT_EQ(200, op2->resp.status_code());
+    while (op2->resp.read(buf, sizeof(buf)) > 0) {}
+    EXPECT_GE(counter->connect_count.load(), 2);
+
+    client->destroy_operation(op);
+    client->destroy_operation(op2);
+    delete client;
+    photon::thread_usleep(50 * 1000);
+    teardown_tunnel_test(env);
+}
+
+// Requests to different targets (host:port) should use separate tunnels.
+TEST(client_proxy, connect_tunnel_multi_target) {
+    // Target A
+    auto tls_svr_a = net::new_tls_server(tls_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tls_svr_a);
+    tls_svr_a->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tls_svr_a->bind_v4localhost());
+    ASSERT_EQ(0, tls_svr_a->listen());
+    auto http_a = net::http::new_http_server();
+    DEFER(delete http_a);
+    http_a->add_handler({nullptr, &echo_target_handler});
+    tls_svr_a->set_handler(http_a->get_connection_handler());
+    tls_svr_a->start_loop();
+    auto port_a = tls_svr_a->getsockname().port;
+
+    // Target B
+    auto tls_svr_b = net::new_tls_server(tls_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tls_svr_b);
+    tls_svr_b->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tls_svr_b->bind_v4localhost());
+    ASSERT_EQ(0, tls_svr_b->listen());
+    auto http_b = net::http::new_http_server();
+    DEFER(delete http_b);
+    http_b->add_handler({nullptr, &echo_target_handler});
+    tls_svr_b->set_handler(http_b->get_connection_handler());
+    tls_svr_b->start_loop();
+    auto port_b = tls_svr_b->getsockname().port;
+
+    // Proxy (own vCPU)
+    auto* counter = new ConnectCountingProxyHandler();
+    ForwardProxyThread proxy(counter);
+    auto proxy_port = proxy.port();
+
+    auto client = net::http::new_http_client(nullptr, tls_ctx);
+    char proxy_url[128];
+    snprintf(proxy_url, sizeof(proxy_url), "http://127.0.0.1:%u", proxy_port);
+    client->set_proxy(proxy_url);
+
+    // Request to target A
+    char url_a[128];
+    snprintf(url_a, sizeof(url_a), "https://127.0.0.1:%u/path-a", port_a);
+    auto op_a = client->new_operation(net::http::Verb::GET, url_a);
+    op_a->req.headers.content_length(0);
+    op_a->retry = 0;
+    ASSERT_EQ(0, op_a->call());
+    EXPECT_EQ(200, op_a->resp.status_code());
+    char buf[4096];
+    auto n = op_a->resp.read(buf, sizeof(buf) - 1);
+    ASSERT_GT(n, 0);
+    buf[n] = '\0';
+    EXPECT_STREQ("/path-a", buf);
+
+    // Request to target B — different port → different pool key → new tunnel.
+    char url_b[128];
+    snprintf(url_b, sizeof(url_b), "https://127.0.0.1:%u/path-b", port_b);
+    auto op_b = client->new_operation(net::http::Verb::GET, url_b);
+    op_b->req.headers.content_length(0);
+    op_b->retry = 0;
+    ASSERT_EQ(0, op_b->call());
+    EXPECT_EQ(200, op_b->resp.status_code());
+    n = op_b->resp.read(buf, sizeof(buf) - 1);
+    ASSERT_GT(n, 0);
+    buf[n] = '\0';
+    EXPECT_STREQ("/path-b", buf);
+
+    // Two different targets → exactly 2 CONNECT requests (no sharing).
+    EXPECT_EQ(2, counter->connect_count.load());
+
+    // Explicit cleanup: close pool connections first, then let proxy threads finish.
+    client->destroy_operation(op_a);
+    client->destroy_operation(op_b);
+    delete client;
+    photon::thread_usleep(50 * 1000);
+}
+
+// Same target with different proxy credentials must NOT share tunnels.
+// Regression guard: TunnelPool::connect_tunnel includes auth in the pool key.
+TEST(client_proxy, connect_tunnel_auth_isolation) {
+    TunnelTestEnv env;
+    auto counter = new ConnectCountingProxyHandler();
+    setup_tunnel_test(env, counter);
+
+    auto client = net::http::new_http_client(nullptr, env.ctx);
+
+    char target_url[128];
+    snprintf(target_url, sizeof(target_url),
+             "https://127.0.0.1:%u/auth-test", env.target_port);
+
+    // Request 1 with user1:pass1 → creates tunnel A.
+    char proxy1[128];
+    snprintf(proxy1, sizeof(proxy1), "http://user1:pass1@127.0.0.1:%u", env.proxy_port);
+    client->set_proxy(proxy1);
+    auto op1 = client->new_operation(net::http::Verb::GET, target_url);
+    op1->req.headers.content_length(0);
+    op1->retry = 0;
+    ASSERT_EQ(0, op1->call());
+    EXPECT_EQ(200, op1->resp.status_code());
+    char buf[4096];
+    while (op1->resp.read(buf, sizeof(buf)) > 0) {}
+    client->destroy_operation(op1);
+
+    // Request 2 with user2:pass2 to same target → different auth → new tunnel.
+    char proxy2[128];
+    snprintf(proxy2, sizeof(proxy2), "http://user2:pass2@127.0.0.1:%u", env.proxy_port);
+    client->set_proxy(proxy2);
+    auto op2 = client->new_operation(net::http::Verb::GET, target_url);
+    op2->req.headers.content_length(0);
+    op2->retry = 0;
+    ASSERT_EQ(0, op2->call());
+    EXPECT_EQ(200, op2->resp.status_code());
+    while (op2->resp.read(buf, sizeof(buf)) > 0) {}
+    client->destroy_operation(op2);
+
+    // Different auth → 2 CONNECT requests (not sharing the same tunnel).
+    EXPECT_EQ(2, counter->connect_count.load());
+
+    delete client;
+    photon::thread_usleep(50 * 1000);
+    teardown_tunnel_test(env);
 }
 
 // Server Name Indication (SNI) for SSL
@@ -242,5 +856,9 @@ int main(int argc, char** arg) {
     DEFER(photon::fini());
     set_log_output_level(ALOG_DEBUG);
     ::testing::InitGoogleTest(&argc, arg);
+
+    tls_ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+    DEFER(delete tls_ctx);
+
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## What changed

### CONNECT tunnel for HTTPS proxy (new)

HTTPS targets through an HTTP/HTTPS proxy are now handled via CONNECT tunnels (RFC 7231 §4.3.6). Previously only HTTP/1.1 forward proxy was supported; HTTPS proxy connections would fail or produce incorrect requests.

The tunnel logic is implemented as private methods of `PooledDialer` (`make_tunnel_stream`, `do_connect_handshake`), reusing the same `ISocketPool` instance for connection grouping — no separate pool class introduced.

### `proxy_header` (new interface)

A new `CommonHeaders<> proxy_header` field is introduced on `Operation`, with a companion `CommonHeaders<>* proxy_headers()` accessor on `Client`, dedicated to proxy-handshake headers (e.g. `Proxy-Authorization`). This separates proxy headers from `req.headers` (target-server headers).

Priority chain in `call()`:

    op->proxy_header  ←  merge client->proxy_headers()  ←  insert URL Basic auth
                              (op wins, allow_dup=0)        (allow_dup=0, manual wins)

- HTTP proxy (target is HTTP): `proxy_header` is merged into `req.headers` before sending. Existing code that sets `Proxy-Authorization` in `req.headers` still works — `merge` with `allow_dup=0` preserves the destination's existing value.
- HTTPS proxy (target is HTTPS): `proxy_header` is consumed exclusively by the CONNECT handshake; `req.headers` is sent to the target server after the tunnel is established.

### `set_proxy()` behavior change

- Operation `set_proxy(url)`: now also resets `op->proxy_header` — old proxy's auth headers are no longer valid for the new proxy.
- Client `set_proxy(url)`: now also resets `client->proxy_headers()`.

Note: the old `m_proxy_auth` field is removed. Auth is now derived from the proxy URL at `call()` time and lives in `proxy_header`.

### Key-based connection pooling (internal)

All connection types — direct TCP/TLS, HTTP proxy, and CONNECT tunnel — share a single `ISocketPool` (`new_tcp_socket_pool`) via `connect(key, connector)`. Connection grouping is purely by key:

| Connection type | Key format |
|---|---|
| Direct / HTTP proxy | `<host>:<port>:<0\|1>` (0=TCP, 1=TLS) |
| CONNECT tunnel | `<proxy_host>:<proxy_port>:<s\|p>:<target_host>:<target_port>[:<auth>]` |

The `connector` lambda (passed as `TempDelegate`, zero `std::function` overhead) is the factory that establishes new connections on pool miss. Different auth credentials or target endpoints produce different keys, preventing cross-contamination.

## Verification

    client_function_test  (-server_no_resp):   18/18 PASSED
    client_tls_test       (client_tls.basic):   1/1  PASSED
    client_tls_test       (client_proxy.*):     8/8  PASSED