### PR TITLE
Fix UB: Remove flexible array member from Operation class

### DIFF
--- a/net/http/client.h
+++ b/net/http/client.h
@@ -130,16 +130,33 @@ public:
         const void *body_buffer = nullptr;
         size_t body_buffer_size = 0;
 
-        char _buf[0];
+        // Avoid UB: use pointer instead of flexible array member
+        char* _buf = nullptr;
+
+        // Internal constructors accepting external buffer pointer
+        Operation(Client* c, Verb v, std::string_view url, uint16_t buf_size, char* buf)
+            : req(buf, buf_size, v, url, c->has_proxy()),
+              enable_proxy(c->has_proxy()),
+              _client(c),
+              _buf(buf) {}
+        Operation(Client* c, uint16_t buf_size, char* buf)
+            : req(buf, buf_size),
+              enable_proxy(c->has_proxy()),
+              _client(c),
+              _buf(buf) {}
+        explicit Operation(uint16_t buf_size, char* buf)
+            : req(buf, buf_size), _client(nullptr),
+              _buf(buf) {}
+
+        // Heap-allocated constructors (used by create())
+        // Buffer is allocated immediately after the object
         Operation(Client* c, Verb v, std::string_view url, uint16_t buf_size)
-            : req(_buf, buf_size, v, url, c->has_proxy()),
-              enable_proxy(c->has_proxy()),
-              _client(c) {}
+            : Operation(c, v, url, buf_size, reinterpret_cast<char*>(this + 1)) {}
         Operation(Client* c, uint16_t buf_size)
-            : req(_buf, buf_size),
-              enable_proxy(c->has_proxy()),
-              _client(c) {}
-        explicit Operation(uint16_t buf_size) : req(_buf, buf_size), _client(nullptr) {}
+            : Operation(c, buf_size, reinterpret_cast<char*>(this + 1)) {}
+        explicit Operation(uint16_t buf_size)
+            : Operation(buf_size, reinterpret_cast<char*>(this + 1)) {}
+
         Operation() = delete;
         ~Operation() = default;
 
@@ -151,9 +168,11 @@ public:
         char _buf[BufferSize];
     public:
         OperationOnStack(Client* c, Verb v, std::string_view url):
-            Operation(c, v, url, BufferSize) {}
-        explicit OperationOnStack(Client* c): Operation(c, BufferSize) {};
-        OperationOnStack(): Operation(BufferSize) {}
+            Operation(c, v, url, BufferSize, _buf) {}
+        explicit OperationOnStack(Client* c):
+            Operation(c, BufferSize, _buf) {}
+        OperationOnStack():
+            Operation(BufferSize, _buf) {}
     };
 
     virtual int call(Operation* /*IN, OUT*/ op) = 0;

--- a/net/http/test/client_function_test.cpp
+++ b/net/http/test/client_function_test.cpp
@@ -1272,6 +1272,41 @@ TEST(http_server, forward_proxy_close_delimited) {
     EXPECT_EQ(g_close_delim_payload, out);
 }
 
+// Regression test: flexible array member caused UB where Clang -O2
+// optimized away the constructor, leaving proxy_url uninitialized.
+// This led to SEGV in destructor when freeing uninitialized pointer.
+TEST(http_client, operation_stack_init) {
+    auto client = new_http_client();
+    DEFER(delete client);
+
+    // Create OperationOnStack and verify members are initialized
+    {
+        Client::OperationOnStack<> op(client, Verb::GET, "http://localhost/test");
+        // proxy_url should be default-constructed with m_url = nullptr
+        // If uninitialized, m_url contains garbage -> SEGV on empty() or destruction
+        auto* proxy = op.get_proxy();
+        ASSERT_TRUE(proxy != nullptr);
+        EXPECT_TRUE(proxy->empty()) << "proxy_url.m_url not initialized to nullptr";
+    }
+    // Key test: destructor runs here. With UB, free(garbage) causes SEGV.
+
+    // Test with larger buffer size
+    {
+        Client::OperationOnStack<4096> op(client, Verb::POST, "http://localhost/large");
+        auto* proxy = op.get_proxy();
+        ASSERT_TRUE(proxy != nullptr);
+        EXPECT_TRUE(proxy->empty()) << "proxy_url.m_url not initialized to nullptr";
+    }
+
+    // Test default constructor (no client)
+    {
+        Client::OperationOnStack<> op;
+        auto* proxy = op.get_proxy();
+        ASSERT_TRUE(proxy != nullptr);
+        EXPECT_TRUE(proxy->empty()) << "proxy_url.m_url not initialized to nullptr";
+    }
+}
+
 int main(int argc, char** arg) {
     if (photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE))
         return -1;


### PR DESCRIPTION
Replace char _buf[0] (flexible array member, UB in C++) with explicit buffer pointer management to avoid undefined behavior.

## Problem with Clang

When compiled with Clang under -O2 optimization, the flexible array member causes the compiler to optimize away the default constructor of Operation. This leads to uninitialized members (e.g., StoredURL proxy_url), causing SEGV crashes when the destructor attempts to free uninitialized pointers.

Example crash:
  ==ERROR: AddressSanitizer: SEGV on unknown address
  #0 URL::~URL() at url.h:58:9
  #1 StoredURL::~StoredURL() at url.h:113:5
  #2 Operation::~Operation() at client.h:142:30

The issue occurs because:
1. Flexible array member (char _buf[0]) is not standard C++
2. Clang treats the class as having trivial initialization
3. Under -O2, the constructor call is optimized away
4. Stack-allocated OperationOnStack objects have uninitialized members

## Changes

- Replace char _buf[0] with char* _buf pointing to external buffer
- Add internal constructors accepting buffer pointer parameter
- Heap-allocated Operation (via create()) uses buffer after object (this + 1)
- Stack-allocated OperationOnStack passes its _buf array to base constructor

This eliminates two sources of UB:
1. Flexible array member (char _buf[0]) - not standard C++
2. Derived class overriding base class member (char _buf[BufferSize])

The fix ensures correct behavior regardless of compiler optimizations and eliminates potential issues with -O2 or different compiler versions.

Verified: DadiCacheTest passes with ASAN enabled, no SEGV crashes.