### PR TITLE
Fix thread_migrate TOCTOU race and work-stealing sleepq dangling ref

### DIFF
--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -2003,6 +2003,10 @@ insert_list:
             if ((possibly_running && th->state == states::RUNNING) ||
                                     !th->allow_work_stealing()) {
                 th = th->next();
+            } else if (th->idx != -1) {
+                // thread still referenced in source vCPU's sleepq; skip to
+                // avoid corrupting the heap structure after stealing.
+                th = th->next();
             } else {
                 auto next = th->remove_from_list();
                 stolen.push_back(th); count++;
@@ -2154,7 +2158,7 @@ insert_list:
         assert(vb != th->vcpu);
         AtomicRunQ arq;
         SCOPED_LOCK(th->lock);
-        if (th->state != READY) {
+        if (th->state != READY || th->vcpu != CURRENT->vcpu) {
             LOG_ERROR_RETURN(EINVAL, -1,
                 "thread ` state changed during migrate", th)
         }

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -2152,7 +2152,13 @@ insert_list:
     }
     static int do_thread_migrate(thread* th, vcpu_base* vb) {
         assert(vb != th->vcpu);
-        AtomicRunQ().remove_from_list(th);
+        AtomicRunQ arq;
+        SCOPED_LOCK(th->lock);
+        if (th->state != READY) {
+            LOG_ERROR_RETURN(EINVAL, -1,
+                "thread ` state changed during migrate", th)
+        }
+        arq.remove_from_list(th);
         th->get_vcpu()->nthreads--;
         th->state = STANDBY;
         auto vcpu = (vcpu_t*)vb;

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -2004,9 +2004,11 @@ insert_list:
                                     !th->allow_work_stealing()) {
                 th = th->next();
             } else if (th->idx != -1) {
-                // thread still referenced in source vCPU's sleepq; skip to
-                // avoid corrupting the heap structure after stealing.
+                // sleeping threads interrupted by another vCPU are inserted to  
+                // standby q without poping from sleeping q, they can not be stolen.
                 th = th->next();
+                // note that migrated threads are also inserted to standby q, but
+                // they are not in a sleeping q, so they are able to be stolen.
             } else {
                 auto next = th->remove_from_list();
                 stolen.push_back(th); count++;


### PR DESCRIPTION
Two fixes for thread scheduling races:

1. **thread_migrate TOCTOU** (#1295): Move `SCOPED_LOCK(th->lock)` + state re-check into `do_thread_migrate()` after acquiring `runq_lock` (via `AtomicRunQ`), ensuring lock order consistency with work-stealing path (runq_lock → th->lock).

2. **work-stealing sleepq dangling ref** (#1294): Skip threads with `th->idx != -1` in `ws_scan_q()` to avoid stealing threads still referenced in the source vCPU sleepq.

Closes #1295, closes #1294