### PR TITLE
[Pick][0.7 to 0.8] | [Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) (#1412)  (#1454) 

### DIFF
--- a/net/http/message.cpp
+++ b/net/http/message.cpp
@@ -268,6 +268,7 @@ size_t Message::body_size() const {
     if (it != headers.end()) return estring_view(it.second()).to_uint64();
     // or calc from Content-Range
     it = headers.find("Content-Range");
+<<<<<<< HEAD
     if (it != headers.end()) {
         size_t start, end;
         if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
@@ -277,6 +278,15 @@ size_t Message::body_size() const {
             return end;
         }
         return 0;
+=======
+    if (it == headers.end()) return 0;
+    size_t start, end;
+    if (sscanf(it.second().data(), "bytes %lu-%lu", &start, &end) == 2) {
+        return end-start+1;
+    }
+    if (sscanf(it.second().data(), "bytes */%lu", &end) == 1) {
+        return end;
+>>>>>>> 3d202f2 ([Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) (#1412)  (#1454))
     }
     // No Content-Length and no Content-Range. If the connection will be closed
     // (Connection: close, Trailer, or HTTP/1.0 implicit close) and the response


### PR DESCRIPTION
> [Backport][0.8 to 0.7] | [Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) (#1412)  (#1454)

* [Backport][main to 0.9] | Fix swapped sscanf arguments in Content-Range parsing (#1262)  (#1325) (#1412)

* Fix swapped sscanf arguments in Content-Range parsing (#1262)

* Update message.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>

* Update message.cpp

* Update message.cpp

---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits