### PR TITLE
fix(executor): prevent self-join in ~ExecutorImpl when destroyed from worker thread

### DIFF
--- a/common/executor/executor.cpp
+++ b/common/executor/executor.cpp
@@ -19,6 +19,7 @@ public:
     using CBList =
         common::RingChannel<LockfreeMPMCRingQueue<Delegate<void>, 32UL * 1024>>;
     std::unique_ptr<std::thread> th;
+    std::atomic<bool> running{false};
     photon::thread *pth = nullptr;
     CBList queue;
     photon::ThreadPoolBase *pool;
@@ -34,10 +35,18 @@ public:
 
     ~ExecutorImpl() {
         queue.send({});
-        if (th)
-            th->join();
-        else
+        if (th) {
+            if (std::this_thread::get_id() == th->get_id()) {
+                // Self-destruction: called from within the worker thread.
+                th->detach();
+                while (running) photon::thread_yield();
+            } else {
+                th->join();
+            }
+        } else {
             while (pool) photon::thread_yield();
+        }
+
     }
 
     struct CallArg {
@@ -68,6 +77,8 @@ public:
     }
 
     void do_loop() {
+        running = true;
+        DEFER(running = false);
         pth = photon::CURRENT;
         pool = photon::new_thread_pool(32);
         LOG_INFO("worker start");

--- a/common/executor/test/CMakeLists.txt
+++ b/common/executor/test/CMakeLists.txt
@@ -26,3 +26,7 @@ add_executable(test-executor-burst-drain test_burst_drain.cpp)
 target_link_libraries(test-executor-burst-drain PRIVATE photon_shared ${GOOGLETEST_GTEST_MAIN_LIBRARIES})
 add_test(NAME test-executor-burst-drain COMMAND $<TARGET_FILE:test-executor-burst-drain>)
 
+add_executable(test-executor-self-join test_self_join.cpp)
+target_link_libraries(test-executor-self-join PRIVATE photon_shared ${GOOGLETEST_GTEST_MAIN_LIBRARIES})
+add_test(NAME test-executor-self-join COMMAND $<TARGET_FILE:test-executor-self-join>)
+

--- a/common/executor/test/test_self_join.cpp
+++ b/common/executor/test/test_self_join.cpp
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Photon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Verify ~ExecutorImpl won't self-join (EDEADLK → terminate) when
+// destroyed from its own worker thread. Related: #967, #969.
+
+#include <photon/common/executor/executor.h>
+#include <photon/common/alog.h>
+#include <photon/photon.h>
+#include "../../../test/gtest.h"
+
+#include <memory>
+#include <atomic>
+#include <future>
+
+using namespace photon;
+
+// Task releases the last shared_ptr ref on the worker thread,
+// triggering ~ExecutorImpl from within → must detach, not join.
+TEST(executor, destroy_from_worker_thread) {
+    std::promise<void> done;
+    auto fut = done.get_future();
+
+    {
+        auto exec = std::make_shared<Executor>(
+            photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE);
+
+        exec->async_perform(new auto([&exec, &done] {
+            exec.reset();       // ~Executor on worker thread
+            done.set_value();   // reachable only if no crash
+        }));
+    }
+
+    fut.wait();
+    LOG_INFO("executor destroyed from worker thread without crash");
+}


### PR DESCRIPTION
Fixes #1561

Same pattern as #967 (WorkPool), fixed in #969.

## Background

In pure C++ usage, `Executor` is typically destroyed from the creating thread, so `th->join()` is safe. The problem only surfaces when object lifetime is managed by a GC/refcount runtime (e.g. **pybind11**, Python, Java JNI):

- A task running on the executor's worker thread holds the last reference (via `py::object` / `shared_ptr`)
- When the task completes and releases the reference, cascade destruction triggers `~ExecutorImpl` **on the worker thread itself**
- `th->join()` → `pthread_join(self)` → `EDEADLK` → `std::system_error` escapes noexcept dtor → `std::terminate`

This is not reproducible in pure C++ tests without simulating the GC cascade.

## Changes

- Detect self-destruction via `worker_id` comparison
- Detach + spin-wait `running` instead of join
- Add `test_self_join.cpp` with synchronous (promise/future) verification