### PR TITLE
fix(arc-runner): add missing curl and unzip dependencies

### DIFF
--- a/.github/workflows/images/arc-runner/Dockerfile
+++ b/.github/workflows/images/arc-runner/Dockerfile
@@ -28,10 +28,8 @@ ENV RUNNER_MANUALLY_TRAP_SIG=1
 ENV ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT=1
 
 # Install additional packages needed by the runner
-RUN dnf install -y icu libicu dotnet-runtime-8.0 && \
-    dnf clean all && rm -rf /var/cache/yum || \
-    # Fallback: install only icu if dotnet repo is unavailable
-    (dnf install -y icu libicu && dnf clean all && rm -rf /var/cache/yum)
+RUN dnf install -y curl unzip icu libicu && \
+    dnf clean all && rm -rf /var/cache/yum
 
 # Create runner user with UID 1001
 RUN useradd -m -u 1001 -s /bin/bash runner && \


### PR DESCRIPTION
## Summary

Fix the ARC runner image build failure caused by missing `curl` and `unzip` commands in the base image.

## Changes

- **`.github/workflows/images/arc-runner/Dockerfile`**: Explicitly install `curl` and `unzip` (along with `icu`/`libicu`) in the dependency layer. Remove the unreliable `dotnet-runtime-8.0` fallback logic since the GitHub Actions runner binary bundles its own .NET runtime.

## Motivation

The `photon-ut-base` image (AlmaLinux 8.10) does not ship `curl` or `unzip` by default. The Dockerfile uses `curl` to download the runner tarball and `unzip` to extract the container hooks archive, resulting in `exit code: 127` (command not found) during the buildx multi-platform build.

## References

- Build failure in #1525 workflow run
- https://docs.github.com/en/actions/concepts/runners/actions-runner-controller#creating-your-own-runner-image