### PR TITLE
[Pick][0.7 to 0.8] | [Backport][0.8 to 0.7] | Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372)  (#1402) 

### DIFF
--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -301,7 +301,11 @@ public:
         auto th = workth;
         workth = nullptr;
         thread_interrupt(th);
+<<<<<<< HEAD
         if (!m_block_serv)
+=======
+        if (!m_block)
+>>>>>>> 1104f42 ([Backport][0.8 to 0.7] | Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372)  (#1402))
             thread_join((join_handle*)th);
     }
 
@@ -1121,3 +1125,9 @@ LogBuffer& operator<<(LogBuffer& log, const sockaddr_in& addr) {
 LogBuffer& operator<<(LogBuffer& log, const sockaddr_in6& addr) {
     return log << photon::net::sockaddr_storage(addr).to_endpoint();
 }
+<<<<<<< HEAD
+=======
+LogBuffer& operator<<(LogBuffer& log, const sockaddr& addr) {
+    return log << photon::net::sockaddr_storage(addr).to_endpoint();
+}
+>>>>>>> 1104f42 ([Backport][0.8 to 0.7] | Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372)  (#1402))


### PR DESCRIPTION
> [Backport][0.8 to 0.7] | Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372)  (#1402)

* Fix terminate() thread join and skip_read static buffer race (#1287) (#1337) (#1372)

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

* Update kernel_socket.cpp

* Update kernel_socket.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits