### PR TITLE
fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -231,13 +231,10 @@ void FileCachePool::updateLru(FileNameMap::iterator iter) {
 }
 
 //  currently, we exist duplicate pwrite
-uint64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
+int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
   auto lruEntry = iter->second.get();
-  uint64_t diff = 0;
-  if (size > lruEntry->size) {
-    diff = size - lruEntry->size;
-    totalUsed_ += diff;
-  }
+  auto diff = static_cast<int64_t>(size) - static_cast<int64_t>(lruEntry->size);
+  totalUsed_ += diff;  
   lruEntry->size = size;
   if (totalUsed_ >= riskMark_) {
     LOG_WARN("pwrite is so heavy, totalUsed:`,riskMark:` || lruEntry->size = `",totalUsed_, riskMark_, lruEntry->size);
@@ -312,6 +309,7 @@ void FileCachePool::eviction() {
     LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
   }
 
+  uint64_t empty_files_sequence = 0;
   while (actualEvict > 0 && !lru_.empty() && !exit_) {
     auto fileIter = lru_.back();
     const auto& fileName = fileIter->first;
@@ -327,9 +325,17 @@ void FileCachePool::eviction() {
         if (0 == fileIter->second->openCount) {
             afterFtrucate(fileIter);
         }
+        empty_files_sequence++;
+        if (empty_files_sequence == lru_.size()) {
+          LOG_ERROR("eviction: all ` LRU entries have size=0 with openCount>0, "
+            "cannot make progress. actualEvict=`, totalUsed=`",
+            lru_.size(), actualEvict, totalUsed_);
+          break;
+        }
         continue;
     }
 
+    empty_files_sequence = 0;
     int err = 0;
     auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
     if (cacheStore) {

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -324,13 +324,14 @@ void FileCachePool::eviction() {
     if (0 == fileSize) {
         if (0 == fileIter->second->openCount) {
             afterFtrucate(fileIter);
-        }
-        empty_files_sequence++;
-        if (empty_files_sequence == lru_.size()) {
-          LOG_ERROR("eviction: all ` LRU entries have size=0 with openCount>0, "
-            "cannot make progress. actualEvict=`, totalUsed=`",
-            lru_.size(), actualEvict, totalUsed_);
-          break;
+        } else {
+          empty_files_sequence++;
+          if (empty_files_sequence == lru_.size()) {
+            LOG_ERROR("eviction: all ` LRU entries have size=0 with openCount>0, "
+              "cannot make progress. actualEvict=`, totalUsed=`",
+              lru_.size(), actualEvict, totalUsed_);
+            break;
+          }
         }
         continue;
     }

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -117,7 +117,7 @@ public:
     void removeOpenFile(FileNameMap::iterator iter);
     void forceRecycle();
     void updateLru(FileNameMap::iterator iter);
-    uint64_t updateSpace(FileNameMap::iterator iter, uint64_t size);
+    int64_t updateSpace(FileNameMap::iterator iter, uint64_t size);
 
     // True if the media filesystem supports fiemap. Decided once at Init()
     // time by probing a named file. When false, FileCacheStore tracks filled

--- a/fs/cache/full_file_cache/quota_pool.cpp
+++ b/fs/cache/full_file_cache/quota_pool.cpp
@@ -120,7 +120,7 @@ bool QuotaFilePool::dirSpaceIsFull(FileIterator iter) {
 }
 
 //  currently, we exist duplicate pwrite
-void QuotaFilePool::updateDirSpace(FileIterator iter, uint64_t diff) {
+void QuotaFilePool::updateDirSpace(FileIterator iter, int64_t diff) {
   auto lruEntry = static_cast<QuotaLruEntry*>(iter->second.get());
   auto& dirInfo = lruEntry->dir->second;
   dirInfo.used += diff;

--- a/fs/cache/full_file_cache/quota_pool.h
+++ b/fs/cache/full_file_cache/quota_pool.h
@@ -30,7 +30,7 @@ class QuotaFilePool : public FileCachePool {
     void updateDirLru(FileIterator iter);
 
     bool dirSpaceIsFull(FileIterator iter);
-    void updateDirSpace(FileIterator iter, uint64_t size);
+    void updateDirSpace(FileIterator iter, int64_t size);
     void updateDirQuota(FileIterator iter, size_t quota);
 
     int set_quota(std::string_view pathname, size_t quota) override;


### PR DESCRIPTION
## Summary

- **Root cause fix**: `updateSpace` now tracks both increases and decreases of `st_blocks`-based file size. Previously only increases were accumulated into `totalUsed_`, but `lruEntry->size` was unconditionally overwritten — causing permanent drift when ext4 `st_blocks` decreases (speculative preallocation reclaim under O_DIRECT/libaio).
- **Deadloop protection**: Added a safeguard in `eviction()` that detects when all remaining LRU entries have `fileSize=0` with `openCount>0` (no progress possible) and breaks out with a log error, instead of spinning the CPU at 100%.
- **QuotaFilePool alignment**: Updated `updateDirSpace` signature from `uint64_t` to `int64_t` to match the signed diff from `updateSpace`.

## Background

Under O_DIRECT, ext4 speculative preallocation can cause `st_blocks` to decrease between consecutive `fstat()` calls on the same file. The old `updateSpace` code only added to `totalUsed_` when size grew, but always overwrote `lruEntry->size` — so each `st_blocks` decrease leaked bytes into `totalUsed_` that could never be reclaimed. Once all files were truncated, eviction would loop forever trying to free the phantom bytes.

## Test plan

- [x] Existing cache unit tests pass
- [x] Verify with O_DIRECT workload that `totalUsed_` stays consistent after eviction cycles
- [x] Confirm no deadloop under stress with concurrent writes and eviction

🤖 Generated with [Claude Code](https://claude.com/claude-code)