### PR TITLE
[Backport][0.7 to 0.6] | | | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) (#1413)  (#1446)

### DIFF
--- a/common/expirecontainer.cpp
+++ b/common/expirecontainer.cpp
@@ -152,7 +152,12 @@ int ObjectCacheBase::ref_release(ItemPtr item, bool recycle) {
 // the argument `key` plays the roles of (type-erased) key
 int ObjectCacheBase::release(const ObjectCacheBase::Item& key_item,
                              bool recycle) {
-    auto item = find(key_item);
-    if (item == end()) return -1;
-    return ref_release(*item, recycle);
+    ItemPtr item; 
+    {
+        SCOPED_LOCK(_lock);
+        auto it = ExpireContainerBase::TypedIterator<Item>(Base::__find_prelock(key_item));
+        if (it == end()) return -1;
+        item = *it;
+    }
+    return ref_release(item, recycle);
 }

--- a/common/lockfree_queue.h
+++ b/common/lockfree_queue.h
@@ -263,8 +263,8 @@ protected:
     using Base::idx;
     using Base::tail;  // write_tail
 
-    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> write_head;
-    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> read_tail;
+    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> write_head{0};
+    alignas(Base::CACHELINE_SIZE) std::atomic<uint64_t> read_tail{0};
 
     T slots[Base::capacity];
 


### PR DESCRIPTION
> [Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) (#1413)  (#1446)

* [Backport][main to 0.9] | Fix lockfree queue init and ObjectCache move/lock bugs (#1284)  (#1339) (#1413)

* Fix lockfree queue init and ObjectCache move/lock bugs (#1284)

* Refactor release method in ObjectCacheBase

* Update lockfree_queue.h

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>

* Delete common/objectcachev2.h

* fix conflict

* Update expirecontainer.cpp

* Update expirecontainer.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.