### PR TITLE
[Backport][0.8 to 0.7] | Fix Timer thread leak, ~Timer hang, and thread-key constant (#1290) (#1476) (#1483)

### DIFF
--- a/thread/thread-key.cpp
+++ b/thread/thread-key.cpp
@@ -177,7 +177,7 @@ void deallocate_tls(void** tls_) {
                         thread_keys[idx].dtor(data);
                 }
             } else {
-                idx += THREAD_KEY_1STLEVEL_SIZE;
+                idx += THREAD_KEY_2NDLEVEL_SIZE;
             }
         }
         if (!tls->specific_used) {

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1486,7 +1486,6 @@ R"(
             if (!timeout)
                 timeout = _default_timeout;
         } while(_repeating);
-        _th = nullptr;
     }
     void* Timer::_stub(void* _this)
     {

--- a/thread/timer.h
+++ b/thread/timer.h
@@ -74,7 +74,6 @@ namespace photon
         ~Timer()
         {
             if (!_th) return;
-            stop();
             _repeating = false;
             if (_waiting)
                 thread_interrupt(_th, ECANCELED);


### PR DESCRIPTION
> Fix Timer thread leak, ~Timer hang, and thread-key constant (#1290) (#1476) (#1483)

* Fix timer thread leak, stop() hang, and thread-key constant



* Fix Timer.OneShot hang: drop stop() from ~Timer

After removing the stub's _th=nullptr (the leak fix), ~Timer no longer short-circuits at if(!_th) return, so it runs stop() first. For an already-fired one-shot the stub thread has exited, so _waiting stays false and it never notifies _wait_ready again; stop()'s while(cancel()) _wait_ready.wait_no_lock() then blocks forever (lost wakeup) -> Timer.OneShot 3600s hang. The destructor's own _repeating=false + interrupt(ECANCELED) + join already tears the stub down (and joins the DONE one-shot immediately, fixing the leak), so stop() is redundant and harmful here.



---------

Co-authored-by: Jiangtian Feng <fengjiangtian.fjt@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.