### PR TITLE
[Backport][0.8 to 0.7] | | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490) (#1500)

### DIFF
--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -143,7 +143,10 @@ void LogFormatter::put_integer_hbo(ALogBuffer& buf, ALogInteger X)
 
     std::reverse(begin, buf.ptr);
     auto ptr = buf.ptr;
-    move_and_fill(begin, ptr, X.width(), X.padding());
+    // Pre-clamp width to remaining buffer space
+    uint64_t width = X.width();
+    if (width > buf.size) width = buf.size;
+    move_and_fill(begin, ptr, width, X.padding());
     if (ptr > buf.ptr) {
         buf.size -= (ptr - buf.ptr);
         buf.ptr = ptr;
@@ -195,8 +198,18 @@ void LogFormatter::put_integer_dec(ALogBuffer& buf, ALogInteger x)
 
     std::reverse(begin, buf.ptr);
     auto ptr = buf.ptr;
-    if (x.comma()) insert_commas(ptr, ndigits);
-    move_and_fill(begin, ptr, x.width(), x.padding());
+    // Pre-clamp width to remaining buffer space
+    uint64_t width = x.width();
+    if (width > buf.size) width = buf.size;
+    // Check if commas fit; skip if not enough room after width
+    if (x.comma()) {
+        auto ncomma = (ndigits - 1) / 3;
+        auto used = ptr - begin;
+        if (used + ncomma + width <= buf.size) {
+            insert_commas(ptr, ndigits);
+        }
+    }
+    move_and_fill(begin, ptr, width, x.padding());
     if (ptr > buf.ptr) {
         buf.size -= (ptr - buf.ptr);
         buf.ptr = ptr;

--- a/common/alog.h
+++ b/common/alog.h
@@ -189,8 +189,21 @@ struct ALogBuffer
     int level;
     char* ptr;
     uint32_t size;
+<<<<<<< HEAD
     uint32_t reserved;
     void consume(size_t n) { ptr += n; size -= n; }
+=======
+    uint32_t level;
+    void consume(size_t n) {
+        if (n >= size) {
+            ptr += size;
+            size = 0;
+        } else {
+            ptr += n;
+            size -= n;
+        }
+    }
+>>>>>>> aa7abe2 ([Backport][main to 0.9] | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490) (#1500))
 };
 
 #define ALOG_DEBUG 0

--- a/common/alog.h
+++ b/common/alog.h
@@ -189,11 +189,7 @@ struct ALogBuffer
     int level;
     char* ptr;
     uint32_t size;
-<<<<<<< HEAD
     uint32_t reserved;
-    void consume(size_t n) { ptr += n; size -= n; }
-=======
-    uint32_t level;
     void consume(size_t n) {
         if (n >= size) {
             ptr += size;
@@ -203,7 +199,6 @@ struct ALogBuffer
             size -= n;
         }
     }
->>>>>>> aa7abe2 ([Backport][main to 0.9] | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490) (#1500))
 };
 
 #define ALOG_DEBUG 0

--- a/common/test/test_alog.cpp
+++ b/common/test/test_alog.cpp
@@ -574,6 +574,44 @@ TEST(ALOG, IPAddr) {
     EXPECT_STREQ("abcd:1111:222:33:4:5:6:7", log_output_test.log_start());
 }
 
+<<<<<<< HEAD
+=======
+TEST(ALOG, signed_zero) {
+    log_output = &log_output_test;
+    DEFER(log_output = log_output_stdout);
+
+    LOG_INFO(DEC(0));
+    EXPECT_STREQ("0", log_output_test.log_start());
+}
+
+// Regression: width specifier exceeding buffer space caused ALogBuffer::size
+// underflow, leading to stack buffer overflow in subsequent writes.
+TEST(ALog, integer_width_overflow) {
+    char small_buf[16];
+    LogBuffer log(small_buf, sizeof(small_buf), &log_output_test);
+
+    log << DEC(6).width(2).padding('0');
+
+    log.printf(ALogString("FFFFFFFFFFFF", 12));
+    log << DEC(7).width(2).padding('0');
+
+    // Width(16) > buf.size — directly tests boundary clamping
+    char small_buf2[8];
+    LogBuffer log2(small_buf2, sizeof(small_buf2), &log_output_test);
+    void* p = (void*)0x1234567890ABCDEFull;
+    log2 << p;
+
+    // Timestamp-style sequence with near-full buffer
+    char small_buf3[32];
+    LogBuffer log3(small_buf3, sizeof(small_buf3), &log_output_test);
+    log3.printf(ALogString("ABCDEFGHIJKLMNOP", 16));
+    log3 << DEC(6).width(2).padding('0')
+         << DEC(19).width(2).padding('0')
+         << DEC(23).width(2).padding('0')
+         << DEC(11).width(2).padding('0');
+}
+
+>>>>>>> aa7abe2 ([Backport][main to 0.9] | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490) (#1500))
 int main(int argc, char **argv)
 {
     if (!photon::is_using_default_engine()) return 0;

--- a/common/test/test_alog.cpp
+++ b/common/test/test_alog.cpp
@@ -574,8 +574,6 @@ TEST(ALOG, IPAddr) {
     EXPECT_STREQ("abcd:1111:222:33:4:5:6:7", log_output_test.log_start());
 }
 
-<<<<<<< HEAD
-=======
 TEST(ALOG, signed_zero) {
     log_output = &log_output_test;
     DEFER(log_output = log_output_stdout);
@@ -611,7 +609,6 @@ TEST(ALog, integer_width_overflow) {
          << DEC(11).width(2).padding('0');
 }
 
->>>>>>> aa7abe2 ([Backport][main to 0.9] | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490) (#1500))
 int main(int argc, char **argv)
 {
     if (!photon::is_using_default_engine()) return 0;


### PR DESCRIPTION
> [Backport][main to 0.9] | fix(alog): clamp integer width/padding to prevent buffer overflow (#1485) (#1490) (#1500)

* fix(alog): clamp integer width/padding to prevent buffer overflow (#1485)

move_and_fill and insert_commas had no bounds check against the buffer
end. When a width specifier (e.g. width(2) for timestamps, width(16)
for pointer hex) exceeded remaining buffer space, ptr would advance
past the buffer end, causing ALogBuffer::size (uint32_t) to underflow
to ~4GB. Subsequent put() calls then wrote freely past the buffer,
corrupting the stack.

Fix:
- Pre-clamp width to buf.size before calling move_and_fill
- Pre-check if commas fit in remaining space; skip if not enough room
- ALogBuffer::consume clamps n >= size to prevent underflow

This approach calculates buffer requirements upfront rather than
checking incrementally during integer formatting, making the code
cleaner and easier to reason about.

Add regression test ALog.integer_width_overflow. Verified with ASAN.

* Update test_alog.cpp

* Update test_alog.cpp

* Update test_alog.cpp

---------

Co-authored-by: 陶汀 <zhouchuan.tt@alibaba-inc.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.