### PR TITLE
[Backport][0.9 to 0.8] | | Fix FIEMAP extent flags check and probeFiemap reliability (#1431) (#1475)

### DIFF
--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -17,6 +17,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel   \
@@ -52,6 +59,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-9/enable
@@ -88,6 +102,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-10/enable
@@ -124,6 +145,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-11/enable
@@ -160,6 +188,13 @@ jobs:
           timezoneMacos: "Asia/Shanghai"
           timezoneWindows: "China Standard Time"
       - uses: actions/checkout@v4
+      - name: Setup ext4 loopback for fiemap tests
+        run: |
+          yum install -y -q e2fsprogs
+          dd if=/dev/zero of=/tmp/ext4.img bs=1M count=256 status=none
+          mkfs.ext4 -q /tmp/ext4.img
+          mkdir -p /root/tmp
+          mount -o loop /tmp/ext4.img /root/tmp
       - name: Build
         run: |
           source /opt/rh/gcc-toolset-12/enable

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -1,0 +1,481 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "cache_pool.h"
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include <algorithm>
+#include <sys/statvfs.h>
+
+#include "cache_store.h"
+#include <photon/common/alog.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/common/enumerable.h>
+#include <photon/common/utility.h>
+#include <photon/fs/fiemap.h>
+#include <photon/fs/path.h>
+
+namespace photon {
+namespace fs {
+
+const uint64_t kGB = 1024 * 1024 * 1024;
+const uint64_t kMaxFreeSpace = 50 * kGB;
+const int64_t kEvictionMark = 5ll * kGB;
+
+FileCachePool::FileCachePool(IFileSystem* mediaFs, uint64_t capacityInGB,
+    uint64_t periodInUs, uint64_t diskAvailInBytes, uint64_t refillUnit,
+    uint64_t storeCacheTTLUsecs)
+    : ICachePool(0, 128, -1U, false, storeCacheTTLUsecs),
+      mediaFs_(mediaFs),
+      capacityInGB_(capacityInGB),
+      periodInUs_(periodInUs),
+      diskAvailInBytes_(diskAvailInBytes),
+      refillUnit_(refillUnit),
+      totalUsed_(0),
+      timer_(nullptr),
+      running_(false),
+      exit_(false),
+      isFull_(false) {
+    int64_t capacityInBytes = capacityInGB_ * kGB;
+    waterMark_ = calcWaterMark(capacityInBytes, kMaxFreeSpace);
+    // keep this relation : waterMark < riskMark < capacity
+    riskMark_ = std::max(capacityInBytes - kEvictionMark, (static_cast<int64_t>(waterMark_) + capacityInBytes) >> 1);
+}
+
+FileCachePool::~FileCachePool() {
+  exit_ = true;
+  if (timer_) {
+    while (running_) {
+      photon::thread_usleep(1);
+    }
+    delete timer_;
+  }
+  this->stores_clear();
+  delete mediaFs_;
+}
+
+void FileCachePool::Init() {
+  probeFiemap();
+  traverseDir("/");
+  timer_ = new photon::Timer(periodInUs_, {this, FileCachePool::timerHandler}, true, 8UL * 1024 * 1024);
+}
+
+void FileCachePool::probeFiemap() {
+  static const char* probePath = "/.photon_fiemap_probe";
+  struct stat st = {};
+  bool preExists = (mediaFs_->stat(probePath, &st) == 0);
+  auto probe = mediaFs_->open(probePath, O_CREAT | O_RDWR, 0600);
+  if (!probe) {
+    LOG_ERRNO_RETURN(0, void(), "fiemap probe file open failed");
+  }
+  DEFER({
+    delete probe;
+    if (!preExists) mediaFs_->unlink(probePath);
+  });
+
+  char buf[4096] = {};
+  if (probe->pwrite(buf, sizeof(buf), 0) != (ssize_t)sizeof(buf)) {
+    LOG_INFO("fiemap probe write failed, errno `", ERRNO());
+    return;
+  }
+
+  fiemap_t<1> fie(0, sizeof(buf));
+  fie.fm_mapped_extents = 0;
+  if (probe->fiemap(&fie) != 0 || fie.fm_mapped_extents == 0) {
+    LOG_INFO("fiemap not supported on this filesystem, errno `", ERRNO());
+    return;
+  }
+
+  // Overlayfs returns extents with FIEMAP_EXTENT_UNKNOWN, which are skipped
+  // by queryRefillRange. Detect and fall back to in-memory range tracking.
+  if (fie.fm_extents[0].fe_flags & FIEMAP_EXTENT_UNKNOWN) {
+    LOG_INFO("fiemap returns UNKNOWN extents, falling back to range tracking");
+    return;
+  }
+
+  fiemapSupported_ = true;
+}
+
+ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t mode) {
+  auto localFile = openMedia(pathname, flags, mode);
+  if (!localFile) {
+    return nullptr;
+  }
+
+  // Check idle container first
+  auto idleIt = idleFileIndex_.find(pathname);
+  if (idleIt != idleFileIndex_.end()) {
+    promoteFromIdle(idleIt);
+  }
+
+  auto find = fileIndex_.find(pathname);
+  if (find == fileIndex_.end()) {
+    auto lruIter = lru_.push_front(fileIndex_.end());
+    std::unique_ptr<LruEntry> entry(new LruEntry{lruIter, 1, 0});
+    find = fileIndex_.emplace(pathname, std::move(entry)).first;
+    lru_.front() = find;
+  } else {
+    lru_.access(find->second->lruIter);
+    find->second->openCount++;
+  }
+
+  // If LRU exceeds the limit, demote the tail (only if not open) to idle
+  while (lru_.size() > demoteThreshold_) {
+    auto tailIt = lru_.back();
+    if (tailIt->second->openCount == 0) {
+      demoteToIdle(tailIt);
+    } else {
+      break;
+    }
+  }
+
+  return new FileCacheStore(this, localFile, refillUnit_, find);
+}
+
+IFile* FileCachePool::openMedia(std::string_view name, int flags, int mode) {
+   if (name.empty() || name[0] != '/') {
+    LOG_ERROR_RETURN(EINVAL, nullptr, "pathname is invalid, path : `", name);
+  }
+
+  auto base_directory = Path(name.data()).dirname();
+  auto ret = mkdir_recursive(base_directory, mediaFs_);
+  if (ret) {
+    LOG_ERRNO_RETURN(0, nullptr, "mkdir failed, path : `", name);
+  }
+
+  auto localFile = mediaFs_->open(name.data(), flags, mode);
+  if (nullptr == localFile) {
+    LOG_ERRNO_RETURN(0, nullptr,
+        "cache store open failed, pathname : `, flags : `, mode : `", name, flags, mode);
+  }
+  return localFile;
+}
+
+int FileCachePool::set_quota(std::string_view pathname, size_t quota) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int FileCachePool::stat(CacheStat* stat, std::string_view pathname) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int FileCachePool::evict(std::string_view filename) {
+  // Check idle container first
+  auto idleIt = idleFileIndex_.find(filename);
+  if (idleIt != idleFileIndex_.end()) {
+    return evictIdleEntry(idleIt) >= 0 ? 0 : -1;
+  }
+
+  auto fileIter = fileIndex_.find(filename);
+  if (fileIter == fileIndex_.end()) {
+    LOG_ERROR("Evict no such file , name: `", filename);
+    return 0;
+  }
+
+  const auto& filePath = fileIter->first;
+  auto lruEntry = fileIter->second.get();
+  if (lruEntry->openCount == 0) {
+    lru_.mark_key_cleared(lruEntry->lruIter);
+  }
+  int err = 0;
+  {
+    auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+    DEFER(cacheStore->release());
+    photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
+    err = cacheStore->evict(0);
+    lruEntry->truncate_done = false;
+  }
+  if (err) {
+    ERRNO e;
+    LOG_ERROR("truncate(0) failed, name: `, ret: `, error code: `", filePath,
+              err, e);
+    // If truncate fails, we can attempt to remove the file directly
+    // in the afterFtrucate function.
+  }
+  return afterFtrucate(fileIter) ? 0 : -1;
+}
+
+int FileCachePool::evict(size_t size) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int FileCachePool::rename(std::string_view oldname, std::string_view newname) {
+  errno = ENOSYS;
+  return -1;
+}
+
+bool FileCachePool::isFull() {
+  return isFull_;
+}
+
+void FileCachePool::removeOpenFile(FileNameMap::iterator iter) {
+  iter->second->openCount--;
+}
+
+void FileCachePool::forceRecycle() {
+  timerHandler(this);
+}
+
+void FileCachePool::updateLru(FileNameMap::iterator iter) {
+  lru_.access(iter->second->lruIter);
+}
+
+//  currently, we exist duplicate pwrite
+uint64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
+  auto lruEntry = iter->second.get();
+  uint64_t diff = 0;
+  if (size > lruEntry->size) {
+    diff = size - lruEntry->size;
+    totalUsed_ += diff;
+  }
+  lruEntry->size = size;
+  if (totalUsed_ >= riskMark_) {
+    LOG_WARN("pwrite is so heavy, totalUsed:`,riskMark:` || lruEntry->size = `",totalUsed_, riskMark_, lruEntry->size);
+    isFull_ = true;
+    forceRecycle();
+    if (lruEntry->size==0) diff = 0;//in some extream condition ,
+                                    //forceRecycle maybe truncate current file to 0
+  }
+  return diff;
+}
+
+uint64_t FileCachePool::timerHandler(void* data) {
+  auto cur = static_cast<FileCachePool*>(data);
+  if (cur->running_) {
+    return 0;
+  }
+  cur->running_ = true;
+  DEFER(cur->running_ = false;);
+  cur->eviction();
+  return 0;
+}
+
+void FileCachePool::eviction() {
+  uint64_t evictByDisk = 0;
+  uint64_t evictByCache = 0;
+  uint64_t fsCapacity = 0;
+
+  DEFER(isFull_ = false);
+  struct statvfs stFs = {};
+  auto err = mediaFs_->statvfs("/", &stFs);
+  if (err) {
+    LOG_ERROR("statvfs failed, ret : `, error code : `", err, ERRNO());
+    return;
+  } else {
+    fsCapacity = stFs.f_frsize * stFs.f_blocks;
+    uint64_t diskAvailInBytes = stFs.f_bavail * stFs.f_frsize;
+    if (diskAvailInBytes < diskAvailInBytes_) {
+      evictByDisk = diskAvailInBytes_ - diskAvailInBytes;
+    } else if (fsCapacity <= waterMark_) { // we occupy the whole disk
+      return;
+    }
+  }
+
+  if (totalUsed_ >= static_cast<int64_t>(waterMark_)) {
+    evictByCache = totalUsed_ - waterMark_;
+  }
+
+  auto actualEvict = std::min(
+    static_cast<int64_t>(std::max(evictByCache, evictByDisk)),
+    totalUsed_
+  );
+
+  if (actualEvict <= 0) {
+    return;
+  }
+
+  isFull_ = true;
+
+  if (!lru_.empty() && !exit_) {
+    LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
+  }
+
+  // Phase 1: evict from idle tier first.
+  actualEvict -= evictIdleWhenFull(actualEvict);
+
+  // Phase 2: fall back to LRU eviction when idle tier is exhausted
+  while (actualEvict > 0 && !lru_.empty() && !exit_) {
+    auto fileIter = lru_.back();
+    const auto& fileName = fileIter->first;
+    auto lruEntry = fileIter->second.get();
+    auto fileSize = lruEntry->size;
+    if (lruEntry->openCount == 0){
+      lru_.mark_key_cleared(fileIter->second->lruIter);
+    } else {
+      lru_.access(fileIter->second->lruIter);
+    }
+    //as soon as possible truncate and unlink
+    if (0 == fileSize) {
+        if (0 == fileIter->second->openCount) {
+            afterFtrucate(fileIter);
+        }
+        continue;
+    }
+
+    {
+      auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
+      DEFER(cacheStore->release());
+      photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
+      err = cacheStore->evict(0);
+      lruEntry->truncate_done = false;
+    }
+
+    if (err) {
+      ERRNO e;
+      LOG_ERROR("truncate(0) failed, name : `, ret : `, error code : `", fileName, err, e);
+    }
+    afterFtrucate(fileIter);
+    actualEvict -= fileSize;
+    photon::thread_yield();
+  }
+}
+
+uint64_t FileCachePool::calcWaterMark(uint64_t capacity, uint64_t maxFreeSpace) {
+  return std::max(static_cast<uint64_t>(capacity * kWaterMarkRatio * 0.01),
+    capacity > maxFreeSpace ? capacity - maxFreeSpace : 0);
+}
+
+bool FileCachePool::afterFtrucate(FileNameMap::iterator iter) {
+  auto lruEntry = iter->second.get();
+  totalUsed_ -= static_cast<int64_t>(lruEntry->size);
+  lruEntry->size = 0;
+  if (totalUsed_ < 0) {
+    totalUsed_ = 0;
+  }
+  if (0 == iter->second->openCount) {
+    auto err = mediaFs_->unlink(iter->first.data());
+    if (err) {
+      ERRNO e;
+      LOG_ERROR("unlink failed, name : `, ret : `, error code : `", iter->first, err, e);
+      // unlink failed may caused by multiple reasons
+      // only EBUSY should may be able to trying to unlink again
+      // other reason should never try to clean it.
+      if (err && (e.no == EBUSY)) {
+        return false;
+      }
+    }
+    lru_.remove(lruEntry->lruIter);
+    fileIndex_.erase(iter);
+  }
+  return true;
+}
+
+int FileCachePool::traverseDir(const std::string& root) {
+  for (auto file : enumerable(Walker(mediaFs_, root))) {
+    insertFile(file);
+  }
+  return 0;
+}
+
+int FileCachePool::insertFile(std::string_view file) {
+  struct stat st = {};
+  auto ret = mediaFs_->stat(file.data(), &st);
+  if (ret) {
+    LOG_ERRNO_RETURN(0, -1, "stat failed, name : `", file.data());
+  }
+  auto fileSize = st.st_blocks * kDiskBlockSize;
+
+  if (lru_.size() >= demoteThreshold_) {
+    auto idleLruIt = idleLru_.push_front(idleFileIndex_.end());
+    auto iter = idleFileIndex_.emplace(file, idleLruIt).first;
+    idleLru_.front() = iter;
+  } else {
+    auto lruIter = lru_.push_front(fileIndex_.end());
+    auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
+    auto iter = fileIndex_.emplace(file, std::move(entry)).first;
+    lru_.front() = iter;
+  }
+  totalUsed_ += fileSize;
+  return 0;
+}
+
+// Demote a LRU entry (openCount must be 0) to the idle container.
+void FileCachePool::demoteToIdle(FileNameMap::iterator iter) {
+  auto idleLruIt = idleLru_.push_front(idleFileIndex_.end());
+  auto idleIndexIt = idleFileIndex_.emplace(iter->first, idleLruIt).first;
+  idleLru_.front() = idleIndexIt;
+
+  lru_.remove(iter->second->lruIter);
+  fileIndex_.erase(iter);
+}
+
+// Promote an idle entry back to the front of LRU.
+void FileCachePool::promoteFromIdle(IdleFileNameMap::iterator idleIt) {
+  uint32_t idleLruIter = idleIt->second;
+  const auto& filename = idleIt->first;
+
+  struct stat st = {};
+  uint64_t fileSize = 0;
+  if (mediaFs_->stat(filename.data(), &st) == 0) {
+    fileSize = st.st_blocks * kDiskBlockSize;
+  }
+
+  auto lruIter = lru_.push_front(fileIndex_.end());
+  auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
+  auto iter = fileIndex_.emplace(filename, std::move(entry)).first;
+  lru_.front() = iter;
+
+  idleLru_.remove(idleLruIter);
+  idleFileIndex_.erase(idleIt);
+}
+
+// Evict the idle entry pointed to by idleIt; return freed bytes or -1 on error.
+ssize_t FileCachePool::evictIdleEntry(IdleFileNameMap::iterator idleIt) {
+  const auto& filename = idleIt->first;
+
+  struct stat st = {};
+  uint64_t fileSize = 0;
+  if (mediaFs_->stat(filename.data(), &st) == 0) {
+    fileSize = st.st_blocks * kDiskBlockSize;
+  }
+
+  if (fileSize > 0) {
+    int err = mediaFs_->truncate(filename.data(), 0);
+    if (err) {
+      LOG_ERRNO_RETURN(0, -1, "truncate(0) failed, name : `", filename);
+    }
+    totalUsed_ -= static_cast<int64_t>(fileSize);
+    if (totalUsed_ < 0) totalUsed_ = 0;
+  }
+  int err = mediaFs_->unlink(filename.data());
+  if (err) {
+    // we still evict fileSize bytes even if unlink fails
+    LOG_ERRNO_RETURN(0, fileSize, "unlink failed, name : `", filename);
+  }
+
+  uint32_t idleLruIter = idleIt->second;
+  idleLru_.remove(idleLruIter);
+  idleFileIndex_.erase(idleIt);
+  return static_cast<ssize_t>(fileSize);
+}
+
+uint64_t FileCachePool::evictIdleWhenFull(uint64_t needEvict) {
+  uint64_t evictSize = 0;
+  while (evictSize < needEvict && !idleLru_.empty() && !exit_) {
+    auto r = evictIdleEntry(idleLru_.back());
+    if (r >= 0) evictSize += static_cast<uint64_t>(r);
+    photon::thread_yield();
+  }
+  return evictSize;
+}
+
+}
+}

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -1,0 +1,143 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <photon/thread/thread.h>
+#include <photon/thread/timer.h>
+#include <photon/common/string-keyed.h>
+#include "../policy/lru.h"
+#include <photon/fs/cache/pool_store.h>
+
+#include <photon/fs/filesystem.h>
+
+namespace photon {
+namespace fs {
+
+class FileCachePool : public photon::fs::ICachePool {
+public:
+    FileCachePool(photon::fs::IFileSystem *mediaFs, uint64_t capacityInGB, uint64_t periodInUs,
+                  uint64_t diskAvailInBytes, uint64_t refillUnit, 
+                  uint64_t storeCacheTTLUsecs = 10'000'000);
+    ~FileCachePool();
+
+    static const uint64_t kDiskBlockSize = 512; // stat(2)
+    static const uint64_t kDeleteDelayInUs = 1000;
+    static const uint32_t kWaterMarkRatio = 90;
+    // max inuse-lru entries before demoting tail to idle-lru (default: 100w)
+    static const uint32_t kDemoteThreshold = 1'000'000;
+
+    void Init();
+
+    int set_quota(std::string_view pathname, size_t quota) override;
+    int stat(photon::fs::CacheStat *stat,
+             std::string_view pathname = std::string_view(nullptr, 0)) override;
+
+    int evict(std::string_view filename) override;
+    int evict(size_t size = 0) override;
+    int rename(std::string_view oldname, std::string_view newname) override;
+
+    struct LruEntry {
+        LruEntry(uint32_t lruIt, int openCnt, uint64_t fileSize)
+            : lruIter(lruIt), openCount(openCnt), size(fileSize), truncate_done(false) {
+        }
+        ~LruEntry() = default;
+        uint32_t lruIter;
+        int openCount;
+        uint64_t size;
+        bool truncate_done;
+    };
+
+    // Normally, fileIndex(std::map) always keep growing, so its iterators always
+    // keep valid, iterator will be erased when file be unlinked in period of eviction,
+    // but on that time corresponding CachedFile had been destructed, so nobody hold
+    // erased iterator.
+    typedef map_string_key<std::unique_ptr<LruEntry>> FileNameMap;
+
+    bool isFull();
+    void removeOpenFile(FileNameMap::iterator iter);
+    void forceRecycle();
+    void updateLru(FileNameMap::iterator iter);
+    uint64_t updateSpace(FileNameMap::iterator iter, uint64_t size);
+
+    // True if the media filesystem supports fiemap. Decided once at Init()
+    // time by probing a named file. When false, FileCacheStore tracks filled
+    // ranges in memory from the start instead of relying on fiemap.
+    // Written only by probeFiemap() during Init(); plain bool is enough since
+    // all FileCacheStore reads happen-after Init().
+    bool fiemapSupported() const { return fiemapSupported_; }
+
+protected:
+    //  pathname must begin with '/'
+    photon::fs::ICacheStore *do_open(std::string_view pathname, int flags, mode_t mode) override;
+    photon::fs::IFile *openMedia(std::string_view name, int flags, int mode);
+
+    static uint64_t timerHandler(void *data);
+    virtual void eviction();
+    uint64_t calcWaterMark(uint64_t capacity, uint64_t maxFreeSpace);
+
+    photon::fs::IFileSystem *mediaFs_; //  owned by current class
+    uint64_t capacityInGB_;
+    uint64_t periodInUs_;
+    uint64_t diskAvailInBytes_;
+    size_t refillUnit_;
+    int64_t totalUsed_;
+    int64_t riskMark_;
+    uint64_t waterMark_;
+
+    photon::Timer *timer_;
+    bool running_;
+    bool exit_;
+
+    bool isFull_;
+
+    bool fiemapSupported_ = false;
+    void probeFiemap();
+
+    virtual bool afterFtrucate(FileNameMap::iterator iter);
+
+    int traverseDir(const std::string &root);
+    virtual int insertFile(std::string_view file);
+
+    typedef photon::fs::LRU<FileNameMap::iterator, uint32_t> LRUContainer;
+    LRUContainer lru_;
+    // filename -> lruEntry
+    FileNameMap fileIndex_;
+
+    uint32_t demoteThreshold_ = kDemoteThreshold;
+
+    // idleFileIndex_ stores filename -> lruContainer's iterator
+    // idleLru_ stores iterators into idleFileIndex_; std::map nodes are stable.
+    typedef map_string_key<uint32_t> IdleFileNameMap;
+    typedef photon::fs::LRU<IdleFileNameMap::iterator, uint32_t> IdleLRUContainer;
+    IdleLRUContainer idleLru_;
+    IdleFileNameMap idleFileIndex_;
+
+    void demoteToIdle(FileNameMap::iterator iter);
+    void promoteFromIdle(IdleFileNameMap::iterator idleIter);
+    uint64_t evictIdleWhenFull(uint64_t needEvictSize);
+    ssize_t evictIdleEntry(IdleFileNameMap::iterator idleIter);
+
+    friend struct FileCachePoolTest;
+};
+
+}
+}

--- a/fs/cache/full_file_cache/cache_store.cpp
+++ b/fs/cache/full_file_cache/cache_store.cpp
@@ -1,0 +1,278 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "cache_store.h"
+
+#include <sys/stat.h>
+#include "sys/statvfs.h"
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include <photon/common/alog.h>
+#include <photon/common/alog-audit.h>
+#include <photon/fs/fiemap.h>
+#include <photon/fs/filesystem.h>
+#include <photon/common/iovector.h>
+#include "cache_pool.h"
+
+
+
+namespace photon {
+namespace fs {
+
+const uint64_t kDiskBlockSize = 512; // stat(2)
+constexpr int kFieExtentSize = 1000;
+const int kBlockSize = 4 * 1024;
+
+FileCacheStore::FileCacheStore(photon::fs::ICachePool* cachePool, IFile* localFile,
+  size_t refillUnit, FileIterator iterator)
+    : cachePool_(static_cast<FileCachePool*>(cachePool)),
+      localFile_(localFile),
+      refillUnit_(refillUnit),
+      iterator_(iterator),
+      fiemapSupported_(cachePool_->fiemapSupported()) {
+  if (!fiemapSupported_) {
+    rebuildFilledRanges();
+  }
+}
+
+FileCacheStore::~FileCacheStore() {
+  delete localFile_;  //  will close file
+  cachePool_->removeOpenFile(iterator_);
+}
+
+ICacheStore::try_preadv_result FileCacheStore::try_preadv2(const struct iovec *iov, int iovcnt,
+                                                           off_t offset, int flags) {
+  photon::scoped_rwlock rl(rw_lock_, photon::RLOCK);
+  return this->ICacheStore::try_preadv2(iov, iovcnt, offset, flags);
+}
+
+ssize_t FileCacheStore::do_preadv2(const struct iovec *iov, int iovcnt, off_t offset, int flags) {
+  // TODO(suoshi.yf): maybe a new interface for updating lru is better for avoiding
+  // multiple cacheStore preadvs but cacheFile preadv only once
+  ssize_t ret = 0;
+  cachePool_->updateLru(iterator_);
+  SCOPE_AUDIT_THRESHOLD(1UL * 1000, "file:read", AU_FILEOP("", offset, ret));
+  ret = localFile_->preadv(iov, iovcnt, offset);
+  return ret;
+}
+
+ssize_t FileCacheStore::do_pwritev(const struct iovec *iov, int iovcnt, off_t offset)
+{
+  ssize_t ret;
+  iovector_view view((iovec*)iov, iovcnt);
+  auto lruEntry = iterator_->second.get();
+  photon::scoped_rwlock rl(rw_lock_, photon::RLOCK);
+  if (!lruEntry->truncate_done) {
+    // May repeated ftruncate() here, but it doesn't matter
+    ret = localFile_->ftruncate(actual_size_);
+    if (ret) {
+      LOG_ERRNO_RETURN(0, -1, "failed to truncate media file: ", VALUE(ret));
+    }
+    lruEntry->truncate_done = true;
+  }
+  ScopedRangeLock lock(rangeLock_, offset, view.sum());
+  SCOPE_AUDIT_THRESHOLD(10UL * 1000, "file:write", AU_FILEOP("", offset, ret));
+  ret = localFile_->pwritev(iov, iovcnt, offset);
+  if (ret > 0 && !fiemapSupported_) {
+    addFilledRange(offset, ret);
+  }
+  return ret;
+}
+
+ssize_t FileCacheStore::do_pwritev2(const struct iovec *iov, int iovcnt, off_t offset, int flags) {
+  if (cacheIsFull()) {
+    errno = ENOSPC;
+    return -1;
+  }
+
+  auto ret = do_pwritev(iov, iovcnt, offset);
+  if (ret < 0 && ENOSPC == errno) {
+    cachePool_->forceRecycle();
+  }
+
+  if (ret > 0) {
+    struct stat st = {};
+    auto err = localFile_->fstat(&st);
+    if (err) {
+      LOG_ERRNO_RETURN(0, ret, "fstat failed")
+    }
+    cachePool_->updateLru(iterator_);
+    cachePool_->updateSpace(iterator_, kDiskBlockSize * st.st_blocks);
+  }
+  return ret;
+}
+
+std::pair<off_t, size_t> FileCacheStore::queryRefillRange(off_t offset, size_t size) {
+  ScopedRangeLock lock(rangeLock_, offset, size);
+
+  if (!fiemapSupported_) {
+    return queryRefillRangeByMap(offset, size);
+  }
+
+  off_t alignLeft = align_down(offset, kBlockSize);
+  off_t alignRight = align_up(offset + size, kBlockSize);
+  ReadRequest request{alignLeft, static_cast<size_t>(alignRight - alignLeft)};
+
+  struct fiemap_t<kFieExtentSize> fie(request.offset, request.size);
+  fie.fm_mapped_extents = 0;
+
+  if (request.size > 0) { //  fiemap cannot handle size zero.
+    auto ok = localFile_->fiemap(&fie);
+    if (ok != 0) {
+      LOG_ERRNO_RETURN(0, std::make_pair(-1, 0),
+                       "media fiemap failed : `, offset : `, size : `",
+                       ok, request.offset, request.size);
+    }
+    if (fie.fm_mapped_extents >= kFieExtentSize) { //TODO: qisheng.ds
+                                                   //it's supposed to be solved by
+                                                   //get fie extents twice,
+                                                   //but just do not concern much
+                                                   //about it rightnow.
+      LOG_ERROR_RETURN(EINVAL, std::make_pair(-1, 0),
+                       "read size is too big : `", request.size);
+    }
+  }
+
+  uint64_t holeStart = request.offset;
+  uint64_t holeEnd = request.offset + request.size;
+
+  for (ssize_t i = (ssize_t)(fie.fm_mapped_extents) - 1; i >= 0; i--) {
+    auto& extent = fie.fm_extents[i];
+    if (extent.fe_flags & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_UNWRITTEN)) continue;
+      if (extent.fe_logical < holeEnd){
+        if (extent.fe_logical_end() >= holeEnd){
+          holeEnd = extent.fe_logical;
+        } else break;
+      }
+  }
+
+  for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
+    auto& extent = fie.fm_extents[i];
+    if (extent.fe_flags & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_UNWRITTEN)) continue;
+      if (extent.fe_logical_end() > holeStart){
+        if (extent.fe_logical <= holeStart){
+          holeStart = extent.fe_logical_end();
+        } else break;
+      }
+  }
+
+  if (holeStart >= holeEnd) return std::make_pair(0, 0);
+  // CacheMiss
+  auto left = align_down(holeStart, refillUnit_);
+  auto right = align_up(holeEnd, refillUnit_);
+  return std::make_pair(left, right - left);
+}
+
+int FileCacheStore::set_quota(size_t quota) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int FileCacheStore::stat(CacheStat* stat) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int FileCacheStore::evict(off_t offset, size_t count, int flags) {
+  int ret;
+  if (static_cast<size_t>(-1) == count) {
+    ret = localFile_->ftruncate(offset);
+  } else {
+    #ifndef FALLOC_FL_KEEP_SIZE
+    #define FALLOC_FL_KEEP_SIZE     0x01 /* default is extend size */
+    #endif
+    #ifndef FALLOC_FL_PUNCH_HOLE
+    #define FALLOC_FL_PUNCH_HOLE	0x02 /* de-allocates range */
+    #endif
+    int mode = FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE;
+    ret = localFile_->fallocate(mode, offset, count);
+  }
+
+  if (ret == 0 && !fiemapSupported_) {
+    removeFilledRange(offset, count);
+  }
+  return ret;
+}
+
+int FileCacheStore::fstat(struct stat *buf) {
+  return localFile_->fstat(buf);
+}
+
+bool FileCacheStore::cacheIsFull() {
+  return cachePool_->isFull();
+}
+
+std::pair<off_t, size_t> FileCacheStore::queryRefillRangeByMap(off_t offset, size_t size) {
+  std::pair<off_t, off_t> hole;
+  {
+    SCOPED_LOCK(filledRangesLock_);
+    hole = filledRanges_.queryRefillRange(offset, offset + size);
+  }
+  if (hole.first == 0 && hole.second == 0) return {0, 0};
+  auto left = align_down(hole.first, refillUnit_);
+  auto right = align_up(hole.second, refillUnit_);
+  return {left, right - left};
+}
+
+void FileCacheStore::addFilledRange(off_t offset, size_t size) {
+  if (size == 0) return;
+  SCOPED_LOCK(filledRangesLock_);
+  filledRanges_.addRange(offset, offset + size);
+}
+
+void FileCacheStore::removeFilledRange(off_t offset, size_t count) {
+  SCOPED_LOCK(filledRangesLock_);
+  if (count == static_cast<size_t>(-1)) {
+    filledRanges_.removeFrom(offset);
+  } else {
+    filledRanges_.removeRange(offset, offset + count);
+  }
+}
+
+void FileCacheStore::rebuildFilledRanges() {
+  // Note: we only hold filledRangesLock_ around the in-memory map mutations.
+  // addFilledRange already takes the lock internally.
+  {
+    SCOPED_LOCK(filledRangesLock_);
+    filledRanges_.clear();
+  }
+  // Skip rebuild on empty/new files.
+  struct stat st = {};
+  if (localFile_->fstat(&st) != 0 || st.st_size == 0) return;
+
+  off_t pos = 0;
+  while (pos < st.st_size) {
+    off_t dataStart = localFile_->lseek(pos, SEEK_DATA);
+    if (dataStart < 0) {
+      ERRNO e;
+      // ENXIO from SEEK_DATA means "no more data past pos".
+      if (e.no != ENXIO) {
+        LOG_ERRNO_RETURN(0, void(), "SEEK_DATA failed during range rebuild.");
+      }
+      break;
+    }
+    off_t holeStart = localFile_->lseek(dataStart, SEEK_HOLE);
+    if (holeStart < 0) {
+      LOG_ERRNO_RETURN(0, void(), "SEEK_HOLE failed during range rebuild.");
+    }
+    addFilledRange(dataStart, holeStart - dataStart);
+    pos = holeStart;
+  }
+}
+
+}
+}

--- a/fs/cache/persistent_cache/persistent_cache.cpp
+++ b/fs/cache/persistent_cache/persistent_cache.cpp
@@ -1,0 +1,365 @@
+/*
+   Copyright The Overlaybd Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+#include <string>
+#include <photon/common/alog.h>
+#include <photon/common/alog-audit.h>
+#include <photon/common/alog-stdstring.h>
+#include <photon/common/iovector.h>
+#include <photon/fs/range-split.h>
+#include <photon/fs/localfs.h>
+#include <photon/fs/virtual-file.h>
+#include <photon/fs/forwardfs.h>
+#include <photon/fs/fiemap.h>
+#include <photon/thread/thread.h>
+#include <photon/common/io-alloc.h>
+#include <photon/common/expirecontainer.h>
+#include <photon/common/range-lock.h>
+#include <photon/fs/cache/cache.h>
+
+#define SET_LOCAL_DIR 118
+#define SET_SIZE 119
+
+namespace photon {
+namespace fs {
+
+class PersistentCacheFs;
+
+class PersistentCacheStore : public ForwardFile_Ownership {
+public:
+    PersistentCacheStore(IFile *file, PersistentCacheFs *fs)
+        : ForwardFile_Ownership(file, true), m_fs(fs) {
+    }
+
+    using ForwardFile_Ownership::ftruncate;
+    using ForwardFile_Ownership::preadv;
+    using ForwardFile_Ownership::pwritev;
+
+    int fallocate(int mode, off_t offset, off_t len) override {
+        ScopedRangeLock lock(m_range_lock, offset, len);
+        return m_file->fallocate(mode, offset, len);
+    }
+    int ftruncate(off_t length) override {
+        // set when initialization, no need lock (length too large for range lock)
+        return m_file->ftruncate(length);
+    }
+
+    std::pair<off_t, size_t> query_refill_range(off_t offset, size_t size);
+
+    int try_lock_wait(uint64_t offset, uint64_t length) {
+        return m_range_lock.try_lock_wait(offset, length);
+    }
+    void lock(uint64_t offset, uint64_t length) {
+        m_range_lock.lock(offset, length);
+    }
+    void unlock(uint64_t offset, uint64_t length) {
+        m_range_lock.unlock(offset, length);
+    }
+
+private:
+    RangeLock m_range_lock;
+    PersistentCacheFs *m_fs;
+};
+
+class PersistentCacheFile : public VirtualFile {
+public:
+    PersistentCacheFile(IFile *file, const char *pathname, PersistentCacheFs *fs)
+        : m_file(file), m_name(pathname), m_fs(fs) {
+    }
+    ~PersistentCacheFile();
+
+    ssize_t preadv(const struct iovec *iov, int iovcnt, off_t offset) override;
+    int fstat(struct stat *buf) override;
+    int vioctl(int request, va_list args) override;
+    // used for evict
+    int fallocate(int mode, off_t offset, off_t len);
+
+    UNIMPLEMENTED_POINTER(IFileSystem *filesystem() override);
+    UNIMPLEMENTED(off_t lseek(off_t offset, int whence) override);
+    UNIMPLEMENTED(int fsync() override);
+    UNIMPLEMENTED(int fdatasync() override);
+    UNIMPLEMENTED(int fchmod(mode_t mode) override);
+    UNIMPLEMENTED(int fchown(uid_t owner, gid_t group) override);
+    UNIMPLEMENTED(int ftruncate(off_t length) override);
+    UNIMPLEMENTED(int close() override);
+
+private:
+    std::string m_local_path;
+    photon::fs::IFile *m_file = nullptr;
+    PersistentCacheStore *m_local_file = nullptr;
+    size_t m_size = 0;
+    bool ready = false;
+    std::string m_name;
+    PersistentCacheFs *m_fs;
+};
+
+class PersistentCacheFs : public IFileSystem {
+public:
+    PersistentCacheFs(IFileSystem *fs, size_t bs, size_t rs, IOAlloc *io_alloc)
+        : block_size(bs), refill_size(rs), io_alloc(io_alloc),
+          m_file_pool(1 * 1000 * 1000), m_src_fs(fs){
+        LOG_INFO("new PersistentCacheFs");
+    }
+    ~PersistentCacheFs() {
+        LOG_INFO("delete PersistentCacheFs");
+    }
+    virtual IFile *open(const char *pathname, int flags) override {
+        auto src_file = m_src_fs->open(pathname, flags);
+        if (src_file == nullptr) {
+            LOG_ERRNO_RETURN(0, nullptr, "failed to open src: `", pathname);
+        }
+        return new PersistentCacheFile(src_file, pathname, this);
+    }
+    IFile *open(const char *pathname, int flags, mode_t mode) {
+        return open(pathname, flags);
+    }
+
+    UNIMPLEMENTED(int stat(const char *pathname, struct stat *buf) override);
+    UNIMPLEMENTED(int lstat(const char *path, struct stat *buf) override);
+    UNIMPLEMENTED_POINTER(IFile *creat(const char *, mode_t) override);
+    UNIMPLEMENTED(int mkdir(const char *, mode_t) override);
+    UNIMPLEMENTED(int rmdir(const char *) override);
+    UNIMPLEMENTED(int link(const char *, const char *) override);
+    UNIMPLEMENTED(int symlink(const char *, const char *) override);
+    UNIMPLEMENTED(ssize_t readlink(const char *, char *, size_t) override);
+    UNIMPLEMENTED(int rename(const char *, const char *) override);
+    UNIMPLEMENTED(int chmod(const char *, mode_t) override);
+    UNIMPLEMENTED(int chown(const char *, uid_t, gid_t) override);
+    UNIMPLEMENTED(int statfs(const char *path, struct statfs *buf) override);
+    UNIMPLEMENTED(int statvfs(const char *path, struct statvfs *buf) override);
+    UNIMPLEMENTED(int access(const char *pathname, int mode) override);
+    UNIMPLEMENTED(int truncate(const char *path, off_t length) override);
+    UNIMPLEMENTED(int syncfs() override);
+    UNIMPLEMENTED(int unlink(const char *filename) override);
+    UNIMPLEMENTED(int lchown(const char *pathname, uid_t owner, gid_t group) override);
+    UNIMPLEMENTED_POINTER(DIR *opendir(const char *) override);
+    UNIMPLEMENTED(int utime(const char *path, const struct utimbuf *file_times) override);
+    UNIMPLEMENTED(int utimes(const char *path, const struct timeval times[2]) override);
+    UNIMPLEMENTED(int lutimes(const char *path, const struct timeval times[2]) override);
+    UNIMPLEMENTED(int mknod(const char *path, mode_t mode, dev_t dev) override);
+
+    size_t block_size;
+    size_t refill_size;
+    IOAlloc *io_alloc;
+    ObjectCache<std::string, PersistentCacheStore *> m_file_pool;
+
+private:
+    photon::fs::IFileSystem *m_src_fs;
+};
+
+PersistentCacheFile::~PersistentCacheFile() {
+    safe_delete(m_file);
+    m_fs->m_file_pool.release(m_local_path);
+}
+
+ssize_t PersistentCacheFile::preadv(const struct iovec *iov, int iovcnt, off_t offset) {
+    ssize_t ret = 0;
+    if (!ready) {
+        LOG_WARN("local path or size not set, read from source ", VALUE(offset));
+        SCOPE_AUDIT("download", AU_FILEOP(m_name, offset, ret));
+        ret = m_file->preadv(iov, iovcnt, offset);
+        return ret;
+    }
+
+    iovector_view view((iovec *)iov, iovcnt);
+    size_t count = view.sum();
+    if (count == 0) {
+        return 0;
+    }
+
+    std::pair<off_t, size_t> q;
+
+    off_t align_left = align_down(offset, m_fs->block_size);
+    off_t align_right = align_up(offset + count, m_fs->block_size);
+
+again:
+
+     m_local_file->lock(align_left, align_right - align_left);
+    {
+        DEFER({m_local_file->unlock(align_left, align_right - align_left);});
+        q = m_local_file->query_refill_range(offset, count);
+        if (q.second == 0) { // no need to refill
+            return m_local_file->preadv(iov, iovcnt, offset);
+        }
+    }
+
+    // refill
+    uint64_t r_offset = q.first;
+    uint64_t r_count = q.second;
+    if (r_offset + r_count > m_size) {
+        r_count = m_size - r_offset;
+    }
+
+    IOVector buffer(*m_fs->io_alloc);
+
+    auto lr = m_local_file->try_lock_wait(r_offset, r_count);
+    if (lr < 0) {
+        goto again;
+    }
+    DEFER({ m_local_file->unlock(r_offset, r_count); });
+
+    auto alloc = buffer.push_back(r_count);
+    if (alloc < r_count) {
+        LOG_ERROR("memory allocate failed, refill size:`, alloc:`", r_count, alloc);
+        SCOPE_AUDIT("download", AU_FILEOP(m_name, offset, ret));
+        ret = m_file->preadv(iov, iovcnt, offset);
+        return ret;
+    }
+
+    ssize_t read = 0;
+    {
+        SCOPE_AUDIT("download", AU_FILEOP(m_name, r_offset, read));
+        read = m_file->preadv(buffer.iovec(), buffer.iovcnt(), r_offset);
+    }
+
+    if (read != (ssize_t)r_count) {
+        LOG_ERRNO_RETURN(0, -1, "src file read failed, read: `, expect: `, size: `, offset: `",
+                         read, r_count, m_size, r_offset);
+    }
+
+    auto write = m_local_file->pwritev(buffer.iovec(), buffer.iovcnt(), r_offset);
+    if (write != (ssize_t)r_count) {
+        LOG_ERRNO_RETURN(0, -1, "local file write failed, write: `, expect: `, size: `, offset: `",
+                         write, r_count, m_size, r_offset);
+    }
+
+    return m_local_file->preadv(iov, iovcnt, offset);
+}
+
+int PersistentCacheFile::fstat(struct stat *buf) {
+    return m_file->fstat(buf);
+}
+
+int PersistentCacheFile::vioctl(int request, va_list args) {
+    if (request == SET_LOCAL_DIR) {
+        auto dir = va_arg(args, std::string);
+        if (m_local_file != nullptr) {
+            LOG_DEBUG("dir already set, ignore");
+            return 0;
+        }
+        m_local_path = dir + "/.download";
+
+        m_local_file = m_fs->m_file_pool.acquire(m_local_path, [&]() -> PersistentCacheStore * {
+            auto f = open_localfile_adaptor(m_local_path.c_str(), O_RDWR | O_CREAT, 0644, 0);
+            if (f == nullptr) {
+                LOG_ERRNO_RETURN(0, nullptr, "failed to open local file ", VALUE(m_local_path));
+            }
+            return new PersistentCacheStore(f, m_fs);
+        });
+
+        if (m_local_file != nullptr && m_size > 0) {
+            m_local_file->ftruncate(m_size);
+            ready = true;
+        }
+        return 0;
+    } else if (request == SET_SIZE) {
+        if (m_size > 0) {
+            LOG_DEBUG("size already set, ignore");
+            return 0;
+        }
+        m_size = va_arg(args, size_t);
+        if (m_local_file != nullptr) {
+            m_local_file->ftruncate(m_size);
+            ready = true;
+        }
+        return 0;
+    } else {
+        return m_file->vioctl(request, args);
+    }
+}
+
+int PersistentCacheFile::fallocate(int mode, off_t offset, off_t len) {
+    if (m_local_file == nullptr) {
+        LOG_WARN("local path or size not set, ignore");
+        return 0;
+    }
+    if (len == -1) {
+        len = m_size - offset;
+    }
+    range_split_power2 rs(offset, len, m_fs->block_size);
+    auto aligned_offset = rs.aligned_begin_offset();
+    auto aligned_len = rs.aligned_length();
+    LOG_DEBUG("fallocate offset: `, len: `, aligned offset: `, aligned len: `", offset, len,
+              aligned_offset, aligned_len);
+
+    return m_local_file->trim(aligned_offset, aligned_len);
+}
+
+std::pair<off_t, size_t> PersistentCacheStore::query_refill_range(off_t offset, size_t size) {
+    off_t align_left = align_down(offset, m_fs->block_size);
+    off_t align_right = align_up(offset + size, m_fs->block_size);
+    auto req_offset = align_left;
+    auto req_size = static_cast<size_t>(align_right - align_left);
+
+    struct photon::fs::fiemap_t<4096> fie(req_offset, req_size);
+    fie.fm_mapped_extents = 0;
+
+    if (req_size > 0) { //  fiemap cannot handle size zero.
+        auto ok = m_file->fiemap(&fie);
+        if (ok != 0) {
+            LOG_ERRNO_RETURN(0, std::make_pair(-1, 0),
+                             "media fiemap failed : `, offset : `, size : `", ok, req_offset,
+                             req_size);
+        }
+        if (fie.fm_mapped_extents >= 4096) {
+            LOG_ERROR_RETURN(EINVAL, std::make_pair(-1, 0), "read size is too big : `", req_size);
+        }
+    }
+
+    uint64_t hole_start = req_offset;
+    uint64_t hole_end = req_offset + req_size;
+
+    for (auto i = fie.fm_mapped_extents - 1; i < fie.fm_mapped_extents; i--) {
+        auto &extent = fie.fm_extents[i];
+        if (extent.fe_flags & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_UNWRITTEN))
+            continue;
+        if (extent.fe_logical < hole_end) {
+            if (extent.fe_logical_end() >= hole_end) {
+                hole_end = extent.fe_logical;
+            } else
+                break;
+        }
+    }
+
+    for (uint32_t i = 0; i < fie.fm_mapped_extents; i++) {
+        auto &extent = fie.fm_extents[i];
+        if (extent.fe_flags & (FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_UNWRITTEN))
+            continue;
+        if (extent.fe_logical_end() > hole_start) {
+            if (extent.fe_logical <= hole_start) {
+                hole_start = extent.fe_logical_end();
+            } else
+                break;
+        }
+    }
+
+    if (hole_start >= hole_end)
+        return std::make_pair(0, 0);
+    // miss
+    auto left = align_down(hole_start, m_fs->refill_size);
+    auto right = align_up(hole_end, m_fs->refill_size);
+    return std::make_pair(left, right - left);
+}
+
+
+IFileSystem *new_persistent_cached_fs(photon::fs::IFileSystem *src_fs, size_t blk_size,
+                                    size_t refill_size, IOAlloc *io_alloc) {
+    if (io_alloc == nullptr) {
+        io_alloc = new IOAlloc;
+    }
+    return new PersistentCacheFs(src_fs, blk_size, refill_size, io_alloc);
+}
+} 
+} // namespace FileSystem


### PR DESCRIPTION
> [Backport][main to 0.9] | Fix FIEMAP extent flags check and probeFiemap reliability (#1431) (#1475)

* Fix FIEMAP extent flags check and probeFiemap reliability (#1431)

* Fix FIEMAP extent flags check using == instead of bitwise &

fe_flags is a bitmask where multiple flags can be set simultaneously
(e.g. FIEMAP_EXTENT_UNKNOWN | FIEMAP_EXTENT_LAST). Using == only
matches when fe_flags is exactly that single flag value, missing
extents that have additional flags set. Use bitwise & to correctly
test whether a specific flag is present.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

* Fix probeFiemap to detect unreliable fiemap on tmpfs and overlayfs

The probe used an empty file, which falsely succeeds on tmpfs (ioctl
returns 0 with no extents instead of failing). On overlayfs, fiemap
returns extents with FIEMAP_EXTENT_UNKNOWN that queryRefillRange
skips, making the fiemap path useless.

Write data before probing and verify that fiemap returns usable
extents (non-zero count, no UNKNOWN flag). When detection fails,
fall back to in-memory range tracking via RangeModule.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

* ci: add ext4 loopback mount for fiemap tests

The CI container uses overlayfs which does not support reliable fiemap.
Mount a 256MB ext4 loopback at /root/tmp so cache_test exercises both
the fiemap path (ext4) and the RangeModule fallback path (tmpfs).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

* probeFiemap: default fiemapSupported_ to false, set true only after all checks pass

Address review feedback: invert the probe logic so fiemapSupported_ starts
false and is only set true at the end of probeFiemap() if no issues are found.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

* Resolve cherry-pick conflict: drop gcc13/gcc14 jobs not present on release/0.9

The backport cherry-pick brought gcc13/gcc14 CI jobs from main, but
release/0.9 only has gcc8.5 through gcc12. Remove the conflicting
gcc13/gcc14 job definitions since they don't belong on this branch.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---------

Co-authored-by: Xiaoyang Lu <luxiaoyang.lxy@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Co-authored-by: zhenjiaseu <zhenjiaseu@gmail.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.