### PR TITLE
[Pick][0.9 to main] | [Backport][main to 0.9] | fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace (#1527) (#1530) 

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -309,6 +309,13 @@ void FileCachePool::eviction() {
     LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
   }
 
+<<<<<<< HEAD
+=======
+  // Phase 1: evict from idle tier first.
+  actualEvict -= evictIdleWhenFull(actualEvict);
+
+  // Phase 2: fall back to LRU eviction when idle tier is exhausted
+>>>>>>> 5fc87fa ([Backport][main to 0.9] | fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace (#1527) (#1530))
   uint64_t empty_files_sequence = 0;
   while (actualEvict > 0 && !lru_.empty() && !exit_) {
     auto fileIter = lru_.back();


### PR DESCRIPTION
> [Backport][main to 0.9] | fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace (#1527) (#1530)

* fix(cache): prevent totalUsed_ drift and eviction deadloop in updateSpace (#1527)

* fix(cache): track both increases and decreases in updateSpace to prevent totalUsed_ drift

updateSpace previously only accumulated increases (size > lruEntry->size),
but unconditionally overwrote lruEntry->size. When ext4 st_blocks decreases
(due to speculative preallocation reclaim under O_DIRECT), totalUsed_ leaks
permanently. This drift causes eviction to loop forever when all LRU entries
have fileSize=0 but totalUsed_ remains positive.

Fix: compute a signed diff and apply it unconditionally to totalUsed_.
Also add a deadloop detector in eviction that breaks out when all remaining
LRU entries are empty files with openCount>0.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

* fix(cache): only count deadloop sequence for entries that cannot be removed

afterFtrucate removes the LRU entry when openCount==0, which is actual
progress. Only increment the deadloop counter for entries with openCount>0
that truly cannot be evicted.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---------

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

* resolve merge conflict in cache_pool.cpp

Keep both changes: the idle-tier eviction (Phase 1/Phase 2) from the
0.9 branch and the empty_files_sequence deadloop counter from the
backported fix (#1527).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---------

Co-authored-by: Xiaoyang Lu <luxiaoyang.lxy@alibaba-inc.com>
Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
Generated by Auto PR, by cherry-pick related commits