### PR TITLE
fix(tls): leak BIO_METHOD singleton to avoid use-after-free at exit

### DIFF
--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -392,12 +392,8 @@ public:
 
 #endif
 
-    struct BIOMethodDeleter {
-        void operator()(BIO_METHOD* ptr) { BIO_meth_free(ptr); }
-    };
-
     static BIO_METHOD* BIO_s_sockstream() {
-        static std::unique_ptr<BIO_METHOD, BIOMethodDeleter> meth([] {
+        static BIO_METHOD* const meth = [] {
             auto m = BIO_meth_new(BIO_TYPE_SOURCE_SINK, "BIO_PHOTON_SOCKSTREAM");
             BIO_meth_set_write(m, &TLSSocketStream::ssbio_bwrite);
             BIO_meth_set_read(m, &TLSSocketStream::ssbio_bread);
@@ -406,8 +402,8 @@ public:
             BIO_meth_set_create(m, &TLSSocketStream::ssbio_create);
             BIO_meth_set_destroy(m, &TLSSocketStream::ssbio_destroy);
             return m;
-        }());
-        return meth.get();
+        }();
+        return meth;
     }
 
     static ISocketStream* get_bio_sockstream(BIO* b) {


### PR DESCRIPTION
## Fix TLS BIO_METHOD use-after-free during process exit

### Summary

Replace `unique_ptr<BIO_METHOD>` with an intentionally-leaked raw pointer in `BIO_s_sockstream()`, preventing SIGSEGV when worker threads call `SSL_shutdown()` after `__cxa_finalize` has already freed the singleton.

### Changes

- Remove `BIOMethodDeleter` struct
- Change `static std::unique_ptr<BIO_METHOD, BIOMethodDeleter>` to `static BIO_METHOD* const` (intentional leak, ~64 bytes, reclaimed by OS at exit)

Closes #1502