### PR TITLE
fix(thread): re-arm sleeper when if_update_now jumps past ts_wakeup

### DIFF
--- a/thread/test/test.cpp
+++ b/thread/test/test.cpp
@@ -787,6 +787,27 @@ TEST(Sleep, sleep_only_thread) {    //Sleep_sleep_only_thread_Test::TestBody
     EXPECT_LE(dt, 3UL*1024*1024);
 }
 
+// Reproduces the stale-`now` short-sleep bug: when `now` hasn't been
+// refreshed since vcpu_init, thread_usleep(useconds) built Timeout(useconds)
+// against the stale `now`; prepare_usleep()'s if_update_now(true) then jumped
+// `now` to real time, and when the jump >= useconds the sleeper's ts_wakeup
+// landed in the past so it was woken immediately (~0us instead of ~useconds).
+// Most visible on the first short sleep after init, amplified under ASan.
+TEST(Sleep, short_sleep_with_stale_now) {
+    // Stall the vCPU 60ms via OS sleep so photon::now keeps its last value
+    // (no yield -> no if_update_now). 60ms > 50ms below, the exact condition
+    // that makes the stale path expire instantly if buggy.
+    ::usleep(60 * 1000);
+    struct timeval tv0, tv1;
+    gettimeofday(&tv0, nullptr);
+    photon::thread_usleep(50 * 1000);  // request 50ms
+    gettimeofday(&tv1, nullptr);
+    uint64_t elapsed_us = (tv1.tv_sec - tv0.tv_sec) * 1000000UL +
+                          (tv1.tv_usec - tv0.tv_usec);
+    // Must sleep at least the requested 50ms; buggy path slept ~0us.
+    EXPECT_GE(elapsed_us, 50UL * 1000);
+}
+
 thread_local uint64_t rw_count;
 thread_local bool writing = false;
 thread_local photon::rwlock rwl;

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1359,8 +1359,19 @@ insert_list:
             waitq->push_back(sw.from);
             sw.from->waitq = waitq;
         }
+        auto now_before = now;
         if_update_now(true);
         sw.from->ts_wakeup = timeout.expiration();
+        // if_update_now may jump `now` forward when it was stale (e.g. the
+        // first sleep after init, when `now` hasn't been refreshed since
+        // vcpu_init). If the jump put ts_wakeup in the past even though the
+        // timeout wasn't expired at construction time, re-arm relative to
+        // the fresh `now` so the sleeper still waits ~useconds instead of
+        // being woken immediately at ~0us.
+        if (sw.from->ts_wakeup <= now) {
+            sw.from->ts_wakeup =
+                sat_add(now, sat_sub(timeout.expiration(), now_before));
+        }
         sw.from->get_vcpu()->sleepq.push(sw.from);
         return sw;
     }


### PR DESCRIPTION
## Problem

`photon::thread_usleep(useconds)` returned in ~0us (claiming success) when the global `now` was stale, instead of sleeping ~useconds. Most visible on the first short sleep after `vcpu_init` (e.g. `thread_usleep(50ms)` → ~0us), amplified under ASan where init is slow. Longer sleeps (e.g. 500ms) and subsequent calls were unaffected — which is why it presents as an intermittent first-call flake.

## Root cause

`thread_usleep(useconds)` builds `Timeout(useconds)` whose ctor computes `m_expiration = sat_add(now, useconds)` against the global `now`. `prepare_usleep()` then calls `if_update_now(true)`, which jumps `now` to real time. When `now` hasn't been refreshed since `vcpu_init` and the jump >= `useconds`, the sleeper's `ts_wakeup` (= stale `now` + `useconds`) lands in the past, so idler's `resume_threads` wakes it immediately.

`__photon_init` never starts the timestamp updater (`timestamp_updater_init` is only called from a test), so `ts_updater==0` makes `if_update_now(true)` always call `update_now()`, guaranteeing the jump whenever `now` has been idle.

## Fix

In `prepare_usleep` (the single chokepoint all sleep paths go through), snapshot `now` before `if_update_now(true)`; if the fresh `now` has jumped past `ts_wakeup`, re-arm it as `now + useconds` (recovered as `m_expiration - now_before`). This covers `thread_usleep`, `thread_usleep_defer`, and `waitq::wait` uniformly, rather than patching only one overload.

## Test

Added `Sleep.short_sleep_with_stale_now` in `thread/test/test.cpp`: stalls the vCPU 60ms via OS sleep to stale `now`, then asserts `thread_usleep(50ms)` sleeps at least 50ms.

**Before fix:**
```
$ ./output/test-thread --gtest_filter='Sleep.short_sleep_with_stale_now'
[ RUN      ] Sleep.short_sleep_with_stale_now
thread/test/test.cpp:808: Failure
Expected: (elapsed_us) >= (50UL * 1000), actual: 3 vs 50000
[  FAILED  ] Sleep.short_sleep_with_stale_now (60 ms)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test
```

**After fix:**
```
$ ./output/test-thread --gtest_filter='Sleep.short_sleep_with_stale_now'
[ RUN      ] Sleep.short_sleep_with_stale_now
[       OK ] Sleep.short_sleep_with_stale_now (110 ms)
[  PASSED  ] 1 test.
```

Full `test-thread` suite: 57 tests passed (no regression).