### PR TITLE
feat(tls): add custom CA certificate support for TLSContext

### DIFF
--- a/net/http/client.h
+++ b/net/http/client.h
@@ -204,7 +204,9 @@ protected:
     std::vector<IPAddr> m_bind_ips;
 };
 
-//A Client without cookie_jar would ignore all response-header "Set-Cookies"
+// Create an HTTP client. Without cookie_jar, "Set-Cookies" headers are ignored.
+// Note: HTTP clients within the same std::thread share TLS config and connection pool.
+// Use separate std::threads for different TLS configurations.
 Client* new_http_client(ICookieJar *cookie_jar = nullptr, TLSContext *tls_ctx = nullptr);
 
 ICookieJar* new_simple_cookie_jar();

--- a/net/http/test/client_tls_test.cpp
+++ b/net/http/test/client_tls_test.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include <openssl/ssl.h>
 
+#include <thread>
+
 #include <photon/photon.h>
 #include <photon/common/alog.h>
 #include <photon/common/alog-stdstring.h>
@@ -29,6 +31,7 @@ limitations under the License.
 #include "to_url.h"
 
 #include "../../test/cert-key.cpp"
+#include "../../security-context/test/test_cert_utils.h"
 
 using namespace photon;
 
@@ -97,6 +100,140 @@ TEST(http_client, DISABLED_SNI) {
     ASSERT_EQ(0, res);
 }
 #endif
+
+// HTTP-level test: verify set_ca_cert works through the HTTP client.
+// Must run in a separate std::thread because the thread_local PooledDialer
+// caches the TLS context from previous tests; reusing it after the context
+// is freed would be a use-after-free.
+TEST(client_tls, http_with_ca_cert) {
+    // Server: TLS + HTTP, using self-signed cert
+    auto server_ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+    DEFER(delete server_ctx);
+    auto tcpserver = net::new_tls_server(server_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tcpserver);
+    tcpserver->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tcpserver->bind_v4localhost());
+    tcpserver->listen();
+
+    auto server = net::http::new_http_server();
+    DEFER(delete server);
+    server->add_handler({nullptr, &idiot_handler});
+    tcpserver->set_handler(server->get_connection_handler());
+    tcpserver->start_loop();
+
+    auto port = tcpserver->getsockname().port;
+    int client_result = -1;
+    int status_code = 0;
+    std::string test_handle;
+    photon::semaphore sem;
+
+    std::thread t([&, port] {
+        photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+        DEFER(photon::fini());
+
+        // Client: separate TLSContext, load server's cert as CA
+        auto client_ctx = net::new_tls_context();
+        DEFER(delete client_ctx);
+        if (client_ctx->set_ca_cert(cert_str) != 0) {
+            sem.signal(1);
+            return;
+        }
+
+        auto client = net::http::new_http_client(nullptr, client_ctx);
+        DEFER(delete client);
+
+        auto url = estring().appends("https://localhost:", port, "/test");
+        auto op = client->new_operation(net::http::Verb::GET, url);
+        DEFER(client->destroy_operation(op));
+        op->req.headers.range(0, 19);
+        client_result = op->call();
+        if (client_result == 0) {
+            status_code = op->resp.status_code();
+            test_handle = std::string(op->resp.headers["Test_Handle"]);
+        }
+        sem.signal(1);
+    });
+    t.detach();
+    sem.wait(1);
+
+    ASSERT_EQ(0, client_result);
+    EXPECT_EQ(200, status_code);
+    EXPECT_EQ("test", test_handle);
+}
+
+// Verify HTTP clients with different CA configs are isolated across OS threads.
+// Each client runs in its own std::thread to get an independent PooledDialer,
+// avoiding use-after-free on the thread_local dialer's cached TLS context.
+TEST(client_tls, http_client_cross_thread_isolation) {
+    auto server_ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+    DEFER(delete server_ctx);
+    auto tcpserver = net::new_tls_server(server_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete tcpserver);
+    tcpserver->timeout(1000UL * 1000);
+    ASSERT_EQ(0, tcpserver->bind_v4localhost());
+    tcpserver->listen();
+
+    auto server = net::http::new_http_server();
+    DEFER(delete server);
+    server->add_handler({nullptr, &idiot_handler});
+    tcpserver->set_handler(server->get_connection_handler());
+    tcpserver->start_loop();
+
+    auto port = tcpserver->getsockname().port;
+
+    // Client A with correct CA (separate thread for fresh PooledDialer)
+    int thread_a_result = -1;
+    int thread_a_status = 0;
+    photon::semaphore sem_a;
+    std::thread ta([&, port] {
+        photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+        DEFER(photon::fini());
+
+        auto ctx_a = net::new_tls_context();
+        DEFER(delete ctx_a);
+        ctx_a->set_ca_cert(cert_str);
+        auto client_a = net::http::new_http_client(nullptr, ctx_a);
+        DEFER(delete client_a);
+
+        auto url = estring().appends("https://127.0.0.1:", port, "/test");
+        auto op = client_a->new_operation(net::http::Verb::GET, url);
+        DEFER(client_a->destroy_operation(op));
+        op->retry = 0;
+        thread_a_result = op->call();
+        if (thread_a_result == 0)
+            thread_a_status = op->resp.status_code();
+        sem_a.signal(1);
+    });
+    ta.detach();
+    sem_a.wait(1);
+    ASSERT_EQ(0, thread_a_result);
+    EXPECT_EQ(200, thread_a_status);
+
+    // Client B with wrong CA (separate thread)
+    auto wrong_ca_pem = generate_different_self_signed_cert();
+    int thread_b_result = 0;
+    photon::semaphore sem_b;
+    std::thread tb([&, port] {
+        photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+        DEFER(photon::fini());
+
+        auto ctx_b = net::new_tls_context();
+        DEFER(delete ctx_b);
+        ctx_b->set_ca_cert(wrong_ca_pem.c_str());
+        auto client_b = net::http::new_http_client(nullptr, ctx_b);
+        DEFER(delete client_b);
+
+        auto url = estring().appends("https://127.0.0.1:", port, "/test");
+        auto op = client_b->new_operation(net::http::Verb::GET, url);
+        DEFER(client_b->destroy_operation(op));
+        op->retry = 0;
+        thread_b_result = op->call();
+        sem_b.signal(1);
+    });
+    tb.detach();
+    sem_b.wait(1);
+    EXPECT_NE(0, thread_b_result);
+}
 
 int main(int argc, char** arg) {
     LOG_DEBUG("Begin test");

--- a/net/security-context/test/test.cpp
+++ b/net/security-context/test/test.cpp
@@ -18,6 +18,10 @@ limitations under the License.
 
 #include "../../../test/gtest.h"
 
+#include <cstdio>
+#include <unistd.h>
+#include <sys/stat.h>
+
 #include <photon/net/socket.h>
 #include <photon/io/fd-events.h>
 #include <photon/thread/thread.h>
@@ -28,6 +32,7 @@ limitations under the License.
 #include <photon/net/security-context/tls-stream.h>
 
 #include "../../test/cert-key.cpp"
+#include "test_cert_utils.h"
 
 using namespace photon;
 
@@ -456,6 +461,221 @@ TEST(sni, hostname_in_client_hello) {
     EXPECT_NE(std::string::npos, g_captured_client_hello.find(kHost));
 }
 #endif
+
+// ==================== CA cert tests ====================
+
+// Server handler that tolerates TLS handshake failure (for negative tests)
+int s_handler_noassert(void*, net::ISocketStream* stream) {
+    char buf[6];
+    stream->read(buf, 6);  // may fail due to TLS handshake error, that's OK
+    sem.signal(1);
+    return 0;
+}
+
+TEST(ca_cert, pem_string) {
+    auto server_ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+    ASSERT_NE(server_ctx, nullptr);
+    DEFER(delete server_ctx);
+    DEFER(photon::wait_all());
+
+    auto server = net::new_tls_server(server_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete server);
+    ASSERT_EQ(0, server->bind_v4localhost());
+    ASSERT_EQ(0, server->listen());
+    auto ep = server->getsockname();
+    ASSERT_EQ(0, server->start_loop(false));
+    server->set_handler({s_handler, server_ctx});
+    photon::thread_yield();
+
+    // Client loads cert_str as CA
+    auto client_ctx = net::new_tls_context();
+    ASSERT_NE(client_ctx, nullptr);
+    DEFER(delete client_ctx);
+    ASSERT_EQ(0, client_ctx->set_ca_cert(cert_str));
+
+    auto client = net::new_tls_client(client_ctx, net::new_tcp_socket_client(), true);
+    DEFER(delete client);
+
+    auto stream = client->connect(ep);
+    ASSERT_NE(nullptr, stream);
+    DEFER(delete stream);
+
+    s_client_test(stream);
+}
+
+TEST(ca_cert, file_path) {
+    auto fn = "/tmp/ca-cert-test-" + std::to_string(::getpid()) + ".pem";
+    FILE* f = fopen(fn.c_str(), "w");
+    ASSERT_NE(f, nullptr);
+    fputs(cert_str, f);
+    fclose(f);
+    DEFER(unlink(fn.c_str()));
+
+    auto server_ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+    ASSERT_NE(server_ctx, nullptr);
+    DEFER(delete server_ctx);
+    DEFER(photon::wait_all());
+
+    auto server = net::new_tls_server(server_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete server);
+    ASSERT_EQ(0, server->bind_v4localhost());
+    ASSERT_EQ(0, server->listen());
+    auto ep = server->getsockname();
+    ASSERT_EQ(0, server->start_loop(false));
+    server->set_handler({s_handler, server_ctx});
+    photon::thread_yield();
+
+    auto client_ctx = net::new_tls_context();
+    ASSERT_NE(client_ctx, nullptr);
+    DEFER(delete client_ctx);
+    ASSERT_EQ(0, client_ctx->set_ca_file(fn.c_str()));
+
+    auto client = net::new_tls_client(client_ctx, net::new_tcp_socket_client(), true);
+    DEFER(delete client);
+
+    auto stream = client->connect(ep);
+    ASSERT_NE(nullptr, stream);
+    DEFER(delete stream);
+
+    s_client_test(stream);
+}
+
+TEST(ca_cert, ca_path_directory) {
+    auto dir = "/tmp/ca-path-test-" + std::to_string(::getpid());
+    mkdir(dir.c_str(), 0755);
+    DEFER(rmdir(dir.c_str()));
+
+    // Compute subject hash and place cert as {hash}.0 (OpenSSL ca_path convention)
+    auto bio = BIO_new_mem_buf((void*)cert_str, -1);
+    auto x509 = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
+    BIO_free(bio);
+    ASSERT_NE(x509, nullptr);
+    auto hash = X509_subject_name_hash(x509);
+    X509_free(x509);
+
+    char hash_name[256];
+    snprintf(hash_name, sizeof(hash_name), "%s/%08lx.0", dir.c_str(), hash);
+    FILE* f = fopen(hash_name, "w");
+    ASSERT_NE(f, nullptr);
+    fputs(cert_str, f);
+    fclose(f);
+    DEFER(unlink(hash_name));
+
+    auto server_ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+    ASSERT_NE(server_ctx, nullptr);
+    DEFER(delete server_ctx);
+    DEFER(photon::wait_all());
+
+    auto server = net::new_tls_server(server_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete server);
+    ASSERT_EQ(0, server->bind_v4localhost());
+    ASSERT_EQ(0, server->listen());
+    auto ep = server->getsockname();
+    ASSERT_EQ(0, server->start_loop(false));
+    server->set_handler({s_handler, server_ctx});
+    photon::thread_yield();
+
+    auto client_ctx = net::new_tls_context();
+    ASSERT_NE(client_ctx, nullptr);
+    DEFER(delete client_ctx);
+    ASSERT_EQ(0, client_ctx->set_ca_file(nullptr, dir.c_str()));
+
+    auto client = net::new_tls_client(client_ctx, net::new_tcp_socket_client(), true);
+    DEFER(delete client);
+
+    auto stream = client->connect(ep);
+    ASSERT_NE(nullptr, stream);
+    DEFER(delete stream);
+
+    s_client_test(stream);
+}
+
+TEST(ca_cert, verify_fail_without_ca) {
+    auto server_ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+    ASSERT_NE(server_ctx, nullptr);
+    DEFER(delete server_ctx);
+    DEFER(photon::wait_all());
+
+    auto server = net::new_tls_server(server_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete server);
+    ASSERT_EQ(0, server->bind_v4localhost());
+    ASSERT_EQ(0, server->listen());
+    auto ep = server->getsockname();
+    ASSERT_EQ(0, server->start_loop(false));
+    server->set_handler({s_handler_noassert, server_ctx});
+    photon::thread_yield();
+
+    // PEER verify enabled, but no CA loaded. Handshake should fail on first write.
+    auto client_ctx = net::new_tls_context();
+    ASSERT_NE(client_ctx, nullptr);
+    DEFER(delete client_ctx);
+    client_ctx->set_verify_mode(net::VerifyMode::PEER);
+
+    auto client = net::new_tls_client(client_ctx, net::new_tcp_socket_client(), true);
+    DEFER(delete client);
+
+    auto stream = client->connect(ep);
+    ASSERT_NE(nullptr, stream);
+    DEFER(delete stream);
+
+    char buf[] = "Hello";
+    auto ret = stream->write(buf, 6);
+    EXPECT_LT(ret, 0);
+    sem.wait(1);
+}
+
+TEST(ca_cert, verify_fail_wrong_ca) {
+    auto wrong_ca_pem = generate_different_self_signed_cert();
+    auto server_ctx = net::new_tls_context(cert_str, key_str, passphrase_str);
+    ASSERT_NE(server_ctx, nullptr);
+    DEFER(delete server_ctx);
+    DEFER(photon::wait_all());
+
+    auto server = net::new_tls_server(server_ctx, net::new_tcp_socket_server(), true);
+    DEFER(delete server);
+    ASSERT_EQ(0, server->bind_v4localhost());
+    ASSERT_EQ(0, server->listen());
+    auto ep = server->getsockname();
+    ASSERT_EQ(0, server->start_loop(false));
+    server->set_handler({s_handler_noassert, server_ctx});
+    photon::thread_yield();
+
+    // Wrong CA: set_ca_cert succeeds (valid X509), but handshake fails
+    auto client_ctx = net::new_tls_context();
+    ASSERT_NE(client_ctx, nullptr);
+    DEFER(delete client_ctx);
+    ASSERT_EQ(0, client_ctx->set_ca_cert(wrong_ca_pem.c_str()));
+
+    auto client = net::new_tls_client(client_ctx, net::new_tcp_socket_client(), true);
+    DEFER(delete client);
+
+    auto stream = client->connect(ep);
+    ASSERT_NE(nullptr, stream);
+    DEFER(delete stream);
+
+    char buf[] = "Hello";
+    auto ret = stream->write(buf, 6);
+    EXPECT_LT(ret, 0);
+    sem.wait(1);
+}
+
+TEST(ca_cert, invalid_ca_cert) {
+    auto ctx = net::new_tls_context();
+    ASSERT_NE(ctx, nullptr);
+    DEFER(delete ctx);
+
+    EXPECT_NE(0, ctx->set_ca_cert("not a valid cert"));
+    EXPECT_NE(0, ctx->set_ca_cert(""));
+}
+
+TEST(ca_cert, invalid_ca_file) {
+    auto ctx = net::new_tls_context();
+    ASSERT_NE(ctx, nullptr);
+    DEFER(delete ctx);
+
+    EXPECT_NE(0, ctx->set_ca_file("/tmp/nonexistent-ca-file.pem"));
+    EXPECT_NE(0, ctx->set_ca_file(nullptr, nullptr));
+}
 
 int main(int argc, char** arg) {
 #ifdef __linux__

--- a/net/security-context/test/test_cert_utils.h
+++ b/net/security-context/test/test_cert_utils.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/opensslv.h>
+
+// Generate a self-signed cert at runtime, different from the hardcoded test cert.
+// Used in negative tests where a valid-but-wrong CA is needed.
+inline std::string generate_different_self_signed_cert() {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000LL
+    EVP_PKEY* pkey = EVP_RSA_gen(2048);
+#else
+    EVP_PKEY* pkey = EVP_PKEY_new();
+    auto rsa = RSA_new();
+    auto bn = BN_new();
+    BN_set_word(bn, RSA_F4);
+    RSA_generate_key_ex(rsa, 2048, bn, nullptr);
+    EVP_PKEY_assign_RSA(pkey, rsa);
+    BN_free(bn);
+#endif
+
+    X509* x509 = X509_new();
+    X509_set_version(x509, 2);
+    ASN1_INTEGER_set(X509_get_serialNumber(x509), 99999);
+    X509_gmtime_adj(X509_get_notBefore(x509), 0);
+    X509_gmtime_adj(X509_get_notAfter(x509), 365 * 24 * 3600);
+    X509_set_pubkey(x509, pkey);
+
+    auto name = X509_get_subject_name(x509);
+    X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC,
+        (unsigned char*)"WrongCA", -1, -1, 0);
+    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+        (unsigned char*)"WrongCA", -1, -1, 0);
+    X509_set_issuer_name(x509, name);
+    X509_sign(x509, pkey, EVP_sha256());
+
+    BIO* bio = BIO_new(BIO_s_mem());
+    PEM_write_bio_X509(bio, x509);
+    char* data = nullptr;
+    long len = BIO_get_mem_data(bio, &data);
+    std::string result(data, len);
+    BIO_free(bio);
+    X509_free(x509);
+    EVP_PKEY_free(pkey);
+    return result;
+}

--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -18,7 +18,9 @@ limitations under the License.
 
 #include <openssl/bio.h>
 #include <openssl/err.h>
+#include <openssl/pem.h>
 #include <openssl/ssl.h>
+#include <openssl/x509.h>
 #include <photon/common/alog-stdstring.h>
 #include <photon/common/iovector.h>
 #include <photon/common/alog.h>
@@ -305,6 +307,60 @@ public:
     int set_verify_mode(VerifyMode mode) override {
         SSL_CTX_set_default_verify_paths(ctx);
         SSL_CTX_set_verify(ctx, (int)mode, nullptr);
+        return 0;
+    }
+
+    int set_ca_cert(const char* ca_cert_str) override {
+        if (!ca_cert_str)
+            LOG_ERROR_RETURN(EINVAL, -1, "ca_cert_str is nullptr");
+        char errbuf[4096];
+        auto bio = BIO_new_mem_buf((void*)ca_cert_str, -1);
+        if (!bio) {
+            LOG_ERROR_RETURN(0, -1, "Failed to create BIO for CA cert");
+        }
+        DEFER(BIO_free(bio));
+
+        auto store = SSL_CTX_get_cert_store(ctx);
+        if (!store) {
+            LOG_ERROR_RETURN(0, -1, "Failed to get cert store from SSL_CTX");
+        }
+
+        int count = 0;
+        X509* cert = nullptr;
+        while ((cert = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr)) != nullptr) {
+            if (X509_STORE_add_cert(store, cert) != 1) {
+                X509_free(cert);
+                ERR_error_string_n(ERR_get_error(), errbuf, MAX_ERRSTRING_SIZE);
+                LOG_ERROR_RETURN(0, -1, "Failed to add CA cert to store: ", errbuf);
+            }
+            X509_free(cert);
+            count++;
+        }
+
+        unsigned long err = ERR_peek_last_error();
+        if (count == 0 || (err && ERR_GET_REASON(err) != PEM_R_NO_START_LINE)) {
+            ERR_error_string_n(err, errbuf, MAX_ERRSTRING_SIZE);
+            LOG_ERROR_RETURN(0, -1, "Failed to read CA cert from PEM: ", errbuf);
+        }
+        ERR_clear_error();
+
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nullptr);
+        LOG_DEBUG("Loaded ` CA certificate(s) from PEM string", count);
+        return 0;
+    }
+
+    int set_ca_file(const char* ca_file, const char* ca_path) override {
+        char errbuf[4096];
+        if (!ca_file && !ca_path) {
+            LOG_ERROR_RETURN(EINVAL, -1, "Both ca_file and ca_path are nullptr");
+        }
+        auto ret = SSL_CTX_load_verify_locations(ctx, ca_file, ca_path);
+        if (ret != 1) {
+            ERR_error_string_n(ERR_get_error(), errbuf, MAX_ERRSTRING_SIZE);
+            LOG_ERROR_RETURN(0, -1, "Failed to load CA from file=` path=`: ", ca_file, ca_path, errbuf);
+        }
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nullptr);
+        LOG_DEBUG("Loaded CA certificates from file=` path=`", ca_file, ca_path);
         return 0;
     }
 };

--- a/net/security-context/tls-stream.h
+++ b/net/security-context/tls-stream.h
@@ -55,6 +55,8 @@ public:
     // return value must be one string_view of the vector
     virtual int set_alpn_select_cb(
         Delegate<estring_view, const std::vector<estring_view>&>) = 0;
+    virtual int set_ca_cert(const char* ca_cert_str) = 0;
+    virtual int set_ca_file(const char* ca_file, const char* ca_path = nullptr) = 0;
 };
 
 enum class TLSVersion{


### PR DESCRIPTION
Add set_ca_cert() and set_ca_file() to TLSContext, allowing each HTTP client to specify custom CA certificates for peer verification, equivalent to curl's --cacert / --capath options.

Changes:
- tls-stream.h: add set_ca_cert(const char*) and set_ca_file(const char*, const char*) pure virtual methods to TLSContext interface
- tls-stream.cpp: implement both methods using OpenSSL X509_STORE and SSL_CTX_load_verify_locations; add missing #include <openssl/pem.h>; add null check for set_ca_cert(nullptr)
- client.h: document that HTTP clients within the same std::thread share TLS config and connection pool