### PR TITLE
refactor socket pool

### DIFF
--- a/common/checksum/test/test_checksum.cpp
+++ b/common/checksum/test/test_checksum.cpp
@@ -169,7 +169,7 @@ TEST(Perf, crc32c_sw) {
 
 void do_test64(const char* name, CRC64ECMA crc64ecma) {
     auto start = std::chrono::system_clock::now();
-    for (int i = 0; i < 100; ++i)
+    // for (int i = 0; i < 100; ++i)
     for (auto& c: cases) {
         auto crc64 = crc64ecma((uint8_t*)c.s.data(), c.s.length(), 0);
         if (crc64 != c.crc64ecma) puts(c.s.data());

--- a/common/intrusive_list.h
+++ b/common/intrusive_list.h
@@ -358,7 +358,7 @@ public:
     {
         return node;
     }
-    bool empty()
+    bool empty() const
     {
         return node == nullptr;
     }
@@ -430,17 +430,19 @@ public:
         }
         return split_front_exclusive(first_not_fit);
     }
-    void delete_all()
+    size_t delete_all()
     {
         auto ptr = node;
+        size_t n = 0;
         if (ptr) {
             do {
                 auto next = ptr->next();
-                delete ptr;
+                delete ptr; n++;
                 ptr = next;
             } while (ptr != node);
         }
         node = nullptr;
+        return n;
     }
     NodeType* round_robin_next() {
         auto x = node;

--- a/common/timeout.h
+++ b/common/timeout.h
@@ -56,6 +56,18 @@ public:
     bool operator < (const Timeout& rhs) const {
         return m_expiration < rhs.m_expiration;
     }
+    bool operator <= (const Timeout& rhs) const {
+        return m_expiration < rhs.m_expiration;
+    }
+    bool operator > (const Timeout& rhs) const {
+        return m_expiration > rhs.m_expiration;
+    }
+    bool operator >= (const Timeout& rhs) const {
+        return m_expiration >= rhs.m_expiration;
+    }
+    bool operator == (const Timeout& rhs) const {
+        return m_expiration == rhs.m_expiration;
+    }
     Timeout& timeout_at_most(uint64_t x) {
         x = sat_add(now, x);
         if (x < m_expiration)

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <mswsock.h>
+#include <mstcpip.h>
 
 // Winsock's getsockname / getpeername / accept / recvfrom all take `int*` for
 // the address-length parameter, while POSIX uses `socklen_t*`.  MinGW

--- a/net/pooled_socket.cpp
+++ b/net/pooled_socket.cpp
@@ -15,30 +15,33 @@ limitations under the License.
 */
 
 #include "socket.h"
-
-#include <unordered_map>
-
+#include <netinet/tcp.h>
+#include <vector>
+#include <unordered_set>
 #include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/common/string_view.h>
 #include <photon/io/fd-events.h>
 #include <photon/thread/thread11.h>
 #include <photon/thread/timer.h>
 #include <photon/net/basic_socket.h>
-
+#include <photon/net/utils.h>
 #include "base_socket.h"
 
 namespace photon {
 namespace net {
 
 class TCPSocketPool;
+struct StreamListHead;
 
 class PooledTCPSocketStream : public ForwardSocketStream {
 public:
     TCPSocketPool* pool;
-    EndPoint ep;
-    bool drop;
+    StreamListHead* head;
+    bool drop = false;
 
-    PooledTCPSocketStream(ISocketStream* stream, TCPSocketPool* pool, const EndPoint& ep)
-            : ForwardSocketStream(stream, false), pool(pool), ep(ep), drop(false) {}
+    PooledTCPSocketStream(ISocketStream* stream, TCPSocketPool* pool, StreamListHead* head)
+            : ForwardSocketStream(stream, false), pool(pool), head(head) { }
     // release socket back to pool when dtor
     ~PooledTCPSocketStream() override;
     // forwarding all actions
@@ -102,166 +105,335 @@ public:
 };
 
 struct StreamListNode : public intrusive_list_node<StreamListNode> {
-    EndPoint key;
     std::unique_ptr<ISocketStream> stream;
-    int fd;
+    StreamListHead* head;
     Timeout timeout;
+    StreamListNode(ISocketStream* stream, StreamListHead* head, uint64_t TTL_us) :
+        stream(stream), head(head), timeout(TTL_us) { }
+};
 
-    StreamListNode(const EndPoint& key, ISocketStream* stream, int fd, uint64_t TTL_us)
-        : key(key), stream(stream), fd(fd), timeout(TTL_us) {
+struct StreamListHead : public StreamListNode {
+    // total # of sockets, including those in use, not including the head
+    uint32_t _refcnt = 0;
+    uint16_t _key_len;
+    char _key[0];
+
+    StreamListHead(std::string_view k) : StreamListNode(0, 0, 0) {
+        assert(k.size() < UINT16_MAX);
+        memcpy(_key, k.data(), k.size());
+        _key[_key_len = k.size()] = '\0';
+    }
+    std::string_view key() const { return {_key, _key_len}; }
+    static StreamListHead* create(std::string_view key) {
+        auto buf = malloc(sizeof(StreamListHead) + key.size() + 1);
+        return new (buf) StreamListHead(key);
+    }
+    void destroy() {
+        this->~StreamListHead();
+        free(this);
     }
 };
 
-class TCPSocketPool : public ForwardSocketClient {
-protected:
-    CascadingEventEngine* ev;
-    photon::thread* collector;
-    std::unordered_map<EndPoint, intrusive_list<StreamListNode>> fdmap;
-    uint64_t TTL_us;
-    photon::Timer timer;
+struct StreamList : intrusive_list<StreamListNode> {
+    StreamList(const StreamList&) = delete;
+    StreamList(StreamList&& rhs) {
+        node = rhs.node;
+        rhs.node = nullptr;
+    }
+    StreamList(std::string_view key)  {
+        auto head = StreamListHead::create(key);
+        push_back(head);
+    }
+    ~StreamList() {
+        auto h = head();
+        assert(h);
+        if (!h->single()) {
+            auto ptr = h->remove_from_list();
+            intrusive_list<StreamListNode> list(ptr);
+            h->_refcnt -= list.delete_all();
+        }
+        if (h->_refcnt)
+            LOG_ERROR("there are still ` living socket stream(s) outside the pool!", h->_refcnt);
+        h->destroy();
+        node = nullptr;
+    }
+    StreamListHead* head() const {
+        return (StreamListHead*)node;
+    }
+    void operator=(const StreamList&) = delete;
+    void operator=(StreamList&& rhs) {
+        if (this == &rhs) return;
+        if (node) delete_all();
+        node = rhs.node;
+        rhs.node = nullptr;
+    }
+};
+
+struct Hash {
+    size_t operator()(const StreamList& list) const {
+        return std::hash<std::string_view>()(list.head()->key());
+    }
+};
+
+struct Equal {
+    bool operator()(const StreamList& a, const StreamList& b) const {
+        return a.head()->key() == b.head()->key();
+    }
+    bool operator()(const StreamList& a, std::string_view b) const {
+        return a.head()->key() == b;
+    }
+};
+
+class TCPSocketPool : public ISocketPool {
+public:
+    SocketPoolArgs args;
+    std::unordered_set<StreamList, Hash, Equal> sockmap;
+    CascadingEventEngine* ev = new_default_cascading_engine();
+    join_handle* collector = thread_enable_join(
+        thread_create11(&TCPSocketPool::collect, this));
+
+    TCPSocketPool(const SocketPoolArgs& args) : args(args) { }
+
+    ~TCPSocketPool() override {
+        auto th = collector;
+        collector = nullptr;
+        thread_interrupt((thread*)th);
+        thread_join(th);
+        delete ev;
+        if (args.client_ownership)
+            delete args.sockclient;
+    }
+
+    __attribute__((noinline))
+    static void logerr_no_client() {
+        LOG_ERROR_RETURN(ENOSYS, , "a socket client must be provided when socket pool was constructed");
+    }
+    int setsockopt(int level, int option_name, const void* option_value, socklen_t option_len) override {
+        if (!args.sockclient) return logerr_no_client(), -1;
+        return args.sockclient->setsockopt(level, option_name, option_value, option_len);
+    }
+    int getsockopt(int level, int option_name, void* option_value, socklen_t* option_len) override {
+        if (!args.sockclient) return logerr_no_client(), -1;
+        return args.sockclient->getsockopt(level, option_name, option_value, option_len);
+    }
+    uint64_t timeout() const override {
+        if (!args.sockclient) return logerr_no_client(), -1;
+        return args.sockclient->timeout();
+    }
+    void timeout(uint64_t tm) override {
+        if (!args.sockclient) return logerr_no_client();
+        args.sockclient->timeout(tm);
+    }
+    Object* get_underlay_object(uint64_t recursion = 0) override {
+        return (recursion == 0) ? args.sockclient :
+                                  args.sockclient->get_underlay_object(recursion - 1);
+    }
 
     // all fd < 0 treated as socket not based on fd
     // and always reuseable. Using such socket needs user
     // to check if connected socket is still usable.
-    // if there still have unread bytes in strema, it should be closed.
+    // if there still have unread bytes in stream, it should be closed.
     bool stream_reusable(int fd) {
         return (fd < 0) || (wait_for_fd_readable(fd, 0) != 0);
     }
 
-    void add_watch(StreamListNode* node) {
-        if (node->fd >= 0) ev->add_interest({node->fd, EVENT_READ, node});
+    void add_watch(int fd, StreamListNode* node) {
+        if (fd >= 0) ev->add_interest({fd, EVENT_READ, node});
     }
 
-    void rm_watch(StreamListNode* node) {
-        if (node->fd >= 0) ev->rm_interest({node->fd, EVENT_READ, node});
-    }
-
-    ISocketStream* get_from_pool(const EndPoint& ep) {
-        auto it = fdmap.find(ep);
-        if (it == fdmap.end()) return nullptr;
-        assert(it != fdmap.end());
-        auto node = it->second.pop_front();
-        rm_watch(node);
-        DEFER(delete node);
-        if (it->second.empty()) fdmap.erase(it);
-        return node->stream.release();
-    }
-
-    void push_into_pool(StreamListNode* node) {
-        fdmap[node->key].push_back(node);
-        add_watch(node);
-    }
-
-    void drop_from_pool(StreamListNode* node) {
-        // or node have no record
-        auto it = fdmap.find(node->key);
-        auto& list = it->second;
-        list.erase(node);
-        if (list.empty()) fdmap.erase(it);
-        rm_watch(node);
-    }
-
-public:
-    TCPSocketPool(ISocketClient* client, uint64_t TTL_us,
-                  bool client_ownership = false)
-        : ForwardSocketClient(client, client_ownership),
-          ev(photon::new_default_cascading_engine()),
-          TTL_us(TTL_us),
-          timer(TTL_us, {this, &TCPSocketPool::evict}) {
-        collector = (photon::thread*)photon::thread_enable_join(
-            photon::thread_create11(&TCPSocketPool::collect, this));
-    }
-
-    ~TCPSocketPool() override {
-        timer.stop();
-        auto th = collector;
-        collector = nullptr;
-        photon::thread_interrupt((photon::thread*)th);
-        photon::thread_join((photon::join_handle*)th);
-        for (auto& l : fdmap) {
-            l.second.delete_all();
-        }
-        delete ev;
+    int rm_watch(StreamListNode* node) {
+        auto fd = node->stream->get_underlay_fd();
+        if (fd >= 0) ev->rm_interest({fd, EVENT_READ, node});
+        return fd;
     }
 
     ISocketStream* connect(const char* path, size_t count) override {
         LOG_ERROR_RETURN(ENOSYS, nullptr,
                          "Socket pool supports TCP-like socket only");
     }
-
     ISocketStream* connect(const EndPoint& remote,
                            const EndPoint* local) override {
-    again:
-        auto stream = get_from_pool(remote);
-        if (!stream) {
-            stream = m_underlay->connect(remote, local);
-            if (!stream) return nullptr;
-        } else if (!stream_reusable(stream->get_underlay_fd())) {
-            delete stream;
-            goto again;
-        }
-        return new PooledTCPSocketStream(stream, this, remote);
+        std::string_view key{(char*)&remote, sizeof(remote)};
+        return connect(key, remote, local);
     }
-    uint64_t evict() {
-        // remove empty entry in fdmap
+    ISocketStream* connect(std::string_view key, const EndPoint& remote, const EndPoint* local = nullptr) override {
+        return connect(key, [&]() -> ISocketStream* {
+            if (!args.sockclient) return logerr_no_client(), nullptr;
+            return args.sockclient->connect(remote, local);
+        });
+    }
+    ISocketStream* connect(std::string_view domain_name, uint16_t port, const EndPoint* local = nullptr) override {
+        return connect(domain_name, domain_name, port, local);
+    }
+    ISocketStream* connect(std::string_view key, std::string_view domain_name, uint16_t port, const EndPoint* local = nullptr) override {
+        return connect(key, [&]() -> ISocketStream* {
+            if (!args.sockclient) return logerr_no_client(), nullptr;
+            std::vector<IPAddr> addrs;
+            int ret = gethostbyname_nb(domain_name, addrs);
+            if (ret < 0 || addrs.empty())
+                LOG_ERRNO_RETURN(0, nullptr, "failed to resolve ", VALUE(domain_name));
+            EndPoint ep{addrs[rand() % addrs.size()], port};
+            return args.sockclient->connect(ep, local);
+        });
+    }
+    ISocketStream* connect(std::string_view key, TempDelegate<ISocketStream*> connector) override {
+        auto ret = sockmap.emplace(key);
+        auto head = ret.first->head();
+        ISocketStream* stream;
+        if (head->single()) {
+            stream = connector();
+            if (!stream)
+                return nullptr;
+            head->_refcnt++;
+            if (args.enable_tcp_keepalive)
+                set_keepalive(stream);
+        } else {
+            auto node = head->next();
+            node->remove_from_list();
+            rm_watch(node);
+            stream = node->stream.release();
+            delete node;
+        }
+        return new PooledTCPSocketStream(stream, this, head);
+    }
+
+    void set_keepalive(ISocketStream* stream) {
+        stream->setsockopt<int>(SOL_SOCKET, SO_KEEPALIVE, 1);
+#ifndef _WIN32
+#ifdef __APPLE__
+#define TCP_KEEPIDLE  TCP_KEEPALIVE
+#define SOL_TCP       IPPROTO_TCP
+#endif
+        stream->setsockopt<int>(SOL_TCP, TCP_KEEPIDLE, args.tcp_keepalive_time);
+        stream->setsockopt<int>(SOL_TCP, TCP_KEEPINTVL, args.tcp_keepalive_intvl);
+        stream->setsockopt<int>(SOL_TCP, TCP_KEEPCNT, args.tcp_keepalive_probes);
+#else
+        struct tcp_keepalive {
+            u_long onoff;
+            u_long keepalivetime;
+            u_long keepaliveinterval;
+        } keepalive_params;
+        keepalive_params.onoff = 1;
+        keepalive_params.keepalivetime = args.tcp_keepalive_time * 1000;
+        keepalive_params.keepaliveinterval = args.tcp_keepalive_intvl * 1000;
+        DWORD bytes_returned = 0;
+        SOCKET s = (SOCKET)(intptr_t)stream->get_underlay_fd();
+        WSAIoctl(s, SIO_KEEPALIVE_VALS,
+                    &keepalive_params, sizeof(keepalive_params),
+                    nullptr, 0, &bytes_returned, nullptr, nullptr);
+#endif
+    }
+
+    void release(StreamListHead* head, ISocketStream* stream) {
+        auto fd = stream->get_underlay_fd();
+        ERRNO err;
+        if (!stream_reusable(fd)) {
+            assert(head->_refcnt > 0);
+            head->_refcnt--;
+            delete stream;
+            return;
+        }
+        auto node = new StreamListNode(stream, head, args.expiration);
+        head->insert_before(node);
+        assert(head->prev() == node);
+        add_watch(fd, node);
+        errno = err.no;
+    }
+
+    Timeout check_expire_heartbeat() {
         intrusive_list<StreamListNode> freelist;
-        uint64_t near_expire = TTL_us + now;
-        for (auto it = fdmap.begin(); it != fdmap.end();) {
-            auto& list = it->second;
-            uint64_t exp;
-            while (!list.empty() && now >=
-                   (exp = list.front()->timeout.expiration())) {
-                freelist.push_back(list.pop_front());
+        auto pre_delete = [&](StreamListHead* head, StreamListNode* ptr) {
+            assert(head->_refcnt > 0);
+            head->_refcnt--;
+            auto next = ptr->remove_from_list();
+            freelist.push_back(ptr);
+            return next;
+        };
+        Timeout near_expire(args.expiration);
+        // uint64_t near_expire = sat_add(now, args.expiration), exp;
+        for (auto it = sockmap.begin(); it != sockmap.end();) {
+            assert(!it->empty());
+            auto head = it->head();
+            auto ptr = head->next();
+            while (ptr != head) {
+                if (now < ptr->timeout.expiration()) {
+                    near_expire = std::min(near_expire, ptr->timeout);
+                    break;
+                }
+                ptr = pre_delete(head, ptr);
             }
-            if (list.empty()) {
-                it = fdmap.erase(it);
-            } else {
-                near_expire = std::min(near_expire, exp);
-                it++;
+            if (args.heartbeater) {
+                while (ptr != head) {
+#ifdef _WIN32                                // a fd (handle) can not be added to multiple
+                    int fd = rm_watch(ptr);  // IOCPs, while epoll, iouring, kqueue can.
+#endif
+                    int ret = args.heartbeater(ptr->stream.get());
+                    if (ret == 0) {
+#ifdef _WIN32
+                        add_watch(fd, ptr);
+#endif
+                        ptr = ptr->next();
+                    } else {
+                        ptr = pre_delete(head, ptr);
+                    }
+                }
             }
+            if (head->_refcnt) ++it;
+            else it = sockmap.erase(it);
         }
         for (auto node : freelist) {
             rm_watch(node);
         }
         freelist.delete_all();
-        assert(near_expire > now);
-        return sat_sub(near_expire, now);
+        assert(near_expire.expiration() > now);
+        return near_expire;
     }
 
-    bool release(const EndPoint& ep, ISocketStream* stream) {
-        auto fd = stream->get_underlay_fd();
-        ERRNO err;
-        if (!stream_reusable(fd)) return false;
-        auto node = new StreamListNode(ep, stream, fd, TTL_us);
-        push_into_pool(node);
-        errno = err.no;
-        return true;
+    void check_fd_state(Timeout timeout) {
+    again:
+        StreamListNode* nodes[16];
+        auto ret = ev->wait_for_events((void**)nodes, 16, timeout);
+        for (int i = 0; i < ret; i++) {
+            // since destructed socket should never become readable before
+            // it have been acquired again
+            // if it is readable or RDHUP, both condition should treat as
+            // socket shutdown
+            assert(!nodes[i]->single());
+            assert(nodes[i] != nodes[i]->head);
+            assert(nodes[i]->head->_refcnt > 0);
+            nodes[i]->head->_refcnt--;
+            nodes[i]->remove_from_list();
+            rm_watch(nodes[i]);
+        }
+        for (int i = 0; i < ret; i++) delete nodes[i];
+        if (ret == (int)LEN(nodes)) goto again; // may have more
     }
 
     void collect() {
-        StreamListNode* nodes[16];
+        auto interval = std::min(args.heartbeat_interval,
+                                 args.expiration);
+        Timeout timeout(interval);
         while (collector) {
-            auto ret = ev->wait_for_events((void**)nodes, 16, -1ULL);
-            for (int i = 0; i < ret; i++) {
-                // since destructed socket should never become readable before
-                // it have been acquired again
-                // if it is readable or RDHUP, both condition should treat as
-                // socket shutdown
-                drop_from_pool(nodes[i]);
-            }
-            for (int i = 0; i < ret; i++) delete nodes[i];
+            check_fd_state(timeout);
+            auto next = check_expire_heartbeat();
+            timeout.timeout(interval);
+            if (timeout > next)
+                timeout = next;
         }
     }
 };
 
-PooledTCPSocketStream::~PooledTCPSocketStream() {
-    if (drop || !pool->release(ep, m_underlay)) {
+inline PooledTCPSocketStream::~PooledTCPSocketStream() {
+    if (drop) {
         delete m_underlay;
+        head->_refcnt--;
+    } else {
+        pool->release(head, m_underlay);
     }
 }
 
-extern "C" ISocketClient* new_tcp_socket_pool(ISocketClient* client, uint64_t TTL_us, bool client_ownership) {
-    return new TCPSocketPool(client, TTL_us, client_ownership);
+extern "C" ISocketPool* new_tcp_socket_pool(const SocketPoolArgs& args) {
+    return new TCPSocketPool(args);
 }
 
 }

--- a/net/socket.h
+++ b/net/socket.h
@@ -272,6 +272,21 @@ namespace net {
         virtual void timeout(uint64_t) = 0;
     };
 
+    class ISocketPool : public ISocketClient {
+    public:
+        using ISocketClient::connect;
+
+        // connect to a domain_name:port, which may resolve to multiple IP addresses
+        virtual ISocketStream* connect(std::string_view domain_name, uint16_t port, const EndPoint* local = nullptr) = 0;
+
+        // grouped by `key` --- connections are considered equal iff with the same key
+        virtual ISocketStream* connect(std::string_view key, const EndPoint& remote, const EndPoint* local = nullptr) = 0;
+        virtual ISocketStream* connect(std::string_view key, std::string_view domain_name, uint16_t port, const EndPoint* local = nullptr) = 0;
+
+        // allow user-defined connector, which will be used to establish new connections
+        virtual ISocketStream* connect(std::string_view key, TempDelegate<ISocketStream*> connector) = 0;
+    };
+
     class ISocketServer : public ISocketBase, public ISocketName, public Object {
     public:
         virtual int bind(const EndPoint& ep) = 0;
@@ -301,8 +316,42 @@ namespace net {
     extern "C" ISocketServer* new_tcp_socket_server();
     extern "C" ISocketClient* new_uds_client();
     extern "C" ISocketServer* new_uds_server(bool autoremove = false);
-    extern "C" ISocketClient* new_tcp_socket_pool(ISocketClient* client, uint64_t expiration = -1ULL,
-                                                  bool client_ownership = false);
+
+    struct SocketPoolArgs {
+        // if not provided, user-defined connector must
+        // be used to establish new connections
+        ISocketClient* sockclient = nullptr;
+        bool client_ownership = false;
+
+        bool enable_tcp_keepalive = false;
+        // idle seconds before the first keepalive probe (TCP_KEEPIDLE)
+        uint16_t tcp_keepalive_time = 2;
+        // seconds between keepalive probes (TCP_KEEPINTVL)
+        uint16_t tcp_keepalive_intvl = 2;
+        // max # of TCP keep-alive probes before killing the connection
+        uint16_t tcp_keepalive_probes = 15;
+
+        // if heartbeater is provided, it is called with each in-stock socket
+        // stream every `heartbeat_interval` us to send heartbeats, and
+        // return value of 0 for success, -1 for failure
+        Callback<ISocketStream*> heartbeater = { };
+        uint64_t heartbeat_interval = 10'000'000;
+
+        // in-stock socket streams are deleted after `expiration` us
+        uint64_t expiration = -1ULL;
+    };
+
+    extern "C" ISocketPool* new_tcp_socket_pool(const SocketPoolArgs& args);
+
+    // `client` can be nullptr, in this case user-defined connector must be used to establish new connections
+    inline ISocketPool* new_tcp_socket_pool(ISocketClient* sockclient,
+            uint64_t expiration = -1ULL, bool client_ownership = false) {
+        return new_tcp_socket_pool({
+            .sockclient = sockclient,
+            .client_ownership = client_ownership,
+            .expiration = expiration,
+        });
+    }
 
     extern "C" ISocketClient* new_zerocopy_tcp_client();
     extern "C" ISocketServer* new_zerocopy_tcp_server();

--- a/net/test/test_sockpool.cpp
+++ b/net/test/test_sockpool.cpp
@@ -4,7 +4,28 @@
 #include <photon/photon.h>
 #include <photon/thread/thread.h>
 #include <photon/thread/thread11.h>
+#ifndef _WIN32
+#include <sys/socket.h>
+#include <netinet/tcp.h>
+#ifdef __APPLE__
+#define TCP_KEEPIDLE  TCP_KEEPALIVE
+#define SOL_TCP       IPPROTO_TCP
+#endif
+#endif
+#include <string_view>
 #include "../../test/gtest.h"
+
+template<typename Pred>
+static bool poll_until(Pred pred, uint64_t timeout_us, uint64_t interval_us = 100'000) {
+    uint64_t waited = 0;
+    while (waited < timeout_us) {
+        if (pred()) return true;
+        auto sleep = std::min(interval_us, timeout_us - waited);
+        photon::thread_usleep(sleep);
+        waited += sleep;
+    }
+    return pred();
+}
 
 void task(photon::net::ISocketClient* client, photon::net::EndPoint ep) {
     photon::net::ISocketStream* st = nullptr;
@@ -109,10 +130,8 @@ TEST(Socket, pooled_multisock_serverclose) {
     DEFER(delete client);
     auto ep = server->getsockname();
     std::vector<photon::join_handle*> jhs;
-    for (int i = 0; i < 1; i++) {
-        jhs.emplace_back(photon::thread_enable_join(
-            photon::thread_create11(task, client, ep)));
-    }
+    jhs.emplace_back(photon::thread_enable_join(
+        photon::thread_create11(task, client, ep)));
     for (auto j : jhs) {
         photon::thread_join(j);
     }
@@ -162,10 +181,13 @@ TEST(Socket, pooled_expiration) {
     };
     server->set_handler(handler);
     server->start_loop();
-    DEFER(delete server);
+    DEFER({
+        delete server;  // dtor doesn't guarantee completion of connections and their serving threads
+        poll_until([&] { return conncount == 0; }, 10'000'000);
+    });
     auto client = photon::net::new_tcp_socket_pool(
         photon::net::new_tcp_socket_client(),
-        1ULL * 1000 * 1000, true);  // release every 1 sec
+        2ULL * 1000 * 1000, true);  // release every 2 sec
     DEFER(delete client);
     auto ep = server->getsockname();
     std::vector<photon::join_handle*> jhs;
@@ -177,8 +199,954 @@ TEST(Socket, pooled_expiration) {
         photon::thread_join(j);
     }
     EXPECT_EQ(4, conncount);
-    photon::thread_usleep(2100 * 1000);
+    poll_until([&] { return conncount < 4; }, 10'000'000);
     EXPECT_LT(conncount, 4);
+}
+
+static void roundtrip(photon::net::ISocketStream* st) {
+    ASSERT_NE(st, nullptr);
+    EXPECT_EQ(4, st->write("TEST", 4));
+    EXPECT_TRUE(st->skip_read(4));
+}
+
+TEST(Socket, pooled_key_connect) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    auto ep = server->getsockname();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+
+    for (int i = 0; i < 5; i++) {
+        auto* st = sp->connect(std::string_view("K"), ep);
+        roundtrip(st);
+        delete st;
+    }
+    EXPECT_EQ(1, conncount);
+
+    for (int i = 0; i < 3; i++) {
+        auto* st = sp->connect(std::string_view("K2"), ep);
+        roundtrip(st);
+        delete st;
+    }
+    EXPECT_EQ(2, conncount);
+}
+
+TEST(Socket, pooled_key_isolation) {
+    auto server1 = photon::net::new_tcp_socket_server();
+    server1->bind_v4localhost();
+    server1->listen();
+    DEFER(delete server1);
+
+    auto server2 = photon::net::new_tcp_socket_server();
+    server2->bind_v4localhost();
+    server2->listen();
+    DEFER(delete server2);
+
+    int cnt1 = 0, cnt2 = 0;
+    auto handler1 = [&](photon::net::ISocketStream* s) -> int {
+        cnt1++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("AAA", 4);
+        return 0;
+    };
+    auto handler2 = [&](photon::net::ISocketStream* s) -> int {
+        cnt2++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("BBB", 4);
+        return 0;
+    };
+    server1->set_handler(handler1);
+    server2->set_handler(handler2);
+    server1->start_loop();
+    server2->start_loop();
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+
+    auto ep1 = server1->getsockname();
+    auto ep2 = server2->getsockname();
+
+    auto* s1 = sp->connect(std::string_view("A"), ep1);
+    ASSERT_NE(s1, nullptr);
+    EXPECT_EQ(4, s1->write("TEST", 4));
+    char buf[4] = {};
+    EXPECT_EQ(4, s1->read(buf, 4));
+    EXPECT_STREQ("AAA", buf);
+    delete s1;
+
+    auto* s2 = sp->connect(std::string_view("A"), ep1);
+    roundtrip(s2);
+    delete s2;
+    EXPECT_EQ(1, cnt1);
+
+    auto* s3 = sp->connect(std::string_view("B"), ep1);
+    roundtrip(s3);
+    delete s3;
+    EXPECT_EQ(2, cnt1);
+
+    auto* s4 = sp->connect(std::string_view("A"), ep2);
+    ASSERT_NE(s4, nullptr);
+    EXPECT_EQ(4, s4->write("TEST", 4));
+    memset(buf, 0, sizeof(buf));
+    EXPECT_EQ(4, s4->read(buf, 4));
+    EXPECT_STREQ("AAA", buf);
+    delete s4;
+    EXPECT_EQ(2, cnt1);
+    EXPECT_EQ(0, cnt2);
+}
+
+TEST(Socket, pooled_domain_port) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+    auto ep = server->getsockname();
+
+    for (int i = 0; i < 3; i++) {
+        auto* st = sp->connect(std::string_view("127.0.0.1"), ep.port);
+        roundtrip(st);
+        delete st;
+    }
+    EXPECT_EQ(1, conncount);
+}
+
+TEST(Socket, pooled_key_connector) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    auto pool = photon::net::new_tcp_socket_pool(raw_client, -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+    auto ep = server->getsockname();
+
+    int connector_calls = 0;
+    auto connector = [&]() -> photon::net::ISocketStream* {
+        connector_calls++;
+        return raw_client->connect(ep);
+    };
+
+    auto* s1 = sp->connect(std::string_view("C"), connector);
+    roundtrip(s1);
+    delete s1;
+    EXPECT_EQ(1, connector_calls);
+    EXPECT_EQ(1, conncount);
+
+    auto* s2 = sp->connect(std::string_view("C"), connector);
+    roundtrip(s2);
+    delete s2;
+    EXPECT_EQ(1, connector_calls);
+    EXPECT_EQ(1, conncount);
+
+    auto* s3 = sp->connect(std::string_view("D"), connector);
+    roundtrip(s3);
+    delete s3;
+    EXPECT_EQ(2, connector_calls);
+    EXPECT_EQ(2, conncount);
+}
+
+TEST(Socket, pooled_connector_failure_refcnt) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    auto pool = photon::net::new_tcp_socket_pool(raw_client, -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+    auto ep = server->getsockname();
+
+    int connector_calls = 0;
+    auto connector = [&]() -> photon::net::ISocketStream* {
+        connector_calls++;
+        return raw_client->connect(ep);
+    };
+
+    auto* s1 = sp->connect(std::string_view("E"), connector);
+    roundtrip(s1);
+    s1->shutdown(ShutdownHow::ReadWrite);
+    delete s1;
+    EXPECT_EQ(1, connector_calls);
+    EXPECT_EQ(1, conncount);
+
+    int fail_count = 0;
+    auto fail_connector = [&]() -> photon::net::ISocketStream* {
+        fail_count++;
+        return nullptr;
+    };
+    auto* s2 = sp->connect(std::string_view("E"), fail_connector);
+    EXPECT_EQ(s2, nullptr);
+    EXPECT_EQ(1, fail_count);
+
+    auto* s3 = sp->connect(std::string_view("E"), connector);
+    roundtrip(s3);
+    s3->shutdown(ShutdownHow::ReadWrite);
+    delete s3;
+    EXPECT_EQ(2, connector_calls);
+    EXPECT_EQ(2, conncount);
+
+    for (int i = 0; i < 3; i++) {
+        auto* s = sp->connect(std::string_view("E"), fail_connector);
+        EXPECT_EQ(s, nullptr);
+    }
+    EXPECT_EQ(4, fail_count);
+
+    auto* s4 = sp->connect(std::string_view("E"), connector);
+    roundtrip(s4);
+    delete s4;
+    EXPECT_EQ(3, connector_calls);
+    EXPECT_EQ(3, conncount);
+}
+
+TEST(Socket, pooled_shutdown_close_drop) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+    auto ep = server->getsockname();
+
+    auto* st = sp->connect(std::string_view("S"), ep);
+    roundtrip(st);
+    delete st;
+    EXPECT_EQ(1, conncount);
+
+    {
+        auto* s = sp->connect(std::string_view("S"), ep);
+        roundtrip(s);
+        s->shutdown(ShutdownHow::ReadWrite);
+        delete s;
+    }
+    photon::thread_usleep(1000 * 1000);
+
+    {
+        auto* s = sp->connect(std::string_view("S"), ep);
+        roundtrip(s);
+        s->close();
+        delete s;
+    }
+    photon::thread_usleep(1000 * 1000);
+
+    auto* s2 = sp->connect(std::string_view("S"), ep);
+    roundtrip(s2);
+    delete s2;
+    EXPECT_GE(conncount, 2);
+}
+
+TEST(Socket, pooled_concurrent_keys) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+    auto ep = server->getsockname();
+
+    auto worker = [&](const char* key) {
+        for (int i = 0; i < 50; i++) {
+            auto* st = sp->connect(std::string_view(key), ep);
+            ASSERT_NE(st, nullptr);
+            EXPECT_EQ(4, st->write("TEST", 4));
+            EXPECT_TRUE(st->skip_read(4));
+            delete st;
+            photon::thread_yield();
+        }
+    };
+
+    std::vector<photon::join_handle*> jhs;
+    for (int i = 0; i < 3; i++) {
+        jhs.emplace_back(photon::thread_enable_join(
+            photon::thread_create11(worker, (const char*)"X")));
+    }
+    for (int i = 0; i < 3; i++) {
+        jhs.emplace_back(photon::thread_enable_join(
+            photon::thread_create11(worker, (const char*)"Y")));
+    }
+    for (auto* j : jhs) photon::thread_join(j);
+
+    EXPECT_EQ(6, conncount);
+}
+
+TEST(Socket, pooled_server_close_reuse) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        if (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto sp = pool;
+    auto ep = server->getsockname();
+
+    for (int i = 0; i < 5; i++) {
+        auto* st = sp->connect(std::string_view("R"), ep);
+        roundtrip(st);
+        delete st;
+        photon::thread_usleep(1000 * 1000);
+    }
+    EXPECT_EQ(5, conncount);
+}
+
+TEST(Socket, pooled_multiple_pools) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    int conn_alive = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        conn_alive++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        conn_alive--;
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER({
+        delete server;  // dtor doesn't guarantee completion of connections and their serving threads
+        poll_until([&] { return conncount == 0; }, 10'000'000);
+    });
+    auto ep = server->getsockname();
+
+    auto pool1 = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), 1000 * 1000, true);
+    DEFER(delete pool1);
+    auto pool2 = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool2);
+
+    auto* s1 = pool1->connect(ep);
+    roundtrip(s1);
+    delete s1;
+
+    auto* s2 = pool2->connect(ep);
+    roundtrip(s2);
+    delete s2;
+
+    EXPECT_EQ(2, conncount);
+
+    poll_until([&] { return conn_alive < 2; }, 10'000'000);
+
+    auto* s3 = pool1->connect(ep);
+    roundtrip(s3);
+    delete s3;
+    EXPECT_EQ(3, conncount);
+
+    auto* s4 = pool2->connect(ep);
+    roundtrip(s4);
+    delete s4;
+    EXPECT_EQ(3, conncount);
+}
+
+TEST(Socket, pooled_read_eof_drop) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        s->write("EOF!", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+    auto ep = server->getsockname();
+
+    {
+        auto* st = sp->connect(std::string_view("EOF"), ep);
+        ASSERT_NE(st, nullptr);
+        char buf[4];
+        EXPECT_EQ(4, st->read(buf, 4));
+        ssize_t ret = st->read(buf, 1);
+        EXPECT_EQ(0, ret);
+        delete st;
+    }
+    photon::thread_usleep(1000 * 1000);
+
+    {
+        auto* st = sp->connect(std::string_view("EOF"), ep);
+        ASSERT_NE(st, nullptr);
+        char buf[4];
+        EXPECT_EQ(4, st->read(buf, 4));
+        delete st;
+    }
+    EXPECT_EQ(2, conncount);
+}
+
+TEST(Socket, pooled_dead_idle_recovery) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        if (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+    auto ep = server->getsockname();
+
+    for (int i = 0; i < 5; i++) {
+        auto* st = sp->connect(std::string_view("D"), ep);
+        roundtrip(st);
+        delete st;
+        photon::thread_usleep(1000 * 1000);
+    }
+    EXPECT_EQ(5, conncount);
+}
+
+TEST(Socket, pooled_key_domain_port) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+    auto ep = server->getsockname();
+
+    for (int i = 0; i < 3; i++) {
+        auto* st = sp->connect(std::string_view("my-key"),
+                               std::string_view("127.0.0.1"), ep.port);
+        roundtrip(st);
+        delete st;
+    }
+    EXPECT_EQ(1, conncount);
+
+    for (int i = 0; i < 2; i++) {
+        auto* st = sp->connect(std::string_view("other-key"),
+                               std::string_view("127.0.0.1"), ep.port);
+        roundtrip(st);
+        delete st;
+    }
+    EXPECT_EQ(2, conncount);
+}
+
+TEST(Socket, pooled_heartbeater_success) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    int conn_alive = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        conn_alive++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        conn_alive--;
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+    auto ep = server->getsockname();
+
+    int hb_count = 0;
+    auto heartbeater = [&](photon::net::ISocketStream*) -> int {
+        hb_count++;
+        return 0;
+    };
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    photon::net::SocketPoolArgs args;
+    args.sockclient = raw_client;
+    args.client_ownership = true;
+    args.heartbeater = heartbeater;
+    args.heartbeat_interval = 300'000;
+    args.expiration = -1ULL;
+    auto pool = photon::net::new_tcp_socket_pool(args);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+
+    auto* s1 = sp->connect(std::string_view("HB"), ep);
+    roundtrip(s1);
+    delete s1;
+
+    poll_until([&] { return hb_count > 0; }, 10'000'000);
+    EXPECT_GT(hb_count, 0);
+
+    auto* s2 = sp->connect(std::string_view("HB"), ep);
+    roundtrip(s2);
+    delete s2;
+
+    auto* s3 = sp->connect(std::string_view("HB"), ep);
+    roundtrip(s3);
+    delete s3;
+
+    EXPECT_EQ(1, conncount);
+
+    delete pool;
+    pool = nullptr;
+    poll_until([&] { return conn_alive == 0; }, 5'000'000);
+    EXPECT_EQ(0, conn_alive);
+}
+
+TEST(Socket, pooled_heartbeater_failure) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    int conn_alive = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        conn_alive++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        conn_alive--;
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+    auto ep = server->getsockname();
+
+    auto heartbeater = [&](photon::net::ISocketStream*) -> int {
+        return -1;
+    };
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    photon::net::SocketPoolArgs args;
+    args.sockclient = raw_client;
+    args.client_ownership = true;
+    args.heartbeater = heartbeater;
+    args.heartbeat_interval = 300'000;
+    args.expiration = -1ULL;
+    auto pool = photon::net::new_tcp_socket_pool(args);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+
+    auto* s1 = sp->connect(std::string_view("HBF"), ep);
+    roundtrip(s1);
+    delete s1;
+    EXPECT_EQ(1, conncount);
+
+    poll_until([&] { return conn_alive == 0; }, 10'000'000);
+    EXPECT_EQ(0, conn_alive);
+
+    auto* s2 = sp->connect(std::string_view("HBF"), ep);
+    roundtrip(s2);
+    delete s2;
+    EXPECT_EQ(2, conncount);
+
+    poll_until([&] { return conn_alive == 0; }, 10'000'000);
+    EXPECT_EQ(0, conn_alive);
+
+    auto* s3 = sp->connect(std::string_view("HBF"), ep);
+    roundtrip(s3);
+    delete s3;
+    EXPECT_EQ(3, conncount);
+
+    poll_until([&] { return conn_alive == 0; }, 10'000'000);
+    EXPECT_EQ(0, conn_alive);
+}
+
+TEST(Socket, pooled_heartbeater_multiple_keys) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    int conn_alive = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        conn_alive++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        conn_alive--;
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+    auto ep = server->getsockname();
+
+    int hb_count = 0;
+    auto heartbeater = [&](photon::net::ISocketStream*) -> int {
+        hb_count++;
+        return 0;
+    };
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    photon::net::SocketPoolArgs args;
+    args.sockclient = raw_client;
+    args.client_ownership = true;
+    args.heartbeater = heartbeater;
+    args.heartbeat_interval = 300'000;
+    args.expiration = -1ULL;
+    auto pool = photon::net::new_tcp_socket_pool(args);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+
+    auto* s1 = sp->connect(std::string_view("HK1"), ep);
+    roundtrip(s1);
+    delete s1;
+
+    auto* s2 = sp->connect(std::string_view("HK2"), ep);
+    roundtrip(s2);
+    delete s2;
+
+    poll_until([&] { return hb_count >= 2; }, 10'000'000);
+    EXPECT_GE(hb_count, 2);
+
+    auto* s3 = sp->connect(std::string_view("HK1"), ep);
+    roundtrip(s3);
+    delete s3;
+
+    auto* s4 = sp->connect(std::string_view("HK2"), ep);
+    roundtrip(s4);
+    delete s4;
+
+    poll_until([&] { return conncount == 2; }, 5'000'000);
+    EXPECT_EQ(2, conncount);
+
+    delete pool;
+    pool = nullptr;
+    poll_until([&] { return conn_alive == 0; }, 5'000'000);
+    EXPECT_EQ(0, conn_alive);
+}
+
+TEST(Socket, pooled_heartbeater_io) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    int conn_alive = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        conn_alive++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("PONG", 4);
+        conn_alive--;
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+    auto ep = server->getsockname();
+
+    int hb_count = 0;
+    auto heartbeater = [&](photon::net::ISocketStream* s) -> int {
+        if (s->write("PING", 4) != 4) return -1;
+        char buf[4];
+        if (s->read(buf, 4) != 4) return -1;
+        if (memcmp(buf, "PONG", 4) != 0) return -1;
+        hb_count++;
+        return 0;
+    };
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    photon::net::SocketPoolArgs args;
+    args.sockclient = raw_client;
+    args.client_ownership = true;
+    args.heartbeater = heartbeater;
+    args.heartbeat_interval = 300'000;
+    args.expiration = -1ULL;
+    auto pool = photon::net::new_tcp_socket_pool(args);
+    DEFER(delete pool);
+    auto* sp = static_cast<photon::net::ISocketPool*>(pool);
+
+    auto* s1 = sp->connect(std::string_view("HBIO"), ep);
+    ASSERT_NE(s1, nullptr);
+    EXPECT_EQ(4, s1->write("PING", 4));
+    char buf[4];
+    EXPECT_EQ(4, s1->read(buf, 4));
+    EXPECT_EQ(0, memcmp(buf, "PONG", 4));
+    delete s1;
+
+    poll_until([&] { return hb_count > 0; }, 10'000'000);
+    EXPECT_GT(hb_count, 0);
+
+    auto* s2 = sp->connect(std::string_view("HBIO"), ep);
+    ASSERT_NE(s2, nullptr);
+    EXPECT_EQ(4, s2->write("PING", 4));
+    EXPECT_EQ(4, s2->read(buf, 4));
+    EXPECT_EQ(0, memcmp(buf, "PONG", 4));
+    delete s2;
+
+    poll_until([&] { return conncount == 1; }, 5'000'000);
+    EXPECT_EQ(1, conncount);
+
+    delete pool;
+    pool = nullptr;
+    poll_until([&] { return conn_alive == 0; }, 5'000'000);
+    EXPECT_EQ(0, conn_alive);
+}
+
+TEST(Socket, pooled_args_ownership) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    int conncount = 0;
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        conncount++;
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+    auto ep = server->getsockname();
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    photon::net::SocketPoolArgs args;
+    args.sockclient = raw_client;
+    args.client_ownership = true;
+    auto pool = photon::net::new_tcp_socket_pool(args);
+    DEFER(delete pool);
+
+    auto* s = pool->connect(ep);
+    roundtrip(s);
+    delete s;
+    EXPECT_EQ(1, conncount);
+
+    auto* s2 = pool->connect(ep);
+    roundtrip(s2);
+    delete s2;
+    EXPECT_EQ(1, conncount);
+}
+
+#ifndef _WIN32
+static void verify_keepalive_params(photon::net::ISocketStream* st,
+                                     int time_s, int intvl_s, int probes) {
+    int idle = -1;
+    EXPECT_EQ(0, st->getsockopt<int>(SOL_TCP, TCP_KEEPIDLE, &idle));
+    EXPECT_EQ(time_s, idle);
+
+    int intvl = -1;
+    EXPECT_EQ(0, st->getsockopt<int>(SOL_TCP, TCP_KEEPINTVL, &intvl));
+    EXPECT_EQ(intvl_s, intvl);
+
+    int cnt = -1;
+    EXPECT_EQ(0, st->getsockopt<int>(SOL_TCP, TCP_KEEPCNT, &cnt));
+    EXPECT_EQ(probes, cnt);
+}
+#else
+#ifndef SIO_KEEPALIVE_VALS
+#define SIO_KEEPALIVE_VALS _WSAIOW(IOC_VENDOR, 4)
+#endif
+struct tcp_keepalive_test {
+    u_long onoff;
+    u_long keepalivetime;
+    u_long keepaliveinterval;
+};
+
+static void verify_keepalive_params(photon::net::ISocketStream* st,
+                                     int time_s, int intvl_s, int) {
+    SOCKET s = (SOCKET)(intptr_t)st->get_underlay_fd();
+    tcp_keepalive_test params = {};
+    DWORD bytes_returned = 0;
+    int ret = WSAIoctl(s, SIO_KEEPALIVE_VALS,
+                       nullptr, 0,
+                       &params, sizeof(params),
+                       &bytes_returned, nullptr, nullptr);
+    EXPECT_EQ(0, ret);
+    EXPECT_EQ(1u, params.onoff);
+    EXPECT_EQ((u_long)(time_s * 1000), params.keepalivetime);
+    EXPECT_EQ((u_long)(intvl_s * 1000), params.keepaliveinterval);
+}
+#endif
+
+TEST(Socket, pooled_keepalive_default) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+    auto ep = server->getsockname();
+
+    auto pool = photon::net::new_tcp_socket_pool(
+        photon::net::new_tcp_socket_client(), -1, true);
+    DEFER(delete pool);
+
+    auto* st = pool->connect(ep);
+    ASSERT_NE(st, nullptr);
+    int keepalive = -1;
+    EXPECT_EQ(0, st->getsockopt<int>(SOL_SOCKET, SO_KEEPALIVE, &keepalive));
+    EXPECT_EQ(0, keepalive);
+    delete st;
+}
+
+TEST(Socket, pooled_keepalive_enabled) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+    auto ep = server->getsockname();
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    photon::net::SocketPoolArgs args;
+    args.sockclient = raw_client;
+    args.client_ownership = true;
+    args.enable_tcp_keepalive = true;
+    auto pool = photon::net::new_tcp_socket_pool(args);
+    DEFER(delete pool);
+
+    auto* st = pool->connect(ep);
+    ASSERT_NE(st, nullptr);
+
+    int keepalive = -1;
+    EXPECT_EQ(0, st->getsockopt<int>(SOL_SOCKET, SO_KEEPALIVE, &keepalive));
+    EXPECT_NE(0, keepalive);
+
+    verify_keepalive_params(st, 2, 2, 15);
+    delete st;
+}
+
+TEST(Socket, pooled_keepalive_custom_values) {
+    auto server = photon::net::new_tcp_socket_server();
+    server->bind_v4localhost();
+    server->listen();
+    auto handler = [&](photon::net::ISocketStream* s) -> int {
+        char buf[4];
+        while (s->read(buf, 4) > 0) s->write("TEST", 4);
+        return 0;
+    };
+    server->set_handler(handler);
+    server->start_loop();
+    DEFER(delete server);
+    auto ep = server->getsockname();
+
+    auto raw_client = photon::net::new_tcp_socket_client();
+    photon::net::SocketPoolArgs args;
+    args.sockclient = raw_client;
+    args.client_ownership = true;
+    args.enable_tcp_keepalive = true;
+    args.tcp_keepalive_time = 30;
+    args.tcp_keepalive_intvl = 10;
+    args.tcp_keepalive_probes = 5;
+    auto pool = photon::net::new_tcp_socket_pool(args);
+    DEFER(delete pool);
+
+    auto* st = pool->connect(ep);
+    ASSERT_NE(st, nullptr);
+
+    verify_keepalive_params(st, 30, 10, 5);
+    delete st;
 }
 
 int main(int argc, char** arg) {
@@ -187,5 +1155,7 @@ int main(int argc, char** arg) {
 
     ::testing::InitGoogleTest(&argc, arg);
 
-    return RUN_ALL_TESTS();
+    auto ret = RUN_ALL_TESTS();
+    photon::thread_usleep(100 * 1000);
+    return ret;
 }


### PR DESCRIPTION
    refactor socket pool

    1. define a new interface ```ISocketPool``` that supports connection grouping by user-defined keys, in addition to Endpoints

    2. allow for user-defined callback for connection heartbeat, as construction argument

    3. support TCP-Keepalive

    4. re-design the implementation to support these new features

    5. optimization of the data structure to eliminate redundant stores of keys (Endpoints), as well as fds

    6. merge the timer and the collector thread

    The keys (Endpoints) were stored 3 times in: unordered_map (fdmap), StreamListNode, and PooledTCPSocketStream. Now they are stored once in StreamListHead, located at the end of StreamListHead to support variable length. And the unordered_map is changed to unordered_set.

    The maintainance routines, e.g. evict(), release(), collect(), etc., are changed accordingly.