### PR TITLE
[Backport][0.7 to 0.6] | fix(tls): leak BIO_METHOD singleton to avoid use-after-free at exit (#1503) (#1510) (#1513) (#1517)

### DIFF
--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -258,12 +258,8 @@ public:
 
 #endif
 
-    struct BIOMethodDeleter {
-        void operator()(BIO_METHOD* ptr) { BIO_meth_free(ptr); }
-    };
-
     static BIO_METHOD* BIO_s_sockstream() {
-        static std::unique_ptr<BIO_METHOD, BIOMethodDeleter> meth([] {
+        static BIO_METHOD* const meth = [] {
             auto m = BIO_meth_new(BIO_TYPE_SOURCE_SINK, "BIO_PHOTON_SOCKSTREAM");
             BIO_meth_set_write(m, &TLSSocketStream::ssbio_bwrite);
             BIO_meth_set_read(m, &TLSSocketStream::ssbio_bread);
@@ -272,8 +268,8 @@ public:
             BIO_meth_set_create(m, &TLSSocketStream::ssbio_create);
             BIO_meth_set_destroy(m, &TLSSocketStream::ssbio_destroy);
             return m;
-        }());
-        return meth.get();
+        }();
+        return meth;
     }
 
     static ISocketStream* get_bio_sockstream(BIO* b) {


### PR DESCRIPTION
> fix(tls): leak BIO_METHOD singleton to avoid use-after-free at exit (#1503) (#1510) (#1513) (#1517)

Signed-off-by: yuchen.cc <yuchen.cc@alibaba-inc.com>
Co-authored-by: Chen Chen <91253032+yuchen0cc@users.noreply.github.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.