### PR TITLE
Fix TLS SNI: hostname set after handshake, never sent in ClientHello

### DIFF
--- a/net/security-context/test/CMakeLists.txt
+++ b/net/security-context/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(test-tls test.cpp)
+target_include_directories(test-tls PRIVATE ${OPENSSL_INCLUDE_DIRS})
 target_link_libraries(test-tls PRIVATE photon_shared)
 add_test(NAME test-tls COMMAND $<TARGET_FILE:test-tls>)
 

--- a/net/security-context/test/test.cpp
+++ b/net/security-context/test/test.cpp
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <openssl/ssl.h>
+
 #include "../../../test/gtest.h"
 
 #include <photon/net/socket.h>
@@ -399,9 +401,61 @@ TEST(basic, alpn) {
     auto port = ep.port;
     auto s_c = cli->connect(net::EndPoint("127.0.0.1", port));
     DEFER(delete s_c);
+    // The client handshake is lazy (deferred to the first I/O), so drive it with a
+    // write before querying the negotiated ALPN.
+    char probe = 'x';
+    s_c->write(&probe, 1);
     auto cli_proto = net::tls_stream_get_alpn_selected(s_c);
     LOG_INFO(VALUE(cli_proto));
+    EXPECT_TRUE(cli_proto == "http/1.1");
 }
+
+// Regression for #1292: the SNI hostname must be carried in the ClientHello.
+// A plain-TCP server captures the first flight (the ClientHello) as raw bytes;
+// the SNI extension is not encrypted, so the hostname must appear verbatim once
+// tls_stream_set_hostname() takes effect before the handshake.
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+static std::string g_captured_client_hello;
+static photon::semaphore sni_sem(0);
+
+static int sni_capture_handler(void*, net::ISocketStream* stream) {
+    char buf[4096];
+    auto n = stream->recv(buf, sizeof(buf));  // first flight == ClientHello
+    if (n > 0) g_captured_client_hello.assign(buf, n);
+    sni_sem.signal(1);
+    return 0;
+}
+
+TEST(sni, hostname_in_client_hello) {
+    g_captured_client_hello.clear();
+    DEFER(photon::wait_all());
+    auto srv = net::new_tcp_socket_server();  // plain TCP: just capture raw bytes
+    DEFER(delete srv);
+    ASSERT_EQ(0, srv->bind_v4localhost());
+    ASSERT_EQ(0, srv->listen());
+    srv->set_handler({&sni_capture_handler, nullptr});
+    ASSERT_EQ(0, srv->start_loop(false));
+    photon::thread_yield();
+    auto ep = srv->getsockname();
+
+    auto ctx = net::new_tls_context();
+    DEFER(delete ctx);
+    auto tcp_cli = net::new_tcp_socket_client();
+    tcp_cli->timeout(1UL * 1000 * 1000);  // 1s, mandatory: bounds the handshake (the plain server never sends a ServerHello)
+    auto cli = net::new_tls_client(ctx, tcp_cli, true);
+    DEFER(delete cli);
+    auto s = cli->connect(ep);
+    ASSERT_NE(nullptr, s);
+    DEFER(delete s);
+
+    const char* kHost = "sni-probe.example.test";
+    net::tls_stream_set_hostname(s, kHost);
+    char req = 'x';
+    s->write(&req, 1);  // drives the client handshake -> sends the ClientHello
+    sni_sem.wait(1);
+    EXPECT_NE(std::string::npos, g_captured_client_hello.find(kHost));
+}
+#endif
 
 int main(int argc, char** arg) {
 #ifdef __linux__

--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -471,7 +471,12 @@ public:
         switch (r) {
             case SecurityRole::Client:
                 SSL_set_connect_state(ssl);
-                break;
+                // Defer the handshake to the first I/O. The SNI hostname is set
+                // via tls_stream_set_hostname() AFTER construction, and it must be
+                // carried in the ClientHello; handshaking here would send the
+                // ClientHello without SNI. SSL_read/SSL_write drives the client
+                // handshake once SNI has been set.
+                return;
             case SecurityRole::Server:
                 SSL_set_accept_state(ssl);
                 break;


### PR DESCRIPTION
## Summary
Fixes #1292. The SNI hostname was set *after* the TLS handshake, so it was never carried in the ClientHello and never reached the server.

## Root cause
Callers set the hostname only after the stream is constructed, e.g. `net/http/client.cpp`:

    sock = tlssock->connect(ep);            // TLSSocketStream ctor handshakes eagerly here
    tls_stream_set_hostname(sock, host);    // SNI set AFTER the ClientHello already went out

`TLSSocketStream`'s constructor called `SSL_do_handshake()` eagerly, so the ClientHello (with the SNI extension) was sent before `SSL_set_tlsext_host_name()` ran.

## Fix
Defer the **client** handshake out of the constructor: the ctor sets `SSL_set_connect_state()` and returns; the first `SSL_read`/`SSL_write` drives the handshake — by which point `tls_stream_set_hostname()` has set the SNI, so the ClientHello carries it. The **server** role is unchanged (still handshakes eagerly in the ctor).

## Behavior note (please review)
A client TLS stream's handshake now completes on the first I/O instead of inside `connect()`. Handshake-derived state (`tls_stream_get_alpn_selected()`, peer certificate) is therefore only available **after** the first read/write. No in-repo production caller is affected (the HTTP client sends the request first; no non-test caller queries ALPN before I/O). `TEST(basic, alpn)` was updated to drive I/O before querying ALPN and now asserts the negotiated protocol.

## Tests
- New `TEST(sni, hostname_in_client_hello)`: a plain-TCP server captures the raw ClientHello; the client sets the hostname then writes; asserts the hostname appears in the captured bytes. **Reverting the fix makes this test fail** (verified locally).
- `TEST(basic, alpn)` strengthened to assert the negotiated ALPN end-to-end.

## Verification
- ✅ **E2E (local, Linux / epoll, OpenSSL 1.1.1w):** `test-tls` 9/9, `client_tls_test` 1/1.
- ✅ **Discrimination confirmed:** the new SNI test fails without the fix.
- ⚠️ **Not run:** macOS / BSD, and the full CI matrix.

## Out of scope (pre-existing, not regressed by this PR)
- Connection reuse keys by IP:port, so two hostnames resolving to the same IP can share a pooled TLS connection (the first SNI wins).
- Photon does not call `SSL_set1_host`, so certificate hostname verification is not enforced either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
