### PR TITLE
[Pick][0.9 to main] | [Backport][main to 0.9] | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490) 

### DIFF
--- a/common/test/test_alog.cpp
+++ b/common/test/test_alog.cpp
@@ -623,6 +623,7 @@ TEST(ALOG, signed_zero) {
     EXPECT_STREQ("0", log_output_test.log_start());
 }
 
+<<<<<<< HEAD
 TEST(ALOG, log_with_color) {
     LOG_DEBUG("some debug log");
     LOG_INFO("some info log");
@@ -642,6 +643,8 @@ TEST(ALOG, log_with_color) {
     default_logger.log_output->preset_color();
 }
 
+=======
+>>>>>>> f87ed24 ([Backport][main to 0.9] | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490))
 // Regression: width specifier exceeding buffer space caused ALogBuffer::size
 // underflow, leading to stack buffer overflow in subsequent writes.
 TEST(ALog, integer_width_overflow) {


### PR DESCRIPTION
> [Backport][main to 0.9] | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490)

* fix(alog): clamp integer width/padding to prevent buffer overflow (#1485)

move_and_fill and insert_commas had no bounds check against the buffer
end. When a width specifier (e.g. width(2) for timestamps, width(16)
for pointer hex) exceeded remaining buffer space, ptr would advance
past the buffer end, causing ALogBuffer::size (uint32_t) to underflow
to ~4GB. Subsequent put() calls then wrote freely past the buffer,
corrupting the stack.

Fix:
- Pre-clamp width to buf.size before calling move_and_fill
- Pre-check if commas fit in remaining space; skip if not enough room
- ALogBuffer::consume clamps n >= size to prevent underflow

This approach calculates buffer requirements upfront rather than
checking incrementally during integer formatting, making the code
cleaner and easier to reason about.

Add regression test ALog.integer_width_overflow. Verified with ASAN.

* Update test_alog.cpp

* Update test_alog.cpp

* Update test_alog.cpp

---------

Co-authored-by: 陶汀 <zhouchuan.tt@alibaba-inc.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Auto PR, by cherry-pick related commits