### PR TITLE
[Backport][0.8 to 0.7] | add spill_additional_fp_simd_regs() (#1556) (#1557) (#1558)

### DIFF
--- a/net/security-context/tls-stream.cpp
+++ b/net/security-context/tls-stream.cpp
@@ -280,10 +280,12 @@ public:
     }
 
     static int ssbio_bwrite(BIO* b, const char* buf, int cnt) {
+        spill_additional_fp_simd_regs();
         return get_bio_sockstream(b)->write(buf, cnt);
     }
 
     static int ssbio_bread(BIO* b, char* buf, int cnt) {
+        spill_additional_fp_simd_regs();
         return get_bio_sockstream(b)->recv(buf, cnt);
     }
 

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -453,6 +453,7 @@ namespace photon
     void* stackful_malloc(size_t size);
     void stackful_free(void* ptr);
 
+<<<<<<< HEAD
     // Set photon allocator/deallocator for photon thread stack
     // this is a hook for thread allocation, both alloc and dealloc
     // helps user to do more works like mark GC while allocating
@@ -492,6 +493,20 @@ namespace photon
       return z;
 #elif defined(__aarch64__)
       return x > y ? x - y : 0;
+=======
+    // Some additional registers are defined as callee-saved ones, such as
+    // d8 ~ d15 fp/simd registers in AARCH64, or xmm6 ~ xmm15 simd registers
+    // in Windows x64.
+    // But in fact, it is likely in reality that they do not actually need
+    // spilling, so we leave them here for the users to manually do spilling
+    // if needed.
+    inline void spill_additional_fp_simd_regs() {
+#ifdef __aarch64__
+        asm volatile("" ::: "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15");
+#elif defined(_WIN32)
+        asm volatile("" ::: "xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11",
+                                          "xmm12", "xmm13", "xmm14", "xmm15");
+>>>>>>> b7edc80 (add spill_additional_fp_simd_regs() (#1556) (#1557) (#1558))
 #endif
     }
 };

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -453,7 +453,6 @@ namespace photon
     void* stackful_malloc(size_t size);
     void stackful_free(void* ptr);
 
-<<<<<<< HEAD
     // Set photon allocator/deallocator for photon thread stack
     // this is a hook for thread allocation, both alloc and dealloc
     // helps user to do more works like mark GC while allocating
@@ -493,7 +492,9 @@ namespace photon
       return z;
 #elif defined(__aarch64__)
       return x > y ? x - y : 0;
-=======
+#endif
+    }
+
     // Some additional registers are defined as callee-saved ones, such as
     // d8 ~ d15 fp/simd registers in AARCH64, or xmm6 ~ xmm15 simd registers
     // in Windows x64.
@@ -506,10 +507,8 @@ namespace photon
 #elif defined(_WIN32)
         asm volatile("" ::: "xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11",
                                           "xmm12", "xmm13", "xmm14", "xmm15");
->>>>>>> b7edc80 (add spill_additional_fp_simd_regs() (#1556) (#1557) (#1558))
-#endif
     }
-};
+}
 
 /*
  WITH_LOCK(mutex)

--- a/thread/thread.h
+++ b/thread/thread.h
@@ -507,6 +507,7 @@ namespace photon
 #elif defined(_WIN32)
         asm volatile("" ::: "xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11",
                                           "xmm12", "xmm13", "xmm14", "xmm15");
+#endif
     }
 }
 


### PR DESCRIPTION
> add spill_additional_fp_simd_regs() (#1556) (#1557) (#1558)

Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- b7edc800edcdaffba45632f23c2e18cfbbc77bda: thread/thread.h