### PR TITLE
build on CLANG

### DIFF
--- a/common/checksum/crc.cpp
+++ b/common/checksum/crc.cpp
@@ -767,7 +767,7 @@ uint64_t crc64ecma_hw(const uint8_t *buffer, size_t nbytes, uint64_t crc) {
 // Pop the basic SSE/PCLMUL pragma that was pushed at the beginning of this file
 #if defined(__x86_64__)
 #ifdef __clang__
-#pragma clang attribute pop
+// clang attributes can't nest and thus were already popped once more than GCC.
 #else // __GNUC__
 #pragma GCC pop_options
 #endif

--- a/common/test/CMakeLists.txt
+++ b/common/test/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(test-scalepool PRIVATE photon_shared)
 add_test(NAME test-scalepool COMMAND $<TARGET_FILE:test-scalepool>)
 
 add_executable(test-throttle test_throttle.cpp)
+target_compile_options(test-throttle PRIVATE 
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-error=vla-cxx-extension>
+)
 target_link_libraries(test-throttle PRIVATE photon_shared)
 add_test(NAME test-throttle COMMAND $<TARGET_FILE:test-throttle>)
 

--- a/common/test/test_throttle.cpp
+++ b/common/test/test_throttle.cpp
@@ -371,7 +371,8 @@ static void run_real_socket(const std::atomic<bool>& running, const PriorityTest
         auto conn = cli->connect(server_ep);
         if (!conn) exit(1);
         DEFER(delete conn);
-        char buf[buf_size] = {};
+        char buf[buf_size];
+        std::memset(buf, 0, buf_size);
         while (running) {
             src.consume(p.io1.bs);
             ssize_t ret = conn->send(buf, p.io1.bs);
@@ -387,7 +388,8 @@ static void run_real_socket(const std::atomic<bool>& running, const PriorityTest
         auto conn = cli->connect(server_ep);
         if (!conn) exit(1);
         DEFER(delete conn);
-        char buf[buf_size] = {};
+        char buf[buf_size];
+        std::memset(buf, 0, buf_size);
         while (running) {
             src.consume(p.io2.bs);
             ssize_t ret = conn->send(buf, p.io2.bs);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,9 @@ if (NOT APPLE)
     target_link_libraries(io-perf PRIVATE photon_static)
 
     add_executable(multi-conn-perf perf/multi-conn-perf.cpp)
+    target_compile_options(multi-conn-perf PRIVATE 
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-error=vla-cxx-extension>
+    )
     target_link_libraries(multi-conn-perf PRIVATE photon_static)
 endif ()
 

--- a/fs/cache/cached_fs.cpp
+++ b/fs/cache/cached_fs.cpp
@@ -164,18 +164,18 @@ public:
         return xattrFs_ ? xattrFs_->lremovexattr(path, name) : -1;
     }
 
-    UNIMPLEMENTED_POINTER(IFile *creat(const char *pathname, mode_t mode));
-    UNIMPLEMENTED(int symlink(const char *oldname, const char *newname));
-    UNIMPLEMENTED(int link(const char *oldname, const char *newname));
-    UNIMPLEMENTED(int chmod(const char *pathname, mode_t mode));
-    UNIMPLEMENTED(int chown(const char *pathname, uid_t owner, gid_t group));
-    UNIMPLEMENTED(int lchown(const char *pathname, uid_t owner, gid_t group));
-    UNIMPLEMENTED(int truncate(const char *path, off_t length));
-    UNIMPLEMENTED(int utime(const char *path, const struct utimbuf *file_times));
-    UNIMPLEMENTED(int utimes(const char *path, const struct timeval times[2]));
-    UNIMPLEMENTED(int lutimes(const char *path, const struct timeval times[2]));
-    UNIMPLEMENTED(int mknod(const char *path, mode_t mode, dev_t dev));
-    UNIMPLEMENTED(int syncfs());
+    UNIMPLEMENTED_POINTER(IFile *creat(const char *pathname, mode_t mode) override);
+    UNIMPLEMENTED(int symlink(const char *oldname, const char *newname) override);
+    UNIMPLEMENTED(int link(const char *oldname, const char *newname) override);
+    UNIMPLEMENTED(int chmod(const char *pathname, mode_t mode) override);
+    UNIMPLEMENTED(int chown(const char *pathname, uid_t owner, gid_t group) override);
+    UNIMPLEMENTED(int lchown(const char *pathname, uid_t owner, gid_t group) override);
+    UNIMPLEMENTED(int truncate(const char *path, off_t length) override);
+    UNIMPLEMENTED(int utime(const char *path, const struct utimbuf *file_times) override);
+    UNIMPLEMENTED(int utimes(const char *path, const struct timeval times[2]) override);
+    UNIMPLEMENTED(int lutimes(const char *path, const struct timeval times[2]) override);
+    UNIMPLEMENTED(int mknod(const char *path, mode_t mode, dev_t dev) override);
+    UNIMPLEMENTED(int syncfs() override);
 
 private:
     IFileSystem *srcFs_;         // owned by extern
@@ -375,10 +375,10 @@ public:
         return src_rwfile->vioctl(request, args);
     }
 
-    UNIMPLEMENTED(off_t lseek(off_t offset, int whence));
-    UNIMPLEMENTED(int fchmod(mode_t mode));
-    UNIMPLEMENTED(int fchown(uid_t owner, gid_t group));
-    UNIMPLEMENTED(int fiemap(photon::fs::fiemap *map));
+    UNIMPLEMENTED(off_t lseek(off_t offset, int whence) override);
+    UNIMPLEMENTED(int fchmod(mode_t mode) override);
+    UNIMPLEMENTED(int fchown(uid_t owner, gid_t group) override);
+    UNIMPLEMENTED(int fiemap(photon::fs::fiemap *map) override);
 
 protected:
     ICacheStore *cache_store_;

--- a/fs/cache/persistent_cache/persistent_cache.cpp
+++ b/fs/cache/persistent_cache/persistent_cache.cpp
@@ -84,7 +84,7 @@ public:
     int fstat(struct stat *buf) override;
     int vioctl(int request, va_list args) override;
     // used for evict
-    int fallocate(int mode, off_t offset, off_t len);
+    int fallocate(int mode, off_t offset, off_t len) override;
 
     UNIMPLEMENTED_POINTER(IFileSystem *filesystem() override);
     UNIMPLEMENTED(off_t lseek(off_t offset, int whence) override);
@@ -122,7 +122,7 @@ public:
         }
         return new PersistentCacheFile(src_file, pathname, this);
     }
-    IFile *open(const char *pathname, int flags, mode_t mode) {
+    IFile *open(const char *pathname, int flags, mode_t mode) override {
         return open(pathname, flags);
     }
 
@@ -244,7 +244,8 @@ int PersistentCacheFile::fstat(struct stat *buf) {
 
 int PersistentCacheFile::vioctl(int request, va_list args) {
     if (request == SET_LOCAL_DIR) {
-        auto dir = va_arg(args, std::string);
+        const char* dir_ptr = va_arg(args, const char*);
+        std::string dir = dir_ptr != nullptr ? std::string(dir_ptr) : "";
         if (m_local_file != nullptr) {
             LOG_DEBUG("dir already set, ignore");
             return 0;


### PR DESCRIPTION
Various things have to be updated for a modern clang build to pass.

We're using this command:

```
cmake -B build -D PHOTON_BUILD_TESTING=ON -DPHOTON_CXX_STANDARD=20 -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
```

- some overriding methods were missing the override.
- we had one too many attribute pop in crc.cpp
- in some examples and tests we're initializing a `char[]` from a flag which is forbidden in clang unless the VLA extension is enabled.