### PR TITLE
[Pick][0.9 to main] | backport compile & test (#1537) 

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+<<<<<<< HEAD
           - gcc: 9
             cxx: 14
           - gcc: 9
@@ -31,6 +32,20 @@ jobs:
             cxx: 23
           - gcc: 13
             cxx: 23
+=======
+          - gcc: 8
+            cxx: 14
+          - gcc: 9
+            cxx: 14
+          - gcc: 10
+            cxx: 17
+          - gcc: 11
+            cxx: 17
+          - gcc: 12
+            cxx: 20
+          - gcc: 13
+            cxx: 20
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
           - gcc: 14
             cxx: 23
             run_test: true
@@ -45,7 +60,13 @@ jobs:
 
       - name: Build
         run: |
+<<<<<<< HEAD
           source /opt/rh/gcc-toolset-${{ matrix.gcc }}/enable
+=======
+          if [ "${{ matrix.gcc }}" != "8" ]; then
+            source /opt/rh/gcc-toolset-${{ matrix.gcc }}/enable
+          fi
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
           cmake -B build -D CMAKE_BUILD_TYPE=MinSizeRel   \
                          -D PHOTON_CXX_STANDARD=${{ matrix.cxx }} \
                          -D PHOTON_ENABLE_ECOSYSTEM=ON    \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,10 @@ endif ()
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -g")
+<<<<<<< HEAD
 set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 -march=native")    # Only for CI test
+=======
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -106,6 +109,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-packed-bitfield-compat -fno-omit-frame-pointer")
 endif()
+<<<<<<< HEAD
 if (WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${PROJECT_SOURCE_DIR}/include -include ${PROJECT_SOURCE_DIR}/common/windows_compat.h -Wno-attributes -Wno-unused-value -Wno-array-bounds -Wno-sign-compare -Wno-narrowing -Wno-unused-variable -Wno-ignored-attributes")
 endif()
@@ -113,6 +117,15 @@ if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16")
 elseif ((CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char -fno-stack-protector -fno-omit-frame-pointer")
+=======
+
+if (${ARCH} STREQUAL x86_64)
+    set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 -march=native")    # Only for CI test
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16")
+elseif (${ARCH} STREQUAL aarch64)
+    set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 -mcpu=native")    # Only for CI test
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char -fno-stack-protector -fomit-frame-pointer")
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
     if (NOT CMAKE_BUILD_TYPE MATCHES "MinSizeRel")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=generic+crc+crypto+lse")
     endif ()

--- a/common/checksum/crc.cpp
+++ b/common/checksum/crc.cpp
@@ -671,6 +671,10 @@ uint64_t crc64ecma_trim_sw(CRC64ECMA_Component all,
 
 #ifdef __x86_64__
 #ifdef __APPLE__ // apple basically doens't support avx-512
+<<<<<<< HEAD
+=======
+#pragma clang attribute pop
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
 uint64_t crc64ecma_hw_avx512(const uint8_t *buf, size_t len, uint64_t crc) {
     return crc64ecma_hw_sse128(buf, len, crc);
 }
@@ -756,6 +760,12 @@ uint64_t crc64ecma_hw_avx512(const uint8_t *buf, size_t len, uint64_t crc) {
 #else // __GNUC__
 #pragma GCC pop_options
 #endif
+<<<<<<< HEAD
+=======
+
+#endif  // apple
+#endif  // __x86_64__
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
 
 #endif  // apple
 #endif  // __x86_64__

--- a/common/unordered_inline_set.h
+++ b/common/unordered_inline_set.h
@@ -8,7 +8,11 @@
 #include <cmath>
 #include <string.h>
 #include <utility>
+<<<<<<< HEAD
 #if __cplusplus >= 202300LL
+=======
+#if __cplusplus >= 202300L
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
 #include <concepts>
 #include <ranges>
 #endif
@@ -331,7 +335,11 @@ public:
     : unordered_inline_set(init, bucket_count,
                     hash, key_equal(), alloc) {}
 
+<<<<<<< HEAD
 #if __cplusplus >= 202300LL
+=======
+#if __cplusplus >= 202300L
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
     template<std::ranges::input_range R>
         requires std::constructible_from<value_type, std::ranges::range_reference_t<R>>
     unordered_inline_set( std::from_range_t, R&& rg,
@@ -495,7 +503,11 @@ public:
         return insert<K>(std::forward<K>(value)).first;
     }
 
+<<<<<<< HEAD
 #if __cplusplus >= 202300LL
+=======
+#if __cplusplus >= 202300L
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
     template<std::ranges::input_range R>
         requires std::constructible_from<value_type, std::ranges::range_reference_t<R>>
     void insert_range( R&& rg );

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -847,8 +847,13 @@ TEST(CachePool, test_demote_threshold) {
   }
 }
 
+<<<<<<< HEAD
 TEST(CachePool, three_tier_cascade) {
   std::string root = "/mnt/tmp/ease/cache/three_tier_cascade/";
+=======
+TEST(CachePool, evict_idle_file) {
+  std::string root = "/mnt/tmp/ease/cache/evict_idle_file/";
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
   SetupTestDir(root);
   const size_t activeLimit = 5;
   const size_t inactiveLimit = 10;
@@ -966,8 +971,13 @@ TEST(CachePool, three_tier_cascade) {
   }
 }
 
+<<<<<<< HEAD
 TEST(CachePool, evict_by_size_cold_first) {
   std::string root = "/mnt/tmp/ease/cache/evict_by_size_cold_first/";
+=======
+TEST(CachePool, evict_by_size_idle_first) {
+  std::string root = "/mnt/tmp/ease/cache/evict_by_size/";
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
   SetupTestDir(root);
   const uint64_t capacityGB = 1;
   const size_t activeLimit = 5;
@@ -1111,7 +1121,11 @@ static void refillRangeDeterministic(bool useShm) {
   std::string root = useShm
       ? "/dev/shm/ease/cache/refill_range_det/"
       : "/mnt/tmp/ease/cache/refill_range_det/";
+<<<<<<< HEAD
   if (useShm && !RequireShmAvailable(144ull * 1024 * 1024)) return;
+=======
+  if (useShm && !RequireShmAvailable(144ul * 1024 * 1024)) return;
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
   SetupTestDir(root);
   auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
   auto cacheAllocator = new AlignedAlloc(4 * 1024);
@@ -1182,7 +1196,11 @@ static void refillRangeRandom(bool useShm) {
   std::string root = useShm
       ? "/dev/shm/ease/cache/refill_range_rand/"
       : "/mnt/tmp/ease/cache/refill_range_rand/";
+<<<<<<< HEAD
   if (useShm && !RequireShmAvailable(240ull * 1024 * 1024)) return;
+=======
+  if (useShm && !RequireShmAvailable(240ul * 1024 * 1024)) return;
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
   SetupTestDir(root);
   auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
   auto cacheAllocator = new AlignedAlloc(4 * 1024);
@@ -1268,7 +1286,11 @@ static void refillRangeEvictWhileOpen(bool useShm) {
   std::string root = useShm
       ? "/dev/shm/ease/cache/refill_range_evict/"
       : "/mnt/tmp/ease/cache/refill_range_evict/";
+<<<<<<< HEAD
   if (useShm && !RequireShmAvailable(144ull * 1024 * 1024)) return;
+=======
+  if (useShm && !RequireShmAvailable(144ul * 1024 * 1024)) return;
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
   SetupTestDir(root);
   auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
   auto cacheAllocator = new AlignedAlloc(4 * 1024);
@@ -1348,7 +1370,11 @@ static void refillRangeNonAlignedTail(bool useShm) {
   std::string root = useShm
       ? "/dev/shm/ease/cache/refill_range_unaligned/"
       : "/mnt/tmp/ease/cache/refill_range_unaligned/";
+<<<<<<< HEAD
   if (useShm && !RequireShmAvailable(144ull * 1024 * 1024)) return;
+=======
+  if (useShm && !RequireShmAvailable(144ul * 1024 * 1024)) return;
+>>>>>>> 37c6bd6 (backport compile & test (#1537))
   SetupTestDir(root);
   auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
   auto cacheAllocator = new AlignedAlloc(4 * 1024);


### PR DESCRIPTION
> backport compile & test (#1537)

* simplify workflow scripts with ```matrix``` (#1515)

Co-authored-by: Coldwings <coldwings@me.com>

* using arc-acs-runner-set (#1522)

* set x86-64 standard to v2; disable avx512 code for macOS; (#1526)

* pick: fix compile warning/error in GCC 14 + C++23 (from #1101)

Cherry-pick header-only changes from 14a3e7e:
- objectcachev2.h: suppress -Wdeprecated-declarations
- unordered_inline_set.h: use standard concepts/ranges instead of compatible_range_type
- redis.h: fix estring_view cast from C-style reference to pointer

* fix

---------

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Auto PR, by cherry-pick related commits