### PR TITLE
[Backport][main to 0.9] | fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace (#1527)

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -305,14 +305,11 @@ void FileCachePool::eviction() {
     LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
   }
 
-<<<<<<< HEAD
   // Phase 1: evict from idle tier first.
   actualEvict -= evictIdleWhenFull(actualEvict);
 
   // Phase 2: fall back to LRU eviction when idle tier is exhausted
-=======
   uint64_t empty_files_sequence = 0;
->>>>>>> 71264cf (fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace (#1527))
   while (actualEvict > 0 && !lru_.empty() && !exit_) {
     auto fileIter = lru_.back();
     const auto& fileName = fileIter->first;

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -239,13 +239,10 @@ void FileCachePool::updateLru(FileNameMap::iterator iter) {
 }
 
 //  currently, we exist duplicate pwrite
-uint64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
+int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
   auto lruEntry = iter->second.get();
-  uint64_t diff = 0;
-  if (size > lruEntry->size) {
-    diff = size - lruEntry->size;
-    totalUsed_ += diff;
-  }
+  auto diff = static_cast<int64_t>(size) - static_cast<int64_t>(lruEntry->size);
+  totalUsed_ += diff;  
   lruEntry->size = size;
   if (totalUsed_ >= riskMark_) {
     LOG_WARN("pwrite is so heavy, totalUsed:`,riskMark:` || lruEntry->size = `",totalUsed_, riskMark_, lruEntry->size);
@@ -308,10 +305,14 @@ void FileCachePool::eviction() {
     LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
   }
 
+<<<<<<< HEAD
   // Phase 1: evict from idle tier first.
   actualEvict -= evictIdleWhenFull(actualEvict);
 
   // Phase 2: fall back to LRU eviction when idle tier is exhausted
+=======
+  uint64_t empty_files_sequence = 0;
+>>>>>>> 71264cf (fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace (#1527))
   while (actualEvict > 0 && !lru_.empty() && !exit_) {
     auto fileIter = lru_.back();
     const auto& fileName = fileIter->first;
@@ -326,10 +327,19 @@ void FileCachePool::eviction() {
     if (0 == fileSize) {
         if (0 == fileIter->second->openCount) {
             afterFtrucate(fileIter);
+        } else {
+          empty_files_sequence++;
+          if (empty_files_sequence == lru_.size()) {
+            LOG_ERROR("eviction: all ` LRU entries have size=0 with openCount>0, "
+              "cannot make progress. actualEvict=`, totalUsed=`",
+              lru_.size(), actualEvict, totalUsed_);
+            break;
+          }
         }
         continue;
     }
 
+    empty_files_sequence = 0;
     int err = 0;
     auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
     if (cacheStore) {

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -76,7 +76,7 @@ public:
     void removeOpenFile(FileNameMap::iterator iter);
     void forceRecycle();
     void updateLru(FileNameMap::iterator iter);
-    uint64_t updateSpace(FileNameMap::iterator iter, uint64_t size);
+    int64_t updateSpace(FileNameMap::iterator iter, uint64_t size);
 
     // True if the media filesystem supports fiemap. Decided once at Init()
     // time by probing a named file. When false, FileCacheStore tracks filled

--- a/fs/cache/full_file_cache/quota_pool.cpp
+++ b/fs/cache/full_file_cache/quota_pool.cpp
@@ -120,7 +120,7 @@ bool QuotaFilePool::dirSpaceIsFull(FileIterator iter) {
 }
 
 //  currently, we exist duplicate pwrite
-void QuotaFilePool::updateDirSpace(FileIterator iter, uint64_t diff) {
+void QuotaFilePool::updateDirSpace(FileIterator iter, int64_t diff) {
   auto lruEntry = static_cast<QuotaLruEntry*>(iter->second.get());
   auto& dirInfo = lruEntry->dir->second;
   dirInfo.used += diff;

--- a/fs/cache/full_file_cache/quota_pool.h
+++ b/fs/cache/full_file_cache/quota_pool.h
@@ -30,7 +30,7 @@ class QuotaFilePool : public FileCachePool {
     void updateDirLru(FileIterator iter);
 
     bool dirSpaceIsFull(FileIterator iter);
-    void updateDirSpace(FileIterator iter, uint64_t size);
+    void updateDirSpace(FileIterator iter, int64_t size);
     void updateDirQuota(FileIterator iter, size_t quota);
 
     int set_quota(std::string_view pathname, size_t quota) override;


### PR DESCRIPTION
> fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace (#1527)

* fix(cache): track both increases and decreases in updateSpace to prevent totalUsed_ drift

updateSpace previously only accumulated increases (size > lruEntry->size),
but unconditionally overwrote lruEntry->size. When ext4 st_blocks decreases
(due to speculative preallocation reclaim under O_DIRECT), totalUsed_ leaks
permanently. This drift causes eviction to loop forever when all LRU entries
have fileSize=0 but totalUsed_ remains positive.

Fix: compute a signed diff and apply it unconditionally to totalUsed_.
Also add a deadloop detector in eviction that breaks out when all remaining
LRU entries are empty files with openCount>0.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

* fix(cache): only count deadloop sequence for entries that cannot be removed

afterFtrucate removes the LRU entry when openCount==0, which is actual
progress. Only increment the deadloop counter for entries with openCount>0
that truly cannot be evicted.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- 71264cf9c6a89354408ad8adb361e1eec51dfbc9: fs/cache/full_file_cache/cache_pool.cpp