### PR TITLE
backport three-tier LRU (#1209) and multi-vCPU thread-safety (#1555) to release/0.9

### DIFF
--- a/common/string-keyed.h
+++ b/common/string-keyed.h
@@ -21,7 +21,9 @@ limitations under the License.
 #include <photon/common/hash_combine.h>
 #include <cstring>
 #include <unordered_map>
+#include <unordered_set>
 #include <map>
+#include <set>
 
 // string_key is a string_view with dedicated storage,
 // primarily used as stored keys in std::map and std::unordered_map,
@@ -192,10 +194,8 @@ template<class T,
 using unordered_map_string_key_case_insensitive = basic_map_string_key<
     std::unordered_map<string_key, T, Hasher, KeyEqual, Alloc>>;
 
-template<class T,
-    class Pred = std::less<string_key>,
-    class Alloc = std::allocator<std::pair<const string_key,T>>>
-class map_string_key : public basic_map_string_key<
+template<class T, class Pred, class Alloc>
+class ordered_map_string_key : public basic_map_string_key<
     std::map<string_key, T, Pred, Alloc>>
 {
 public:
@@ -225,6 +225,11 @@ public:
     }
 };
 
+template<class T,
+    class Pred = std::less<string_key>,
+    class Alloc = std::allocator<std::pair<const string_key,T>>>
+using map_string_key = ordered_map_string_key<T, Pred, Alloc>;
+
 class Less_CaseInsensitive {
 public:
     bool operator()(std::string_view a, std::string_view b) const {
@@ -239,8 +244,125 @@ public:
 template<class T,
     class Pred = Less_CaseInsensitive,
     class Alloc = std::allocator<std::pair<const string_key,T>>>
-using map_string_key_case_insensitive = basic_map_string_key<
-    std::map<string_key, T, Pred, Alloc>>;
+using map_string_key_case_insensitive = ordered_map_string_key<
+    T, Pred, Alloc>;
+
+// The basic class for sets with string keys, aims to avoid temp
+// std::string construction in queries, by accepting string_views.
+// S is the underlying set, either std::set or std::unordered_set
+template <class S>
+class basic_set_string_key : public S
+{
+public:
+    using base = S;
+    using typename base::const_iterator;
+    using typename base::iterator;
+    using typename base::size_type;
+    using base::base;
+
+    using base::erase;
+
+    using key_type = std::string_view;
+    using value_type = string_key;
+
+    iterator find ( const key_type& k )
+    {
+        return base::find((const string_key&)k);
+    }
+    const_iterator find ( const key_type& k ) const
+    {
+        return base::find((const string_key&)k);
+    }
+    size_type count ( const key_type& k ) const
+    {
+        return base::count((const string_key&)k);
+    }
+    std::pair<iterator,iterator> equal_range ( const key_type& k )
+    {
+        return base::equal_range((const string_key&)k);
+    }
+    std::pair<const_iterator,const_iterator> equal_range ( const key_type& k ) const
+    {
+        return base::equal_range((const string_key&)k);
+    }
+    std::pair<iterator,bool> emplace ( const key_type& k )
+    {
+        return base::emplace((const string_key&)k);
+    }
+    template <class... Args>
+    std::pair<iterator,bool> emplace ( const key_type& k, Args&&... args )
+    {
+        return base::emplace((const string_key&)k, std::forward<Args>(args)...);
+    }
+    template <class... Args>
+    iterator emplace_hint ( const_iterator position, const key_type& k, Args&&... args )
+    {
+        return base::emplace_hint(position, (const string_key&)k, std::forward<Args>(args)...);
+    }
+    std::pair<iterator,bool> insert ( const key_type& k )
+    {
+        return emplace(k);
+    }
+    iterator insert ( const_iterator hint, const key_type& k )
+    {
+        return emplace_hint(hint, k);
+    }
+    size_type erase ( const std::string_view& k )
+    {
+        return base::erase((const string_key&)k);
+    }
+};
+
+template<class Hasher = std::hash<std::string_view>,
+    class KeyEqual = std::equal_to<std::string_view>,
+    class Alloc = std::allocator<string_key>>
+using unordered_set_string_key = basic_set_string_key<
+    std::unordered_set<string_key, Hasher, KeyEqual, Alloc>>;
+
+template<class Hasher = Hasher_CaseInsensitive,
+    class KeyEqual = Equal_CaseInsensitive,
+    class Alloc = std::allocator<string_key>>
+using unordered_set_string_key_case_insensitive = basic_set_string_key<
+    std::unordered_set<string_key, Hasher, KeyEqual, Alloc>>;
+
+// ordered set with string keys, provides lower_bound/upper_bound
+template <class S>
+class ordered_set_string_key : public basic_set_string_key<S>
+{
+public:
+    using base = basic_set_string_key<S>;
+    using typename base::key_type;
+    using typename base::const_iterator;
+    using typename base::iterator;
+    using base::base;
+
+    iterator lower_bound (const key_type& k)
+    {
+        return base::lower_bound((const string_key&)k);
+    }
+    const_iterator lower_bound (const key_type& k) const
+    {
+        return base::lower_bound((const string_key&)k);
+    }
+    iterator upper_bound (const key_type& k)
+    {
+        return base::upper_bound((const string_key&)k);
+    }
+    const_iterator upper_bound (const key_type& k) const
+    {
+        return base::upper_bound((const string_key&)k);
+    }
+};
+
+template<class Pred = std::less<string_key>,
+    class Alloc = std::allocator<string_key>>
+using set_string_key = ordered_set_string_key<
+    std::set<string_key, Pred, Alloc>>;
+
+template<class Pred = Less_CaseInsensitive,
+    class Alloc = std::allocator<string_key>>
+using set_string_key_case_insensitive = ordered_set_string_key<
+    std::set<string_key, Pred, Alloc>>;
 
 // the String Key-Value (Mutable), stored together
 // in a consecutive area, so as to save one allocation

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -1300,6 +1300,72 @@ TEST(string_key, case_insensitive) {
     test_map_case_insensitive<map_string_kv_case_insensitive>();
 }
 
+template<typename S> static
+void basic_set_test(S& test_set) {
+    const auto& const_set = test_set;
+    std::string prefix = "seggwrg90if908234j5rlkmx.c,bnmi7890wer1234rbdfb";
+
+    for (int i = 0; i < 100; i++) {
+        std::string s = prefix + std::to_string(i);
+        test_set.insert(s);
+    }
+    EXPECT_EQ(test_set.size(), 100);
+
+    for (int i = 0; i < 100; i++) {
+        std::string s = prefix + std::to_string(i);
+        EXPECT_NE(test_set.find(s), test_set.end());
+        EXPECT_EQ(test_set.count(s), 1);
+        EXPECT_NE(const_set.find(s), const_set.end());
+        EXPECT_EQ(const_set.count(s), 1);
+    }
+    for (int i = 100; i < 200; i++) {
+        std::string s = prefix + std::to_string(i);
+        EXPECT_EQ(test_set.find(s), test_set.end());
+        EXPECT_EQ(test_set.count(s), 0);
+    }
+
+    test_set.erase(prefix + "50");
+    EXPECT_EQ(test_set.size(), 99);
+    EXPECT_EQ(test_set.count(prefix + "50"), 0);
+
+    test_set.clear();
+    EXPECT_EQ(test_set.size(), 0);
+}
+
+TEST(string_key, unordered_set_string_key) {
+    unordered_set_string_key<> test_set;
+    basic_set_test(test_set);
+}
+
+TEST(string_key, set_string_key) {
+    set_string_key<> test_set;
+    basic_set_test(test_set);
+
+    std::string prefix = "seggwrg90if908234j5rlkmx.c,bnmi7890wer1234rbdfb";
+    EXPECT_EQ(test_set.lower_bound(prefix + "2"), test_set.find(prefix + "2"));
+    EXPECT_EQ(test_set.lower_bound(prefix + "1"), test_set.find(prefix + "2"));
+    EXPECT_EQ(test_set.upper_bound(prefix + "22"), test_set.find(prefix + "23"));
+
+    const auto& const_set = test_set;
+    EXPECT_EQ(const_set.lower_bound(prefix + "2"), const_set.find(prefix + "2"));
+    EXPECT_EQ(const_set.upper_bound(prefix + "22"), const_set.find(prefix + "23"));
+}
+
+template<typename S> static
+void test_set_case_insensitive() {
+    S s;
+    s.insert("asdf");
+    auto it = s.find("ASDF");
+    EXPECT_NE(it, s.end());
+    EXPECT_EQ(*it, "asdf");
+    EXPECT_EQ(s.count("kuherqf"), 0);
+}
+
+TEST(string_key, set_case_insensitive) {
+    test_set_case_insensitive<unordered_set_string_key_case_insensitive<>>();
+    test_set_case_insensitive<set_string_key_case_insensitive<>>();
+}
+
 TEST(RangeLock, Basic) {
   RangeLock m;
 

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "cache_pool.h"
+#include <cassert>
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -117,6 +118,7 @@ void FileCachePool::probeFiemap() {
 }
 
 ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t mode) {
+  SCOPED_LOCK(m_lock_);
   auto localFile = openMedia(pathname, flags, mode);
   if (!localFile) {
     return nullptr;
@@ -169,43 +171,56 @@ int FileCachePool::stat(CacheStat* stat, std::string_view pathname) {
   return -1;
 }
 
-int FileCachePool::evict(std::string_view filename) {
-  // Check cold tiers first
-  for (auto* tier : coldTiers_) {
-    if (tier->contains(filename)) {
-      auto freed = truncateAndUnlink(filename);
-      tier->remove(filename);
-      return freed >= 0 ? 0 : -1;
-    }
-  }
-
-  auto fileIter = fileIndex_.find(filename);
-  if (fileIter == fileIndex_.end()) {
-    LOG_ERROR("Evict no such file , name: `", filename);
-    return 0;
-  }
-
-  const auto& filePath = fileIter->first;
-  auto lruEntry = fileIter->second.get();
-  if (lruEntry->openCount == 0) {
-    lru_.mark_key_cleared(lruEntry->lruIter);
-  }
+// Opens `name`, truncates it, then finalizes eviction.
+// MUST be called WITHOUT m_lock_ held.
+bool FileCachePool::evictOpenedFile(const std::string& name) {
   int err = 0;
-  auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+  auto cacheStore = static_cast<FileCacheStore*>(open(name, O_RDWR, 0644));
   if (cacheStore) {
     DEFER(cacheStore->release());
     photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
     err = cacheStore->evict(0);
-    lruEntry->truncate_done = false;
   }
   if (err) {
     ERRNO e;
-    LOG_ERROR("truncate(0) failed, name: `, ret: `, error code: `", filePath,
-              err, e);
-    // If truncate fails, we can attempt to remove the file directly
-    // in the afterFtrucate function.
+    LOG_ERROR("truncate(0) failed, name: `, ret: `, error code: `", name, err, e);
+    // Fall through: afterFtrucate can still remove the file directly.
   }
-  return afterFtrucate(fileIter) ? 0 : -1;
+  return finalizeEvicted(name);
+}
+
+// Acquires m_lock_ and finalizes eviction bookkeeping for `name`.
+bool FileCachePool::finalizeEvicted(const std::string& name) {
+  SCOPED_LOCK(m_lock_);
+  auto it = fileIndex_.find(name);
+  if (it == fileIndex_.end()) return true;  // already evicted concurrently
+  it->second->truncate_done = false;
+  return afterFtrucate(it);
+}
+
+int FileCachePool::evict(std::string_view filename) {
+  std::string name(filename);
+  {
+    SCOPED_LOCK(m_lock_);
+    // Check cold tiers first
+    for (auto* tier : coldTiers_) {
+      if (tier->contains(filename)) {
+        auto freed = evictColdVictim(tier, filename);
+        return freed >= 0 ? 0 : -1;
+      }
+    }
+
+    auto fileIter = fileIndex_.find(name);
+    if (fileIter == fileIndex_.end()) {
+      LOG_ERROR("Evict no such file , name: `", filename);
+      return 0;
+    }
+    auto lruEntry = fileIter->second.get();
+    if (lruEntry->openCount == 0) {
+      lru_.mark_key_cleared(lruEntry->lruIter);
+    }
+  }
+  return evictOpenedFile(name) ? 0 : -1;
 }
 
 int FileCachePool::evict(size_t size) {
@@ -223,6 +238,7 @@ bool FileCachePool::isFull() {
 }
 
 void FileCachePool::removeOpenFile(FileNameMap::iterator iter) {
+  SCOPED_LOCK(m_lock_);
   iter->second->openCount--;
 }
 
@@ -231,11 +247,18 @@ void FileCachePool::forceRecycle() {
 }
 
 void FileCachePool::updateLru(FileNameMap::iterator iter) {
+  SCOPED_LOCK(m_lock_);
   lru_.access(iter->second->lruIter);
 }
 
 //  currently, we exist duplicate pwrite
-int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
+int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, IFile* localFile) {
+  SCOPED_LOCK(m_lock_);
+  struct stat st = {};
+  if (localFile->fstat(&st) != 0) {
+    LOG_ERRNO_RETURN(0, 0, "fstat failed");
+  }
+  uint64_t size = kDiskBlockSize * st.st_blocks;
   auto lruEntry = iter->second.get();
   auto diff = static_cast<int64_t>(size) - static_cast<int64_t>(lruEntry->size);
   totalUsed_ += diff;
@@ -257,13 +280,7 @@ int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
       LOG_WARN("disk free space below floor `, force recycle", diskAvailInBytes_);
     }
   }
-
-  if (full) {
-    isFull_ = true;
-    forceRecycle();
-    if (lruEntry->size==0) diff = 0;//in some extream condition ,
-                                    //forceRecycle maybe truncate current file to 0
-  }
+  if (full) isFull_ = true;
   return diff;
 }
 
@@ -279,10 +296,10 @@ bool FileCachePool::diskSpaceLow() {
 
 uint64_t FileCachePool::timerHandler(void* data) {
   auto cur = static_cast<FileCachePool*>(data);
-  if (cur->running_) {
+  // Atomic test-and-set: only one vCPU runs eviction at a time.
+  if (cur->running_.exchange(true)) {
     return 0;
   }
-  cur->running_ = true;
   DEFER(cur->running_ = false;);
   cur->eviction();
   return 0;
@@ -309,79 +326,71 @@ void FileCachePool::eviction() {
     }
   }
 
-  if (totalUsed_ >= static_cast<int64_t>(waterMark_)) {
-    evictByCache = totalUsed_ - waterMark_;
-  }
-
-  auto actualEvict = std::min(
-    static_cast<int64_t>(std::max(evictByCache, evictByDisk)),
-    totalUsed_
-  );
-
-  if (actualEvict <= 0) {
-    return;
-  }
-
-  isFull_ = true;
-
-  // Evict from cold tiers first in reverse order
-  for (int i = coldTiers_.size() - 1; i >= 0; i--) {
-    auto* tier = coldTiers_[i];
-    while (actualEvict > 0 && !tier->empty() && !exit_) {
-      auto name = tier->victim();
-      auto freed = truncateAndUnlink(name);
-      tier->remove(name);
-      if (freed >= 0) actualEvict -= freed;
-      photon::thread_yield();
+  int64_t actualEvict;
+  {
+    SCOPED_LOCK(m_lock_);
+    if (totalUsed_ >= static_cast<int64_t>(waterMark_)) {
+      evictByCache = totalUsed_ - waterMark_;
     }
-  }
 
-  if (!lru_.empty() && !exit_) {
-    LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
+    actualEvict = std::min(
+      static_cast<int64_t>(std::max(evictByCache, evictByDisk)),
+      totalUsed_
+    );
+
+    if (actualEvict <= 0) {
+      return;
+    }
+
+    isFull_ = true;
+
+    for (auto i = coldTiers_.size(); i > 0 && actualEvict > 0 && !exit_; --i) {
+      auto* tier = coldTiers_[i - 1];
+      while (actualEvict > 0 && !tier->empty() && !exit_) {
+        auto freed = evictColdVictim(tier, tier->victim());
+        if (freed >= 0) actualEvict -= freed;
+      }
+    }
+
+    if (!lru_.empty() && !exit_) {
+      LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
+    }
   }
 
   uint64_t empty_files_sequence = 0;
-  while (actualEvict > 0 && !lru_.empty() && !exit_) {
-    auto fileIter = lru_.back();
-    const auto& fileName = fileIter->first;
-    auto lruEntry = fileIter->second.get();
-    auto fileSize = lruEntry->size;
-    if (lruEntry->openCount == 0){
-      lru_.mark_key_cleared(fileIter->second->lruIter);
-    } else {
-      lru_.access(fileIter->second->lruIter);
-    }
-    //as soon as possible truncate and unlink
-    if (0 == fileSize) {
-        if (0 == fileIter->second->openCount) {
-            afterFtrucate(fileIter);
+  while (actualEvict > 0 && !exit_) {
+    std::string fileName;
+    uint64_t fileSize;
+    {
+      SCOPED_LOCK(m_lock_);
+      if (lru_.empty() || totalUsed_ <= 0) break;
+      auto fileIter = lru_.back();
+      fileName = std::string(fileIter->first);
+      auto lruEntry = fileIter->second.get();
+      fileSize = lruEntry->size;
+      if (lruEntry->openCount == 0) {
+        lru_.mark_key_cleared(lruEntry->lruIter);
+      } else {
+        lru_.access(lruEntry->lruIter);
+      }
+      if (0 == fileSize) {
+        if (0 == lruEntry->openCount) {
+          afterFtrucate(fileIter);
         } else {
           empty_files_sequence++;
-          if (empty_files_sequence == lru_.size()) {
+          if (empty_files_sequence >= lru_.size()) {
             LOG_ERROR("eviction: all ` LRU entries have size=0 with openCount>0, "
               "cannot make progress. actualEvict=`, totalUsed=`",
               lru_.size(), actualEvict, totalUsed_);
             break;
           }
         }
-        continue;
+        continue;  // releases m_lock_ via SCOPED_LOCK scope
+      }
+      empty_files_sequence = 0;
     }
-
-    empty_files_sequence = 0;
-    int err = 0;
-    auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
-    if (cacheStore) {
-      DEFER(cacheStore->release());
-      photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
-      err = cacheStore->evict(0);
-      lruEntry->truncate_done = false;
-    }
-
-    if (err) {
-      ERRNO e;
-      LOG_ERROR("truncate(0) failed, name : `, ret : `, error code : `", fileName, err, e);
-    }
-    afterFtrucate(fileIter);
+    // open()+WLOCK+finalize with m_lock_ released.
+    evictOpenedFile(fileName);
     actualEvict -= fileSize;
     photon::thread_yield();
   }
@@ -392,6 +401,7 @@ uint64_t FileCachePool::calcWaterMark(uint64_t capacity, uint64_t maxFreeSpace) 
     capacity > maxFreeSpace ? capacity - maxFreeSpace : 0);
 }
 
+// With m_lock_ held.
 bool FileCachePool::afterFtrucate(FileNameMap::iterator iter) {
   auto lruEntry = iter->second.get();
   totalUsed_ -= static_cast<int64_t>(lruEntry->size);
@@ -432,6 +442,7 @@ int FileCachePool::insertFile(std::string_view file) {
   }
   auto fileSize = st.st_blocks * kDiskBlockSize;
 
+  SCOPED_LOCK(m_lock_);
   auto lruIter = lru_.push_front(fileIndex_.end());
   auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
   auto iter = fileIndex_.emplace(file, std::move(entry)).first;
@@ -459,6 +470,7 @@ void FileCachePool::adaptThresholds() {
   tierHits_.fill(0);
 }
 
+// With m_lock_ held.
 void FileCachePool::demoteToCold() {
   while (lru_.size() > thresholds_[0].value) {
     auto tailIt = lru_.back();
@@ -478,6 +490,7 @@ void FileCachePool::demoteToCold() {
   }
 }
 
+// With m_lock_ held.
 void FileCachePool::promoteToHot(std::string_view filename) {
   auto find = fileIndex_.find(filename);
   if (find != fileIndex_.end()) {
@@ -511,6 +524,18 @@ void FileCachePool::promoteToHot(std::string_view filename) {
   lru_.front() = iter;
 }
 
+// With m_lock_ held.
+ssize_t FileCachePool::evictColdVictim(ColdCacheTier* tier, std::string_view name) {
+  auto freed = truncateAndUnlink(name);
+  tier->remove(name);
+  if (freed >= 0) {
+    totalUsed_ -= freed;
+    if (totalUsed_ < 0) totalUsed_ = 0;
+  }
+  return freed;
+}
+
+// I/O only: does NOT touch totalUsed_ and does NOT require m_lock_.
 ssize_t FileCachePool::truncateAndUnlink(std::string_view filename) {
   struct stat st = {};
   uint64_t fileSize = 0;
@@ -523,8 +548,6 @@ ssize_t FileCachePool::truncateAndUnlink(std::string_view filename) {
     if (err) {
       LOG_ERRNO_RETURN(0, -1, "truncate(0) failed, name : `", filename);
     }
-    totalUsed_ -= static_cast<int64_t>(fileSize);
-    if (totalUsed_ < 0) totalUsed_ = 0;
   }
   int err = mediaFs_->unlink(filename.data());
   if (err) {

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <numeric>
 #include <sys/statvfs.h>
 
 #include "cache_store.h"
@@ -121,11 +122,7 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
     return nullptr;
   }
 
-  // Check idle container first
-  auto idleIt = idleFileIndex_.find(pathname);
-  if (idleIt != idleFileIndex_.end()) {
-    promoteFromIdle(idleIt);
-  }
+  promoteToHot(pathname);
 
   auto find = fileIndex_.find(pathname);
   if (find == fileIndex_.end()) {
@@ -138,15 +135,7 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
     find->second->openCount++;
   }
 
-  // If LRU exceeds the limit, demote the tail (only if not open) to idle
-  while (lru_.size() > demoteThreshold_) {
-    auto tailIt = lru_.back();
-    if (tailIt->second->openCount == 0) {
-      demoteToIdle(tailIt);
-    } else {
-      break;
-    }
-  }
+  demoteToCold();
 
   return new FileCacheStore(this, localFile, refillUnit_, find);
 }
@@ -181,10 +170,13 @@ int FileCachePool::stat(CacheStat* stat, std::string_view pathname) {
 }
 
 int FileCachePool::evict(std::string_view filename) {
-  // Check idle container first
-  auto idleIt = idleFileIndex_.find(filename);
-  if (idleIt != idleFileIndex_.end()) {
-    return evictIdleEntry(idleIt) >= 0 ? 0 : -1;
+  // Check cold tiers first
+  for (auto* tier : coldTiers_) {
+    if (tier->contains(filename)) {
+      auto freed = truncateAndUnlink(filename);
+      tier->remove(filename);
+      return freed >= 0 ? 0 : -1;
+    }
   }
 
   auto fileIter = fileIndex_.find(filename);
@@ -332,14 +324,22 @@ void FileCachePool::eviction() {
 
   isFull_ = true;
 
+  // Evict from cold tiers first in reverse order
+  for (int i = coldTiers_.size() - 1; i >= 0; i--) {
+    auto* tier = coldTiers_[i];
+    while (actualEvict > 0 && !tier->empty() && !exit_) {
+      auto name = tier->victim();
+      auto freed = truncateAndUnlink(name);
+      tier->remove(name);
+      if (freed >= 0) actualEvict -= freed;
+      photon::thread_yield();
+    }
+  }
+
   if (!lru_.empty() && !exit_) {
     LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
   }
 
-  // Phase 1: evict from idle tier first.
-  actualEvict -= evictIdleWhenFull(actualEvict);
-
-  // Phase 2: fall back to LRU eviction when idle tier is exhausted
   uint64_t empty_files_sequence = 0;
   while (actualEvict > 0 && !lru_.empty() && !exit_) {
     auto fileIter = lru_.back();
@@ -432,34 +432,72 @@ int FileCachePool::insertFile(std::string_view file) {
   }
   auto fileSize = st.st_blocks * kDiskBlockSize;
 
-  if (lru_.size() >= demoteThreshold_) {
-    auto idleLruIt = idleLru_.push_front(idleFileIndex_.end());
-    auto iter = idleFileIndex_.emplace(file, idleLruIt).first;
-    idleLru_.front() = iter;
-  } else {
-    auto lruIter = lru_.push_front(fileIndex_.end());
-    auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
-    auto iter = fileIndex_.emplace(file, std::move(entry)).first;
-    lru_.front() = iter;
-  }
+  auto lruIter = lru_.push_front(fileIndex_.end());
+  auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
+  auto iter = fileIndex_.emplace(file, std::move(entry)).first;
+  lru_.front() = iter;
   totalUsed_ += fileSize;
+
+  demoteToCold();
   return 0;
 }
 
-// Demote a LRU entry (openCount must be 0) to the idle container.
-void FileCachePool::demoteToIdle(FileNameMap::iterator iter) {
-  auto idleLruIt = idleLru_.push_front(idleFileIndex_.end());
-  auto idleIndexIt = idleFileIndex_.emplace(iter->first, idleLruIt).first;
-  idleLru_.front() = idleIndexIt;
+void FileCachePool::adaptThresholds() {
+  uint64_t count = std::accumulate(tierHits_.begin(), tierHits_.end(), 0ULL);
+  for (size_t i = 0; i + 1 < tierHits_.size(); i++) {
+    if (count > 0) {
+      double ratio = static_cast<double>(tierHits_[i]) / count;
+      // High ratio => this tier absorbs the bulk of hits, it has room to shrink.
+      // Low ratio => hits leak to colder tiers, grow it.
+      if (ratio > 0.90) thresholds_[i].adapt(0.80);
+      else if (ratio < 0.50) thresholds_[i].adapt(1.25);
+    }
+    count -= tierHits_[i];
+  }
 
-  lru_.remove(iter->second->lruIter);
-  fileIndex_.erase(iter);
+  promoteCount_ = 0;
+  tierHits_.fill(0);
 }
 
-// Promote an idle entry back to the front of LRU.
-void FileCachePool::promoteFromIdle(IdleFileNameMap::iterator idleIt) {
-  uint32_t idleLruIter = idleIt->second;
-  const auto& filename = idleIt->first;
+void FileCachePool::demoteToCold() {
+  while (lru_.size() > thresholds_[0].value) {
+    auto tailIt = lru_.back();
+    if (tailIt->second->openCount != 0) break;
+
+    coldTiers_[0]->insert(tailIt->first);
+    lru_.remove(tailIt->second->lruIter);
+    fileIndex_.erase(tailIt);
+
+    for (size_t i = 1; i < coldTiers_.size(); i++) {
+      if (coldTiers_[i-1]->size() > thresholds_[i].value) {
+        auto key = coldTiers_[i-1]->victim();
+        coldTiers_[i]->insert(key);
+        coldTiers_[i-1]->remove(key);
+      } else break;
+    }
+  }
+}
+
+void FileCachePool::promoteToHot(std::string_view filename) {
+  auto find = fileIndex_.find(filename);
+  if (find != fileIndex_.end()) {
+    tierHits_[0]++;
+    return;
+  }
+
+  bool found = false;
+  for (size_t i = 0; i < coldTiers_.size(); ++i) {
+    if (coldTiers_[i]->contains(filename)) {
+      tierHits_[i + 1]++;
+      found = true;
+      coldTiers_[i]->remove(filename);
+      break;
+    }
+  }
+  if (!found) return;
+
+  promoteCount_++;
+  if (promoteCount_ >= kPromotesPerAdapt) adaptThresholds();
 
   struct stat st = {};
   uint64_t fileSize = 0;
@@ -471,15 +509,9 @@ void FileCachePool::promoteFromIdle(IdleFileNameMap::iterator idleIt) {
   auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
   auto iter = fileIndex_.emplace(filename, std::move(entry)).first;
   lru_.front() = iter;
-
-  idleLru_.remove(idleLruIter);
-  idleFileIndex_.erase(idleIt);
 }
 
-// Evict the idle entry pointed to by idleIt; return freed bytes or -1 on error.
-ssize_t FileCachePool::evictIdleEntry(IdleFileNameMap::iterator idleIt) {
-  const auto& filename = idleIt->first;
-
+ssize_t FileCachePool::truncateAndUnlink(std::string_view filename) {
   struct stat st = {};
   uint64_t fileSize = 0;
   if (mediaFs_->stat(filename.data(), &st) == 0) {
@@ -499,22 +531,49 @@ ssize_t FileCachePool::evictIdleEntry(IdleFileNameMap::iterator idleIt) {
     // we still evict fileSize bytes even if unlink fails
     LOG_ERRNO_RETURN(0, fileSize, "unlink failed, name : `", filename);
   }
-
-  uint32_t idleLruIter = idleIt->second;
-  idleLru_.remove(idleLruIter);
-  idleFileIndex_.erase(idleIt);
   return static_cast<ssize_t>(fileSize);
 }
 
-uint64_t FileCachePool::evictIdleWhenFull(uint64_t needEvict) {
-  uint64_t evictSize = 0;
-  while (evictSize < needEvict && !idleLru_.empty() && !exit_) {
-    auto r = evictIdleEntry(idleLru_.back());
-    if (r >= 0) evictSize += static_cast<uint64_t>(r);
-    photon::thread_yield();
-  }
-  return evictSize;
+// --- InactiveCacheTier ---
+bool InactiveCacheTier::contains(std::string_view name) {
+  return index_.find(name) != index_.end();
 }
+
+void InactiveCacheTier::remove(std::string_view name) {
+  auto it = index_.find(name);
+  if (it == index_.end()) return;
+  lru_.remove(it->second);
+  index_.erase(it);
+}
+
+void InactiveCacheTier::insert(std::string_view name) {
+  auto lruIt = lru_.push_front(index_.end());
+  auto it = index_.emplace(name, lruIt).first;
+  lru_.front() = it;
+}
+
+size_t InactiveCacheTier::size() { return index_.size(); }
+bool InactiveCacheTier::empty() { return lru_.empty(); }
+std::string_view InactiveCacheTier::victim() { return lru_.back()->first; }
+
+// --- IdleCacheTier ---
+bool IdleCacheTier::contains(std::string_view name) {
+  return index_.find(std::string(name)) != index_.end();
+}
+
+void IdleCacheTier::remove(std::string_view name) {
+  auto it = index_.find(std::string(name));
+  if (it == index_.end()) return;
+  index_.erase(it);
+}
+
+void IdleCacheTier::insert(std::string_view name) {
+  index_.emplace(name);
+}
+
+size_t IdleCacheTier::size() { return index_.size(); }
+bool IdleCacheTier::empty() { return index_.empty(); }
+std::string_view IdleCacheTier::victim() { return *index_.begin(); }
 
 }
 }

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -17,6 +17,7 @@ limitations under the License.
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -104,7 +105,8 @@ public:
         uint32_t lruIter;
         int openCount;
         uint64_t size;
-        bool truncate_done;
+        // May concurrently be modified in store write path.
+        std::atomic<bool> truncate_done;
     };
 
     // Normally, fileIndex(std::map) always keep growing, so its iterators always
@@ -117,7 +119,10 @@ public:
     void removeOpenFile(FileNameMap::iterator iter);
     void forceRecycle();
     void updateLru(FileNameMap::iterator iter);
-    int64_t updateSpace(FileNameMap::iterator iter, uint64_t size);
+    // Updates size accounting for `iter`, doing the fstat inside m_lock_ so
+    // "read on-disk size + store it" is atomic against concurrent writers to the
+    // same file.
+    int64_t updateSpace(FileNameMap::iterator iter, photon::fs::IFile* localFile);
 
     // True if the media filesystem supports fiemap. Decided once at Init()
     // time by probing a named file. When false, FileCacheStore tracks filled
@@ -154,14 +159,22 @@ protected:
     uint64_t lastDiskCheckUs_ = 0;
 
     photon::Timer *timer_;
-    bool running_;
-    bool exit_;
+    std::atomic<bool> running_;
+    std::atomic<bool> exit_;
 
-    bool isFull_;
+    std::atomic<bool> isFull_;
+
+    // Guards all pool metadata.
+    photon::mutex m_lock_;
 
     bool fiemapSupported_ = false;
     void probeFiemap();
 
+    // Opens+truncates+finalizes. MUST be called without m_lock_.
+    bool evictOpenedFile(const std::string& name);
+    // Acquires m_lock_ and finalizes eviction bookkeeping.
+    bool finalizeEvicted(const std::string& name);
+    // With m_lock_ held.
     virtual bool afterFtrucate(FileNameMap::iterator iter);
 
     int traverseDir(const std::string &root);
@@ -203,6 +216,7 @@ protected:
 
     void promoteToHot(std::string_view filename);
     ssize_t truncateAndUnlink(std::string_view filename);
+    ssize_t evictColdVictim(ColdCacheTier* tier, std::string_view name);
 
     friend struct FileCachePoolTest;
 };

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -16,10 +16,10 @@ limitations under the License.
 
 #pragma once
 
+#include <array>
 #include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 #include <photon/thread/thread.h>
 #include <photon/thread/timer.h>
@@ -32,6 +32,49 @@ limitations under the License.
 namespace photon {
 namespace fs {
 
+// Abstract base for cold (non-hot) cache tiers.
+class ColdCacheTier {
+public:
+    virtual ~ColdCacheTier() = default;
+    virtual bool contains(std::string_view name) = 0;
+    virtual void remove(std::string_view name) = 0;
+    virtual void insert(std::string_view name) = 0;
+    virtual size_t size() = 0;
+    virtual bool empty() = 0;
+    // The returned view is valid until remove().
+    virtual std::string_view victim() = 0;
+};
+
+class InactiveCacheTier : public ColdCacheTier {
+public:
+    typedef map_string_key<uint32_t> IndexMap;
+    typedef photon::fs::LRU<IndexMap::iterator, uint32_t> LRUContainer;
+
+    bool contains(std::string_view name) override;
+    void remove(std::string_view name) override;
+    void insert(std::string_view name) override;
+    size_t size() override;
+    bool empty() override;
+    std::string_view victim() override;
+
+private:
+    LRUContainer lru_;
+    IndexMap index_;
+};
+
+class IdleCacheTier : public ColdCacheTier {
+public:
+    bool contains(std::string_view name) override;
+    void remove(std::string_view name) override;
+    void insert(std::string_view name) override;
+    size_t size() override;
+    bool empty() override;
+    std::string_view victim() override;
+
+private:
+    unordered_set_string_key<> index_;
+};
+
 class FileCachePool : public photon::fs::ICachePool {
 public:
     FileCachePool(photon::fs::IFileSystem *mediaFs, uint64_t capacityInGB, uint64_t periodInUs,
@@ -42,8 +85,6 @@ public:
     static const uint64_t kDiskBlockSize = 512; // stat(2)
     static const uint64_t kDeleteDelayInUs = 1000;
     static const uint32_t kWaterMarkRatio = 90;
-    // max inuse-lru entries before demoting tail to idle-lru (default: 100w)
-    static const uint32_t kDemoteThreshold = 1'000'000;
 
     void Init();
 
@@ -131,19 +172,37 @@ protected:
     // filename -> lruEntry
     FileNameMap fileIndex_;
 
-    uint32_t demoteThreshold_ = kDemoteThreshold;
+    // Cold tiers: inactive (LRU-ordered) and idle (unordered).
+    // Eviction/promote cascades iterate coldTiers_ in order.
+    InactiveCacheTier inactiveTier_;
+    IdleCacheTier idleTier_;
+    std::array<ColdCacheTier*, 2> coldTiers_ = {&inactiveTier_, &idleTier_};
 
-    // idleFileIndex_ stores filename -> lruContainer's iterator
-    // idleLru_ stores iterators into idleFileIndex_; std::map nodes are stable.
-    typedef map_string_key<uint32_t> IdleFileNameMap;
-    typedef photon::fs::LRU<IdleFileNameMap::iterator, uint32_t> IdleLRUContainer;
-    IdleLRUContainer idleLru_;
-    IdleFileNameMap idleFileIndex_;
+    // Adaptive threshold tuning.
+    struct AdaptiveThreshold {
+        uint32_t min;
+        uint32_t max;
+        uint32_t value;
 
-    void demoteToIdle(FileNameMap::iterator iter);
-    void promoteFromIdle(IdleFileNameMap::iterator idleIter);
-    uint64_t evictIdleWhenFull(uint64_t needEvictSize);
-    ssize_t evictIdleEntry(IdleFileNameMap::iterator idleIter);
+        AdaptiveThreshold(int min, int max)
+            : min(min), max(max), value(min) {}
+        
+        void adapt(double ratio) {
+            value = std::max(min, std::min(max, static_cast<uint32_t>(value * ratio)));
+        }
+    };
+    std::array<AdaptiveThreshold, 2> thresholds_ = 
+        {AdaptiveThreshold(1'000, 100'000), AdaptiveThreshold(100'000, 100'000'000)};
+
+    static constexpr uint64_t kPromotesPerAdapt = 10'000;
+    uint64_t promoteCount_ = 0;
+    std::array<uint64_t, 3> tierHits_{};
+
+    void adaptThresholds();
+    void demoteToCold();
+
+    void promoteToHot(std::string_view filename);
+    ssize_t truncateAndUnlink(std::string_view filename);
 
     friend struct FileCachePoolTest;
 };

--- a/fs/cache/full_file_cache/cache_store.cpp
+++ b/fs/cache/full_file_cache/cache_store.cpp
@@ -84,11 +84,15 @@ ssize_t FileCacheStore::do_pwritev(const struct iovec *iov, int iovcnt, off_t of
     }
     lruEntry->truncate_done = true;
   }
-  ScopedRangeLock lock(rangeLock_, offset, view.sum());
-  SCOPE_AUDIT_THRESHOLD(10UL * 1000, "file:write", AU_FILEOP("", offset, ret));
-  ret = localFile_->pwritev(iov, iovcnt, offset);
-  if (ret > 0 && !fiemapSupported_) {
-    addFilledRange(offset, ret);
+  {
+    ScopedRangeLock lock(rangeLock_, offset, view.sum());
+    SCOPE_AUDIT_THRESHOLD(10ULL * 1000, "file:write", AU_FILEOP("", offset, ret));
+    ret = localFile_->pwritev(iov, iovcnt, offset);
+  }
+  if (ret > 0) {
+    if (!fiemapSupported_) addFilledRange(offset, ret);
+    cachePool_->updateLru(iterator_);
+    cachePool_->updateSpace(iterator_, localFile_);
   }
   return ret;
 }
@@ -100,18 +104,8 @@ ssize_t FileCacheStore::do_pwritev2(const struct iovec *iov, int iovcnt, off_t o
   }
 
   auto ret = do_pwritev(iov, iovcnt, offset);
-  if (ret < 0 && ENOSPC == errno) {
+  if ((ret < 0 && ENOSPC == errno) || cacheIsFull()) {
     cachePool_->forceRecycle();
-  }
-
-  if (ret > 0) {
-    struct stat st = {};
-    auto err = localFile_->fstat(&st);
-    if (err) {
-      LOG_ERRNO_RETURN(0, ret, "fstat failed")
-    }
-    cachePool_->updateLru(iterator_);
-    cachePool_->updateSpace(iterator_, kDiskBlockSize * st.st_blocks);
   }
   return ret;
 }

--- a/fs/cache/full_file_cache/quota_pool.h
+++ b/fs/cache/full_file_cache/quota_pool.h
@@ -21,6 +21,8 @@ limitations under the License.
 namespace photon {
 namespace fs {
 
+// TODO: support multi-threaded (multi-vCPU) access.
+// Unlike the base FileCachePool, QuotaFilePool is NOT thread-safe yet.
 class QuotaFilePool : public FileCachePool {
   public:
     typedef FileCachePool::FileNameMap::iterator FileIterator;

--- a/fs/cache/full_file_cache/quota_store.cpp
+++ b/fs/cache/full_file_cache/quota_store.cpp
@@ -67,14 +67,9 @@ ssize_t QuotaFileStore::do_pwritev2(const struct iovec *iov, int iovcnt, off_t o
   }
 
   if (ret > 0) {
-    struct stat st = {};
-    auto err = localFile_->fstat(&st);
-    if (err) {
-      LOG_ERRNO_RETURN(0, ret, "fstat failed")
-    }
     dirPool->updateDirLru(iterator_);
     cachePool_->updateLru(iterator_);
-    auto diff = dirPool->updateSpace(iterator_, QuotaFilePool::kDiskBlockSize * st.st_blocks);
+    auto diff = dirPool->updateSpace(iterator_, localFile_);
     dirPool->updateDirSpace(iterator_, diff);
   }
   return ret;

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include <photon/fs/localfs.h>
 #include <photon/fs/aligned-file.h>
 #include <photon/thread/thread.h>
+#include <photon/thread/std-compat.h>
 #include <photon/common/io-alloc.h>
 #include <photon/fs/cache/cache.h>
 
@@ -769,6 +770,7 @@ struct FileCachePoolTest {
   static size_t active_size(FileCachePool *p) { return p->lru_.size(); }
   static size_t inactive_size(FileCachePool *p) { return p->inactiveTier_.size(); }
   static size_t idle_size(FileCachePool *p) { return p->idleTier_.size(); }
+  static int64_t total_used(FileCachePool *p) { return p->totalUsed_; }
   static bool active(FileCachePool *p, std::string_view n) {
     return p->fileIndex_.find(n) != p->fileIndex_.end();
   }
@@ -1471,6 +1473,94 @@ TEST(CachePool, eviction_with_deleted_cache_dir) {
     auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
     ASSERT_NE(nullptr, store);
     store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    store->release();
+  }
+}
+
+// Multi-vCPU stress: every thread does a random mix of open/write/read/evict/
+// forceRecycle at random offsets over a shared small file set, hammering one
+// FileCachePool across N vCPUs. This maximizes per-file rw_lock contention and
+// interleaving (read-vs-evict RLOCK/WLOCK, evict-while-open, write-vs-evict,
+// concurrent do_open->demoteToCold). Must not crash, hang, corrupt metadata,
+// or drift totalUsed_ negative.
+TEST(CachePool, concurrent_stress) {
+  const int kVcpus = 6;
+  const int kThreads = 24;
+  const int kIters = 1000;
+  const int kNameCount = 6;          // small set => heavy per-file contention
+  const size_t kPage = 4 * 1024;
+  const size_t kFileSize = 1 << 20;  // 1 MiB logical size per file
+  const size_t kMaxWrite = 64 * 1024;
+  const int kOffSlots = kFileSize / kMaxWrite;
+
+  std::string root = "/mnt/tmp/ease/cache/concurrent_stress/";
+  SetupTestDir(root);
+  // psync: plain syscalls, safe across vCPUs without a per-vCPU IO engine.
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ull * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  ASSERT_EQ(0, photon_std::work_pool_init(kVcpus, photon::INIT_EVENT_DEFAULT,
+                                          photon::INIT_IO_NONE));
+  DEFER(photon_std::work_pool_fini());
+
+  // open(O_CREAT) must always succeed; a null store signals a real problem.
+  std::atomic<int> open_failures{0};
+  auto worker = [&](int tid) {
+    std::mt19937 rng(0x9e3779b9u ^ (uint32_t)tid);  // per-thread, no shared rand()
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(kMaxWrite);
+    for (int it = 0; it < kIters; it++) {
+      std::string name = "/f_" + std::to_string(rng() % kNameCount);
+      auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+      if (!store) { open_failures.fetch_add(1); continue; }
+      DEFER(store->release());
+      store->set_actual_size(kFileSize);
+      off_t off = (off_t)(rng() % kOffSlots) * kMaxWrite;  // 64K-aligned
+      switch (rng() % 10) {
+        case 0: case 1: case 2: case 3: case 4:  // write (ENOSPC ok)
+          store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), off, 0);
+          break;
+        case 5: case 6: case 7:                  // read
+          store->do_preadv2(buffer.iovec(), buffer.iovcnt(), off, 0);
+          break;
+        case 8:                                  // evict while we hold it open
+          cachePool->evict(name.c_str());
+          break;
+        default:                                 // full recycle sweep
+          pool->forceRecycle();
+      }
+    }
+  };
+
+  std::vector<photon_std::thread> threads;
+  for (int i = 0; i < kThreads; i++) threads.emplace_back(worker, i);
+  for (auto& t : threads) t.join();
+
+  // Drain, then check invariants once quiesced.
+  pool->forceRecycle();
+  EXPECT_EQ(0, open_failures.load());
+  EXPECT_GE(FileCachePoolTest::total_used(pool), 0);
+  // Each name lives in at most one tier.
+  size_t totalEntries = FileCachePoolTest::active_size(pool) +
+                        FileCachePoolTest::inactive_size(pool) +
+                        FileCachePoolTest::idle_size(pool);
+  EXPECT_LE(totalEntries, (size_t)kNameCount);
+  // Every file must still be openable/usable after the storm.
+  IOVector buf(*cacheAllocator);
+  buf.push_back(kPage);
+  for (int i = 0; i < kNameCount; i++) {
+    std::string name = "/f_" + std::to_string(i);
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->set_actual_size(kFileSize);
+    EXPECT_GE(store->do_preadv2(buf.iovec(), buf.iovcnt(), 0, 0), 0);
     store->release();
   }
 }

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 
 #include <cstring>
 #include <algorithm>
+#include <set>
 #include <random>
 #include <vector>
 
@@ -758,15 +759,24 @@ TEST(CachePool, open_same_file) {
 // Friend accessor — declared as friend in FileCachePool.
 struct FileCachePoolTest {
   static void set_demote_threshold(FileCachePool *p, uint32_t limit) {
-    p->demoteThreshold_ = limit;
+    p->thresholds_[0].min = limit;
+    p->thresholds_[0].value = limit;
   }
-  static size_t inuse_size(FileCachePool *p) { return p->lru_.size(); }
-  static size_t idle_size(FileCachePool *p) { return p->idleLru_.size(); }
-  static bool inuse(FileCachePool *p, std::string_view n) {
+  static void set_inactive_demote_threshold(FileCachePool *p, uint32_t limit) {
+    p->thresholds_[1].min = limit;
+    p->thresholds_[1].value = limit;
+  }
+  static size_t active_size(FileCachePool *p) { return p->lru_.size(); }
+  static size_t inactive_size(FileCachePool *p) { return p->inactiveTier_.size(); }
+  static size_t idle_size(FileCachePool *p) { return p->idleTier_.size(); }
+  static bool active(FileCachePool *p, std::string_view n) {
     return p->fileIndex_.find(n) != p->fileIndex_.end();
   }
+  static bool inactive(FileCachePool *p, std::string_view n) {
+    return p->inactiveTier_.contains(n);
+  }
   static bool idle(FileCachePool *p, std::string_view n) {
-    return p->idleFileIndex_.find(n) != p->idleFileIndex_.end();
+    return p->idleTier_.contains(n);
   }
 };
 
@@ -803,28 +813,28 @@ TEST(CachePool, test_demote_threshold) {
     ASSERT_TRUE(openClose(pool, name.c_str()));
   }
 
-  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
-  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+  EXPECT_LE(T::active_size(pool), demoteThreshold);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
 
-  // first fileNum-demoteThreshold files are in idle
+  // first fileNum-demoteThreshold files are in inactive or idle
   for (size_t i = 0; i < fileNum - demoteThreshold; i++) {
     std::string name = "/f" + std::to_string(i);
-    EXPECT_TRUE(T::idle(pool, name));
-    EXPECT_FALSE(T::inuse(pool, name));
+    EXPECT_TRUE(T::inactive(pool, name) || T::idle(pool, name));
+    EXPECT_FALSE(T::active(pool, name));
   }
-  // last demoteThreshold files are in hot
+  // last demoteThreshold files are in active
   for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
     std::string name = "/f" + std::to_string(i);
-    EXPECT_TRUE(T::inuse(pool, name));
-    EXPECT_FALSE(T::idle(pool, name));
+    EXPECT_TRUE(T::active(pool, name));
+    EXPECT_FALSE(T::inactive(pool, name));
   }
-  // re-open /f0 — must promote to hot
+  // re-open /f0 — must promote to active
   ASSERT_TRUE(openClose(pool, "/f0"));
-  EXPECT_TRUE(T::inuse(pool, "/f0"));
-  EXPECT_FALSE(T::idle(pool, "/f0"));
+  EXPECT_TRUE(T::active(pool, "/f0"));
+  EXPECT_FALSE(T::inactive(pool, "/f0"));
 
-  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
-  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+  EXPECT_LE(T::active_size(pool), demoteThreshold);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
 
   // random access
   for (size_t i = 0; i < 100; i++) {
@@ -833,16 +843,17 @@ TEST(CachePool, test_demote_threshold) {
     ASSERT_TRUE(openClose(pool, name.c_str()));
 
     if (rand() % 3 == 0) {
-      EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
+      EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
     }
   }
 }
 
-TEST(CachePool, evict_idle_file) {
-  std::string root = "/mnt/tmp/ease/cache/evict_idle_file/";
+TEST(CachePool, three_tier_cascade) {
+  std::string root = "/tmp/ease/cache/three_tier_cascade/";
   SetupTestDir(root);
-  const size_t demoteThreshold = 10;
-  const size_t fileNum = 100;
+  const size_t activeLimit = 5;
+  const size_t inactiveLimit = 10;
+  const size_t fileNum = 30;
 
   auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
   auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
@@ -855,46 +866,113 @@ TEST(CachePool, evict_idle_file) {
 
   auto pool = dynamic_cast<FileCachePool*>(cachePool);
   ASSERT_NE(nullptr, pool);
-  T::set_demote_threshold(pool, demoteThreshold);
+  T::set_demote_threshold(pool, activeLimit);
+  T::set_inactive_demote_threshold(pool, inactiveLimit);
 
+  // Open 30 files sequentially — forces cascade: active → inactive → idle
+  // Sleep between opens must exceed storeCacheTTLUsecs (1ms) so that each
+  // store expires before the next open, allowing demoteToInactive to run.
   for (size_t i = 0; i < fileNum; i++) {
-    photon::thread_usleep(100);
+    photon::thread_usleep(1500);
     std::string name = "/f" + std::to_string(i);
     ASSERT_TRUE(openClose(pool, name.c_str()));
   }
 
-  photon::thread_sleep(1);
+  // --- 1. Verify tier sizes ---
+  EXPECT_LE(T::active_size(pool), activeLimit);
+  EXPECT_LE(T::inactive_size(pool), inactiveLimit);
+  EXPECT_GT(T::idle_size(pool), 0u);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
+
+  // Earliest files in idle, middle in inactive, latest in active
+  size_t expectedIdle = fileNum - activeLimit - inactiveLimit;
+  EXPECT_EQ(T::idle_size(pool), expectedIdle);
+  for (size_t i = 0; i < expectedIdle; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::idle(pool, name)) << name << " should be in idle tier";
+  }
+  for (size_t i = expectedIdle; i < fileNum - activeLimit; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::inactive(pool, name)) << name << " should be in inactive tier";
+  }
+  for (size_t i = fileNum - activeLimit; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    EXPECT_TRUE(T::active(pool, name)) << name << " should be in active tier";
+  }
+
+  // --- 2. Promote from idle → active ---
   ASSERT_TRUE(T::idle(pool, "/f0"));
-  EXPECT_LE(T::inuse_size(pool), demoteThreshold);
-  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum);
-
-  ASSERT_EQ(0, pool->evict("/f0"));
+  ASSERT_TRUE(openClose(pool, "/f0"));
+  EXPECT_TRUE(T::active(pool, "/f0"));
   EXPECT_FALSE(T::idle(pool, "/f0"));
-  EXPECT_FALSE(T::inuse(pool, "/f0"));
-  EXPECT_EQ(T::inuse_size(pool), demoteThreshold);
-  EXPECT_EQ(T::inuse_size(pool) + T::idle_size(pool), fileNum - 1);
+  EXPECT_FALSE(T::inactive(pool, "/f0"));
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
 
-  std::vector<bool> evicted(fileNum, false);
-  evicted[0] = true;
-  for (size_t i = 0; i < 9; i++) {
-    int index = rand() % fileNum;
-    std::string name = "/f" + std::to_string(index);
-    while (evicted[index] || !T::idle(pool, name)) {
-      index = rand() % fileNum;
-      name = "/f" + std::to_string(index);
+  // --- 3. Promote from inactive → active ---
+  std::string inactiveName;
+  for (size_t i = 0; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    if (T::inactive(pool, name)) { inactiveName = name; break; }
+  }
+  ASSERT_FALSE(inactiveName.empty());
+  ASSERT_TRUE(openClose(pool, inactiveName.c_str()));
+  EXPECT_TRUE(T::active(pool, inactiveName));
+  EXPECT_FALSE(T::inactive(pool, inactiveName));
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum);
+
+  // --- 4. Evict from idle ---
+  std::string idleName;
+  for (size_t i = 0; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    if (T::idle(pool, name)) { idleName = name; break; }
+  }
+  ASSERT_FALSE(idleName.empty());
+  size_t idleBefore = T::idle_size(pool);
+  ASSERT_EQ(0, pool->evict(idleName));
+  EXPECT_FALSE(T::idle(pool, idleName));
+  EXPECT_FALSE(T::inactive(pool, idleName));
+  EXPECT_FALSE(T::active(pool, idleName));
+  EXPECT_EQ(T::idle_size(pool), idleBefore - 1);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum - 1);
+
+  // --- 5. Evict from inactive ---
+  inactiveName.clear();
+  for (size_t i = 0; i < fileNum; i++) {
+    std::string name = "/f" + std::to_string(i);
+    if (T::inactive(pool, name)) { inactiveName = name; break; }
+  }
+  ASSERT_FALSE(inactiveName.empty());
+  size_t inactiveBefore = T::inactive_size(pool);
+  ASSERT_EQ(0, pool->evict(inactiveName));
+  EXPECT_FALSE(T::inactive(pool, inactiveName));
+  EXPECT_EQ(T::inactive_size(pool), inactiveBefore - 1);
+  EXPECT_EQ(T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool), fileNum - 2);
+
+  // --- 6. Random access preserves invariant ---
+  // Skip evicted files to avoid re-creating cache entries.
+  std::set<std::string> evicted;
+  evicted.insert(idleName);
+  evicted.insert(inactiveName);
+  size_t totalFiles = fileNum - evicted.size();
+  for (size_t i = 0; i < 200; i++) {
+    int r = rand() % fileNum;
+    std::string name = "/f" + std::to_string(r);
+    if (evicted.count(name)) continue;
+    openClose(pool, name.c_str());
+    if (i % 10 == 0) {
+      photon::thread_usleep(1500);
+      size_t total = T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool);
+      EXPECT_EQ(total, totalFiles);
     }
-    ASSERT_EQ(0, pool->evict(name));
-    evicted[index] = true;
-    EXPECT_FALSE(T::idle(pool, name));
-    EXPECT_EQ(T::idle_size(pool), fileNum - demoteThreshold - 2 - i);
   }
 }
 
-TEST(CachePool, evict_by_size_idle_first) {
-  std::string root = "/mnt/tmp/ease/cache/evict_by_size/";
+TEST(CachePool, evict_by_size_cold_first) {
+  std::string root = "/tmp/ease/cache/evict_by_size_cold_first/";
   SetupTestDir(root);
   const uint64_t capacityGB = 1;
-  const size_t demoteThreshold = 5;
+  const size_t activeLimit = 5;
+  const size_t inactiveLimit = 10;
   const size_t fileNum = 40;
   const size_t fileSizeMB = 60;
   const size_t fileSizeBytes = fileSizeMB * 1024 * 1024;
@@ -910,13 +988,14 @@ TEST(CachePool, evict_by_size_idle_first) {
 
   auto pool = dynamic_cast<FileCachePool*>(cachePool);
   ASSERT_NE(nullptr, pool);
-  T::set_demote_threshold(pool, demoteThreshold);
+  T::set_demote_threshold(pool, activeLimit);
+  T::set_inactive_demote_threshold(pool, inactiveLimit);
 
   IOVector buffer(*cacheAllocator);
   buffer.push_back(fileSizeBytes);
 
   for (size_t i = 0; i < fileNum; i++) {
-    photon::thread_usleep(1000);
+    photon::thread_usleep(1500);
     std::string name = "/g" + std::to_string(i);
     auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
     ASSERT_NE(nullptr, store);
@@ -924,25 +1003,33 @@ TEST(CachePool, evict_by_size_idle_first) {
     store->release();
   }
 
-  size_t remaining = T::inuse_size(pool) + T::idle_size(pool);
-  EXPECT_LT(remaining, fileNum);
-  EXPECT_LE(T::inuse_size(pool), (size_t)demoteThreshold);
+  // After writing 40 x 60MB = 2.4GB with 1GB capacity, eviction should have
+  // kicked in.  Cold tiers (idle first, then inactive) are evicted before active.
+  EXPECT_LE(T::active_size(pool), activeLimit);
+  size_t totalRemaining = T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool);
+  EXPECT_LT(totalRemaining, fileNum);
 
-  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+  // The most recent active files must survive eviction
+  for (size_t i = fileNum - activeLimit; i < fileNum; i++) {
     std::string name = "/g" + std::to_string(i);
-    EXPECT_TRUE(T::inuse(pool, name)) << name << " should still be in hot";
-    EXPECT_FALSE(T::idle(pool, name)) << name << " must not be in idle";
+    EXPECT_TRUE(T::active(pool, name)) << name << " should still be in active";
   }
 
-  // Write a new file to trigger eviction, the idle file should be evicted first
+  // Idle tier should be drained first — if any files remain in cold tiers,
+  // idle should have fewer or equal entries compared to inactive.
+  EXPECT_LE(T::idle_size(pool), T::inactive_size(pool));
+
+  // Write one more file to trigger another round of eviction
   std::string name = "/g" + std::to_string(fileNum);
   auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
   ASSERT_NE(nullptr, store);
   store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
   store->release();
-  for (size_t i = fileNum - demoteThreshold; i < fileNum; i++) {
+
+  // Active files must still survive after the extra eviction round
+  for (size_t i = fileNum - activeLimit; i < fileNum; i++) {
     std::string name = "/g" + std::to_string(i);
-    bool existed = T::inuse(pool, name) || T::idle(pool, name);
+    bool existed = T::active(pool, name) || T::inactive(pool, name);
     EXPECT_TRUE(existed) << name << " must still exist";
   }
 }
@@ -979,7 +1066,7 @@ TEST(CachePool, DISABLED_test_mem_usage) {
   SetupTestDir(root);
   const uint64_t capacityGB = 1;
   const size_t fileNum = 10'000'000;
-  const size_t inuse = 1'000'000;
+  const size_t activeNum = 100'000;
 
   auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_libaio);
   auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
@@ -1003,11 +1090,11 @@ TEST(CachePool, DISABLED_test_mem_usage) {
     store->release();
     if (i % 100'000 == 0) {
       LOG_INFO("Opened ` files. current: ` KiB.", i+1, get_physical_memory_KiB());
-      LOG_INFO("inuse size `, idle size `", T::inuse_size(pool), T::idle_size(pool));
+      LOG_INFO("active size `, inactive size `", T::active_size(pool), T::inactive_size(pool));
     }
   }
-  EXPECT_EQ(inuse, T::inuse_size(pool));
-  EXPECT_EQ(fileNum - inuse, T::idle_size(pool));
+  EXPECT_EQ(activeNum, T::active_size(pool));
+  EXPECT_EQ(fileNum - activeNum, T::inactive_size(pool) + T::idle_size(pool));
 
   photon::thread_sleep(10);
   malloc_trim(0);
@@ -1394,6 +1481,7 @@ int main(int argc, char** argv) {
   log_output_level = ALOG_ERROR;
   // photon::vcpu_init();
   ::testing::InitGoogleTest(&argc, argv);
+  srand(time(nullptr));
 
   photon::init();
   DEFER(photon::fini());


### PR DESCRIPTION
## What

Backport the two cache features that had diverged between `main` and `release/0.9`, bringing `fs/cache` to functional parity with `main`.

Cherry-picked (in order):
1. **#1207** `add string-keyed set and unordered_set` — prerequisite for the idle tier's `unordered_set_string_key`.
2. **#1209** `introduce three-tier LRU cache (active→inactive→idle)` — generalized cold-tier abstraction (`ColdCacheTier`/`InactiveCacheTier`/`IdleCacheTier`) with adaptive thresholds, replacing the older single idle-LRU scheme.
3. **#1555** `make FileCachePool thread-safe for multi-vCPU access` — `m_lock_` guarding pool metadata, atomic flags, `updateSpace(IFile*)` doing the `fstat` under lock, and the `evictOpenedFile`/`finalizeEvicted` split.

## Notes

- `#1555` uses `photon::mutex::locked()` (added on `main` in #1168). To avoid pulling in that change, the two debug-only `assert(m_lock_.locked())` calls were dropped instead.
- Deliberately **not** included: #1378 (portability `UL→ULL` / `sys/fcntl.h`) and #1563 (CMake modernization) — build/portability only, no runtime behavior change on Linux.

## Test

Built with full features and ran `cache_test` in the `ghcr.io/alibaba/photon-ut-base` container: **18/18 passed**, including `concurrent_stress` (#1555) and `three_tier_cascade` (#1209).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
