### PR TITLE
[Backport][main to 0.9] | Fix nullptr crash in eviction when cache directory is externally deleted (#1498)

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -195,8 +195,8 @@ int FileCachePool::evict(std::string_view filename) {
     lru_.mark_key_cleared(lruEntry->lruIter);
   }
   int err = 0;
-  {
-    auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+  auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+  if (cacheStore) {
     DEFER(cacheStore->release());
     photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
     err = cacheStore->evict(0);
@@ -330,8 +330,9 @@ void FileCachePool::eviction() {
         continue;
     }
 
-    {
-      auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
+    int err = 0;
+    auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
+    if (cacheStore) {
       DEFER(cacheStore->release());
       photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
       err = cacheStore->evict(0);

--- a/fs/cache/full_file_cache/quota_pool.cpp
+++ b/fs/cache/full_file_cache/quota_pool.cpp
@@ -201,15 +201,17 @@ int QuotaFilePool::evict(std::string_view filename) {
     return 0;
   }
   const auto& filePath = fileIter->first;
-  int err;
   auto lruEntry = static_cast<QuotaLruEntry*>(fileIter->second.get());
 
+  int err = 0;
   {
     auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
-    DEFER(cacheStore->release());
-    photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
-    lru.mark_key_cleared(lruEntry->QuotaLruIter);
-    err = cacheStore->evict(0);
+    if (cacheStore) {
+      DEFER(cacheStore->release());
+      photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
+      lru.mark_key_cleared(lruEntry->QuotaLruIter);
+      err = cacheStore->evict(0);
+    }
     if (err) {
       ERRNO e;
       LOG_ERROR("truncate(0) failed, name : `, ret : `, error code : `", filePath, err, ERRNO());
@@ -244,12 +246,12 @@ void QuotaFilePool::dirEviction() {
       auto fileIter = dir->lru.back();
       const auto& fileName = fileIter->first;
       auto lruEntry = static_cast<QuotaLruEntry*>(fileIter->second.get());
-      int err;
+      int err = 0;
       bool flags_dir_delete = false;
 
       auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
-      DEFER(cacheStore->release());
-      {
+      if (cacheStore) {
+        DEFER(cacheStore->release());
         photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
         if (lruEntry->openCount==0){
           dir->lru.mark_key_cleared(lruEntry->QuotaLruIter);

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -1344,6 +1344,50 @@ TEST(CachePool, refill_range_non_aligned_tail) {
   refillRangeNonAlignedTail(false);
 }
 
+TEST(CachePool, eviction_with_deleted_cache_dir) {
+  std::string root = "/tmp/ease/cache/evict_dir_deleted/";
+  SetupTestDir(root);
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  // capacity=1GB (waterMark≈900MB, riskMark≈950MB), short store TTL (1ms)
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 100 * 1000 * 1000, 128ull * 1024 * 1024, cacheAllocator, 0, nullptr, 1000);
+  auto cachePool = roCachedFs->get_pool();
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  const size_t fileSize = 100 * 1024 * 1024;
+  IOVector buffer(*cacheAllocator);
+  buffer.push_back(fileSize);
+
+  // Phase 1: write 600MB (below riskMark, no eviction yet)
+  for (int i = 0; i < 6; i++) {
+    std::string name = "/file_" + std::to_string(i);
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    store->release();
+  }
+
+  // Wait for first batch stores to expire from ObjectCache
+  photon::thread_usleep(100 * 1000);
+
+  // Externally delete all cached files
+  std::string cmd = "rm -rf " + root + "*";
+  ASSERT_NE(-1, system(cmd.c_str()));
+
+  // Phase 2: keep writing — totalUsed_ will exceed riskMark (~950MB),
+  // updateSpace triggers eviction which tries to open the deleted files.
+  // Must not crash.
+  for (int i = 6; i < 12; i++) {
+    std::string name = "/file_" + std::to_string(i);
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    store->release();
+  }
+}
+
 }
 }
 int main(int argc, char** argv) {


### PR DESCRIPTION
> Fix nullptr crash in eviction when cache directory is externally deleted (#1498)

* Fix nullptr crash in eviction when cache directory is externally deleted

When the cache directory is deleted while the cache pool is running,
open() returns nullptr during eviction. The code dereferences it without
a null check, causing a SIGSEGV. Add null checks in both evict(filename)
and the timer-driven eviction loop.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

* Fix same nullptr crash in QuotaFilePool eviction paths

Apply the same null check for open() return value in
QuotaFilePool::evict() and QuotaFilePool::dirEviction(),
which have the identical bug as FileCachePool.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.