### PR TITLE
[Pick][0.7 to 0.8] | [Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) (#1413)  (#1446) 

### DIFF
--- a/common/expirecontainer.cpp
+++ b/common/expirecontainer.cpp
@@ -151,6 +151,7 @@ void* ObjectCacheBase::ref_release(ItemPtr item, bool recycle, bool destroy) {
 }
 
 // the argument `key` plays the roles of (type-erased) key
+<<<<<<< HEAD
 void* ObjectCacheBase::release(const Item& key_item, bool recycle,
                                bool destroy) {
     ItemPtr item;
@@ -162,4 +163,16 @@ void* ObjectCacheBase::release(const Item& key_item, bool recycle,
     }
     return ref_release(item, recycle, destroy);
 
+=======
+int ObjectCacheBase::release(const ObjectCacheBase::Item& key_item,
+                             bool recycle) {
+    ItemPtr item; 
+    {
+        SCOPED_LOCK(_lock);
+        auto it = ExpireContainerBase::TypedIterator<Item>(Base::__find_prelock(key_item));
+        if (it == end()) return -1;
+        item = *it;
+    }
+    return ref_release(item, recycle);
+>>>>>>> b0028b2 ([Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) (#1413)  (#1446))
 }


### PR DESCRIPTION
> [Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) (#1413)  (#1446)

* [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) (#1413)

* Fix lockfree queue init and ObjectCache move/lock bugs (#1284)

* Refactor release method in ObjectCacheBase

* Update lockfree_queue.h

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>

* Delete common/objectcachev2.h

* fix conflict

* Update expirecontainer.cpp

* Update expirecontainer.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits