### PR TITLE
[Pick][0.9 to main] | [Backport][main to 0.9] | ci: harden backport autopr with bugfix label gate, conflict handling, and CI skip (#1410) (#1471) 

### DIFF
--- a/common/checksum/crc.cpp
+++ b/common/checksum/crc.cpp
@@ -206,13 +206,23 @@ inline __attribute__((always_inline)) uint32_t crc32c(uint32_t crc, uint64_t dat
 }
 
 #elif defined(__aarch64__)
+<<<<<<< HEAD
 #include "mm_intrin_neon.h"
+=======
+>>>>>>> a15941b ([Backport][main to 0.9] | ci: harden backport autopr with bugfix label gate, conflict handling, and CI skip (#1410) (#1471))
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("aes,crc"))), apply_to=function)
 #else // __GNUC__
 #pragma GCC push_options
 #pragma GCC target ("+crc+crypto")
+<<<<<<< HEAD
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
+=======
+#endif
+#if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ < 10)
+#undef __GNUC__
+#define __GNUC__ 10
+>>>>>>> a15941b ([Backport][main to 0.9] | ci: harden backport autopr with bugfix label gate, conflict handling, and CI skip (#1410) (#1471))
 #endif
 
 // CRC32C hardware instructions for ARM
@@ -752,6 +762,15 @@ uint64_t crc64ecma_hw_avx512(const uint8_t *buf, size_t len, uint64_t crc) {
 #pragma GCC pop_options
 #endif
 #endif  // __x86_64__
+
+// Pop aarch64 target options pushed at the beginning of the SIMD section
+#ifdef __aarch64__
+#ifdef __clang__
+#pragma clang attribute pop
+#else // __GNUC__
+#pragma GCC pop_options
+#endif
+#endif
 
 uint64_t crc64ecma_hw(const uint8_t *buffer, size_t nbytes, uint64_t crc) {
     return crc64ecma_auto(buffer, nbytes, crc);


### PR DESCRIPTION
> [Backport][main to 0.9] | ci: harden backport autopr with bugfix label gate, conflict handling, and CI skip (#1410) (#1471)

* ci: harden backport autopr with bugfix label gate, conflict handling, and CI skip (#1410)

- Replace commit message parsing with GitHub API (listPullRequestsAssociatedWithCommit)
  to reliably detect source PR head ref regardless of merge strategy (rebase/squash/merge)
- Add bugfix label gate: only backport commits from PRs with 'bugfix' label
- Cherry-pick conflict handling: mark conflicts, create draft PR with 'needs-manual-merge' label
- Auto-drop new files introduced by cherry-pick that don't exist in target branch
- Add 'bugfix' label to created backport PRs for consistency
- CI workflows skip jobs on PRs with 'needs-manual-merge' label to avoid wasting runners
- Support 'unlabeled' event to re-trigger CI after label removal without empty commits
- Symmetric fix for auto-pr-precise.yml using same API-based detection

* resolve conflicts

* Update ci.linux.x86_64.yml

0.9 do not test with GCC13/14

* fix(arm): add explicit +crc+crypto target for aarch64 SIMD section

GCC 9 cannot correctly detect crypto features via -march=native on
newer ARM CPUs (e.g. Graviton3/4) used by GitHub-hosted ubuntu-24.04-arm
runners. This causes vmull_p64 (PMULL) and CRC32 instructions to fail
compilation when MinSizeRel build type sets -march=native, which
prevents the fallback -mcpu=generic+crc+crypto+lse from being applied.

Add #pragma GCC target ("+crc+crypto") (and equivalent clang attribute)
to explicitly enable these extensions at the function level, matching
the approach already used on the main branch.

---------

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits