### PR TITLE
[Backport][main to 0.9] | fix(fs): support SEEK_DATA/SEEK_HOLE for AioFileAdaptor (#1535)

### DIFF
--- a/fs/localfs.cpp
+++ b/fs/localfs.cpp
@@ -280,6 +280,17 @@ namespace fs
         {
             return AIOEngine::fdatasync(fd);
         }
+#ifdef __linux__
+        virtual off_t lseek(off_t offset, int whence) override
+        {
+            if (whence == SEEK_DATA || whence == SEEK_HOLE) {
+                off_t ret = UISysCall(::lseek(fd, offset, whence));
+                if (ret >= 0) m_offset = ret;
+                return ret;
+            }
+            return VirtualFile::lseek(offset, whence);
+        }
+#endif
         virtual int close() override
         {
             if (fd < 0) return 0;

--- a/fs/test/test.cpp
+++ b/fs/test/test.cpp
@@ -937,6 +937,43 @@ TEST(LocalFileSystem, basic) {
     lf->fsync();
 }
 
+#ifdef __linux__
+TEST(LocalFileSystem, aio_seek_data_hole) {
+    const off_t bs = 4096;
+    const char* path = "/tmp/photon_seek_data_hole";
+    // Build a sparse file with a plain fd:
+    //   data[0, bs)  hole[bs, 2*bs)  data[2*bs, 3*bs)
+    int fd = ::open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    ASSERT_GE(fd, 0);
+    DEFER(::unlink(path));
+    std::unique_ptr<char[]> block(new char[bs]);
+    memset(block.get(), 'A', bs);
+    ASSERT_EQ(bs, ::pwrite(fd, block.get(), bs, 0));
+    ASSERT_EQ(bs, ::pwrite(fd, block.get(), bs, 2 * bs));
+    ::fsync(fd);
+
+    // Wrap the fd in an AioFileAdaptor (posixaio).
+    std::unique_ptr<IFile> f(new_localfile_adaptor(fd, ioengine_posixaio));
+    ASSERT_NE(nullptr, f.get());
+
+    // SEEK_DATA / SEEK_HOLE reach the kernel and sync the self-managed offset.
+    off_t d = f->lseek(0, SEEK_DATA);
+    EXPECT_EQ(0, d);
+    EXPECT_EQ(d, f->lseek(0, SEEK_CUR));
+
+    off_t h = f->lseek(0, SEEK_HOLE);
+    EXPECT_EQ(bs, h);
+    EXPECT_EQ(h, f->lseek(0, SEEK_CUR));
+
+    EXPECT_EQ(3 * bs, f->lseek(2 * bs, SEEK_HOLE));
+
+    // Plain whence values still follow the VirtualFile (m_offset) route.
+    EXPECT_EQ(0, f->lseek(0, SEEK_SET));
+    EXPECT_EQ(bs, f->lseek(bs, SEEK_CUR));
+    EXPECT_EQ(3 * bs, f->lseek(0, SEEK_END));
+}
+#endif // __linux__
+
 std::unique_ptr<char[]> random_block(uint64_t size) {
     std::unique_ptr<char[]> buff(new char[size]);
     char * p = buff.get();


### PR DESCRIPTION
> fix(fs): support SEEK_DATA/SEEK_HOLE for AioFileAdaptor (#1535)

Override lseek in AioFileAdaptor to handle SEEK_DATA/SEEK_HOLE by
delegating to the kernel (::lseek on the real fd) and syncing the
self-managed m_offset with the result; all other whence values keep the
VirtualFile (m_offset-based) route. Guarded by #if defined(SEEK_DATA)
&& defined(SEEK_HOLE) so platforms without these macros (e.g. iocp on
Windows) still compile.

Previously AioFileAdaptor inherited VirtualFile::lseek, which only
supports SEEK_SET/CUR/END and returned -1 for SEEK_DATA/SEEK_HOLE, so
sparse-file queries (e.g. full_file_cache) failed on aio-backed files.
PsyncFileAdaptor keeps its own kernel-offset lseek and is unaffected.

Add LocalFileSystem.aio_seek_data_hole to verify SEEK_DATA/SEEK_HOLE on
an AioFileAdaptor over a sparse file, including m_offset sync.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.