### PR TITLE
feat(cache): trigger eviction by disk free space on the write path

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -56,6 +56,10 @@ FileCachePool::FileCachePool(IFileSystem* mediaFs, uint64_t capacityInGB,
     waterMark_ = calcWaterMark(capacityInBytes, kMaxFreeSpace);
     // keep this relation : waterMark < riskMark < capacity
     riskMark_ = std::max(capacityInBytes - kEvictionMark, (static_cast<int64_t>(waterMark_) + capacityInBytes) >> 1);
+    // Probe disk free space on the write path at most once per this many bytes
+    // written, bounding how far we may overshoot the diskAvailInBytes_ floor
+    // between probes. Never smaller than one refill unit.
+    diskCheckStepBytes_ = std::max<uint64_t>(diskAvailInBytes_ / 8, refillUnit_);
 }
 
 FileCachePool::~FileCachePool() {
@@ -234,16 +238,43 @@ void FileCachePool::updateLru(FileNameMap::iterator iter) {
 int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
   auto lruEntry = iter->second.get();
   auto diff = static_cast<int64_t>(size) - static_cast<int64_t>(lruEntry->size);
-  totalUsed_ += diff;  
+  totalUsed_ += diff;
   lruEntry->size = size;
-  if (totalUsed_ >= riskMark_) {
+  if (diff > 0) bytesSinceDiskCheck_ += diff;
+
+  bool full = totalUsed_ >= riskMark_;
+  if (full) {
     LOG_WARN("pwrite is so heavy, totalUsed:`,riskMark:` || lruEntry->size = `",totalUsed_, riskMark_, lruEntry->size);
+  } else if (diskAvailInBytes_ > 0 &&
+             (bytesSinceDiskCheck_ >= diskCheckStepBytes_ ||
+              photon::now - lastDiskCheckUs_ >= kDiskCheckIntervalUs)) {
+    // Throttled real statvfs: react to low disk free space even when our
+    // totalUsed_ is far below riskMark_.
+    lastDiskCheckUs_ = photon::now;
+    bytesSinceDiskCheck_ = 0;
+    full = diskSpaceLow();
+    if (full) {
+      LOG_WARN("disk free space below floor `, force recycle", diskAvailInBytes_);
+    }
+  }
+
+  if (full) {
     isFull_ = true;
     forceRecycle();
     if (lruEntry->size==0) diff = 0;//in some extream condition ,
                                     //forceRecycle maybe truncate current file to 0
   }
   return diff;
+}
+
+bool FileCachePool::diskSpaceLow() {
+  struct statvfs stFs = {};
+  if (mediaFs_->statvfs("/", &stFs) != 0) {
+    LOG_ERROR("statvfs failed, error code : `", ERRNO());
+    return false; // don't force eviction on a failed probe
+  }
+  uint64_t avail = static_cast<uint64_t>(stFs.f_bavail) * stFs.f_frsize;
+  return avail < diskAvailInBytes_;
 }
 
 uint64_t FileCachePool::timerHandler(void* data) {

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -135,6 +135,10 @@ protected:
     virtual void eviction();
     uint64_t calcWaterMark(uint64_t capacity, uint64_t maxFreeSpace);
 
+    // Throttled real disk-free-space probe used on the write path.
+    bool diskSpaceLow();
+    static const uint64_t kDiskCheckIntervalUs = 200'000; // 200ms
+
     photon::fs::IFileSystem *mediaFs_; //  owned by current class
     uint64_t capacityInGB_;
     uint64_t periodInUs_;
@@ -143,6 +147,11 @@ protected:
     int64_t totalUsed_;
     int64_t riskMark_;
     uint64_t waterMark_;
+
+    // Write-path disk-check throttle state.
+    uint64_t diskCheckStepBytes_ = 0; // bytes written between forced probes
+    uint64_t bytesSinceDiskCheck_ = 0;
+    uint64_t lastDiskCheckUs_ = 0;
 
     photon::Timer *timer_;
     bool running_;


### PR DESCRIPTION
## Background

`FileCachePool::updateSpace()` (the write path) previously forced recycling **only** when the logical watermark was hit (`totalUsed_ >= riskMark_`). Since `totalUsed_` accounts only for this cache's own writes:

- when the medium is shared and filled by other writers, the write path is completely unaware of it;
- a deployment that wants capacity governed by **disk free space** rather than the logical watermark only gets a reaction on the next periodic `eviction()` tick.

## Change

Add a **throttled real `statvfs` probe** to the write path, reusing the existing disk-based logic in `eviction()`:

- **Dual throttle**: probe at most once per `diskCheckStepBytes_` written (`max(diskAvailInBytes_/8, refillUnit_)`) **or** once per `kDiskCheckIntervalUs` (200ms, decided via the `photon::now`).
- Decouples `statvfs` frequency from write throughput, keeping it off the hot path on fast media such as tmpfs (where a `statvfs` percpu sum can rival a single pwrite).

## Verification

- `cache_test` (17 cases) all pass.

No targeted unit test yet (it needs a controllable media `statvfs`; testing against a real localfs would be flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)