### PR TITLE
Add ARC runner image for scalable runner sets on ACS cluster

### DIFF
--- a/.github/workflows/images/arc-runner/Dockerfile
+++ b/.github/workflows/images/arc-runner/Dockerfile
@@ -1,0 +1,69 @@
+# ARC (Actions Runner Controller) runner image for scalable runner sets.
+# Based on photon-ut-base which contains all build/test dependencies.
+#
+# Usage:
+#   docker build --build-arg RUNNER_VERSION=2.323.0 \
+#                --build-arg RUNNER_CONTAINER_HOOKS_VERSION=0.7.0 \
+#                -t photon-arc-runner .
+
+ARG BASE_IMAGE=ghcr.io/alibaba/photon-ut-base:latest
+FROM ${BASE_IMAGE}
+
+# Runner release versions - update as needed
+# https://github.com/actions/runner/releases
+ARG RUNNER_VERSION=2.323.0
+# https://github.com/actions/runner-container-hooks/releases
+ARG RUNNER_CONTAINER_HOOKS_VERSION=0.7.0
+
+# Map Docker platform to runner arch
+ARG TARGETARCH
+RUN RUNNER_ARCH="" && \
+    if [ "${TARGETARCH}" = "amd64" ]; then RUNNER_ARCH="x64"; \
+    elif [ "${TARGETARCH}" = "arm64" ]; then RUNNER_ARCH="arm64"; \
+    else echo "Unsupported arch: ${TARGETARCH}" && exit 1; fi && \
+    echo "RUNNER_ARCH=${RUNNER_ARCH}" > /tmp/runner_arch.env
+
+# ARC environment variables
+ENV RUNNER_MANUALLY_TRAP_SIG=1
+ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
+
+# Install additional packages needed by the runner
+RUN dnf install -y icu libicu dotnet-runtime-8.0 && \
+    dnf clean all && rm -rf /var/cache/yum || \
+    # Fallback: install only icu if dotnet repo is unavailable
+    (dnf install -y icu libicu && dnf clean all && rm -rf /var/cache/yum)
+
+# Create runner user with UID 1001
+RUN useradd -m -u 1001 -s /bin/bash runner && \
+    echo "runner ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+WORKDIR /home/runner
+
+# Install runner binary
+RUN source /tmp/runner_arch.env && \
+    curl -fL -o runner.tar.gz \
+        "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz" && \
+    tar xzf runner.tar.gz && \
+    rm runner.tar.gz && \
+    # Install runner dependencies
+    ./bin/installdependencies.sh || true
+
+# Install runner container hooks (for Kubernetes mode)
+RUN source /tmp/runner_arch.env && \
+    curl -fL -o runner-container-hooks.zip \
+        "https://github.com/actions/runner-container-hooks/releases/download/v${RUNNER_CONTAINER_HOOKS_VERSION}/actions-runner-hooks-k8s-${RUNNER_CONTAINER_HOOKS_VERSION}.zip" && \
+    unzip runner-container-hooks.zip -d ./k8s && \
+    rm runner-container-hooks.zip
+
+# Clean up temp file
+RUN rm -f /tmp/runner_arch.env
+
+# Ensure runner user owns the working directory
+RUN chown -R runner:runner /home/runner
+
+# Retain LD_LIBRARY_PATH from base image
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/usr/lib:/usr/lib64:/lib:/lib64
+
+USER runner
+
+ENTRYPOINT ["/home/runner/run.sh"]

--- a/.github/workflows/ut-image-arc-runner.yml
+++ b/.github/workflows/ut-image-arc-runner.yml
@@ -1,0 +1,61 @@
+name: Build ARC runner image
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_version:
+        description: 'GitHub Actions Runner version (e.g. 2.323.0)'
+        required: false
+        default: '2.323.0'
+      runner_hooks_version:
+        description: 'Runner container hooks version (e.g. 0.7.0)'
+        required: false
+        default: '0.7.0'
+      reason:
+        description: 'Why ?'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: photon-arc-runner
+
+jobs:
+  ghcr_build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/workflows/images/arc-runner
+          push: true
+          build-args: |
+            RUNNER_VERSION=${{ inputs.runner_version }}
+            RUNNER_CONTAINER_HOOKS_VERSION=${{ inputs.runner_hooks_version }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:v${{ inputs.runner_version }}
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Add a custom runner image and build workflow for deploying GitHub Actions self-hosted runners via Actions Runner Controller (ARC) on ACS (Azure Container Services) Kubernetes clusters.

## Changes

- **`.github/workflows/images/arc-runner/Dockerfile`**: A new Dockerfile that layers the GitHub Actions runner binary and Kubernetes container hooks on top of `photon-ut-base`. Key features:
  - Multi-arch support (amd64 / arm64)
  - Inherits all build & test dependencies from the base image
  - Configurable runner version via build args
  - Non-root `runner` user (UID 1001) with sudo access
  - Proper ARC environment variables (`RUNNER_MANUALLY_TRAP_SIG`, `ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT`)

- **`.github/workflows/ut-image-arc-runner.yml`**: A `workflow_dispatch` workflow that builds and pushes the image to `ghcr.io/<owner>/photon-arc-runner` with version and `latest` tags.

## Motivation

Current CI uses GitHub-hosted runners with a container image. To enable elastic scaling on a self-managed ACS/K8s cluster (via ARC runner scale sets), we need a runner image that combines our existing build environment with the Actions runner runtime.

## References

- [ARC: Creating your own runner image](https://docs.github.com/en/actions/concepts/runners/actions-runner-controller#creating-your-own-runner-image)
- [GitHub Actions Runner releases](https://github.com/actions/runner/releases)
- [Runner container hooks](https://github.com/actions/runner-container-hooks/releases)