### PR TITLE
[Backport][main to 0.9] | feat(cache): make FileCachePool thread-safe for multi-vCPU access (#1555)

### DIFF
--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "cache_pool.h"
+#include <cassert>
 #include <dirent.h>
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -117,6 +118,7 @@ void FileCachePool::probeFiemap() {
 }
 
 ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t mode) {
+  SCOPED_LOCK(m_lock_);
   auto localFile = openMedia(pathname, flags, mode);
   if (!localFile) {
     return nullptr;
@@ -169,43 +171,56 @@ int FileCachePool::stat(CacheStat* stat, std::string_view pathname) {
   return -1;
 }
 
-int FileCachePool::evict(std::string_view filename) {
-  // Check cold tiers first
-  for (auto* tier : coldTiers_) {
-    if (tier->contains(filename)) {
-      auto freed = truncateAndUnlink(filename);
-      tier->remove(filename);
-      return freed >= 0 ? 0 : -1;
-    }
-  }
-
-  auto fileIter = fileIndex_.find(filename);
-  if (fileIter == fileIndex_.end()) {
-    LOG_ERROR("Evict no such file , name: `", filename);
-    return 0;
-  }
-
-  const auto& filePath = fileIter->first;
-  auto lruEntry = fileIter->second.get();
-  if (lruEntry->openCount == 0) {
-    lru_.mark_key_cleared(lruEntry->lruIter);
-  }
+// Opens `name`, truncates it, then finalizes eviction.
+// MUST be called WITHOUT m_lock_ held.
+bool FileCachePool::evictOpenedFile(const std::string& name) {
   int err = 0;
-  auto cacheStore = static_cast<FileCacheStore*>(open(filePath, O_RDWR, 0644));
+  auto cacheStore = static_cast<FileCacheStore*>(open(name, O_RDWR, 0644));
   if (cacheStore) {
     DEFER(cacheStore->release());
     photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
     err = cacheStore->evict(0);
-    lruEntry->truncate_done = false;
   }
   if (err) {
     ERRNO e;
-    LOG_ERROR("truncate(0) failed, name: `, ret: `, error code: `", filePath,
-              err, e);
-    // If truncate fails, we can attempt to remove the file directly
-    // in the afterFtrucate function.
+    LOG_ERROR("truncate(0) failed, name: `, ret: `, error code: `", name, err, e);
+    // Fall through: afterFtrucate can still remove the file directly.
   }
-  return afterFtrucate(fileIter) ? 0 : -1;
+  return finalizeEvicted(name);
+}
+
+// Acquires m_lock_ and finalizes eviction bookkeeping for `name`.
+bool FileCachePool::finalizeEvicted(const std::string& name) {
+  SCOPED_LOCK(m_lock_);
+  auto it = fileIndex_.find(name);
+  if (it == fileIndex_.end()) return true;  // already evicted concurrently
+  it->second->truncate_done = false;
+  return afterFtrucate(it);
+}
+
+int FileCachePool::evict(std::string_view filename) {
+  std::string name(filename);
+  {
+    SCOPED_LOCK(m_lock_);
+    // Check cold tiers first
+    for (auto* tier : coldTiers_) {
+      if (tier->contains(filename)) {
+        auto freed = evictColdVictim(tier, filename);
+        return freed >= 0 ? 0 : -1;
+      }
+    }
+
+    auto fileIter = fileIndex_.find(name);
+    if (fileIter == fileIndex_.end()) {
+      LOG_ERROR("Evict no such file , name: `", filename);
+      return 0;
+    }
+    auto lruEntry = fileIter->second.get();
+    if (lruEntry->openCount == 0) {
+      lru_.mark_key_cleared(lruEntry->lruIter);
+    }
+  }
+  return evictOpenedFile(name) ? 0 : -1;
 }
 
 int FileCachePool::evict(size_t size) {
@@ -223,6 +238,7 @@ bool FileCachePool::isFull() {
 }
 
 void FileCachePool::removeOpenFile(FileNameMap::iterator iter) {
+  SCOPED_LOCK(m_lock_);
   iter->second->openCount--;
 }
 
@@ -231,11 +247,18 @@ void FileCachePool::forceRecycle() {
 }
 
 void FileCachePool::updateLru(FileNameMap::iterator iter) {
+  SCOPED_LOCK(m_lock_);
   lru_.access(iter->second->lruIter);
 }
 
 //  currently, we exist duplicate pwrite
-int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
+int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, IFile* localFile) {
+  SCOPED_LOCK(m_lock_);
+  struct stat st = {};
+  if (localFile->fstat(&st) != 0) {
+    LOG_ERRNO_RETURN(0, 0, "fstat failed");
+  }
+  uint64_t size = kDiskBlockSize * st.st_blocks;
   auto lruEntry = iter->second.get();
   auto diff = static_cast<int64_t>(size) - static_cast<int64_t>(lruEntry->size);
   totalUsed_ += diff;
@@ -257,13 +280,7 @@ int64_t FileCachePool::updateSpace(FileNameMap::iterator iter, uint64_t size) {
       LOG_WARN("disk free space below floor `, force recycle", diskAvailInBytes_);
     }
   }
-
-  if (full) {
-    isFull_ = true;
-    forceRecycle();
-    if (lruEntry->size==0) diff = 0;//in some extream condition ,
-                                    //forceRecycle maybe truncate current file to 0
-  }
+  if (full) isFull_ = true;
   return diff;
 }
 
@@ -279,10 +296,10 @@ bool FileCachePool::diskSpaceLow() {
 
 uint64_t FileCachePool::timerHandler(void* data) {
   auto cur = static_cast<FileCachePool*>(data);
-  if (cur->running_) {
+  // Atomic test-and-set: only one vCPU runs eviction at a time.
+  if (cur->running_.exchange(true)) {
     return 0;
   }
-  cur->running_ = true;
   DEFER(cur->running_ = false;);
   cur->eviction();
   return 0;
@@ -309,79 +326,71 @@ void FileCachePool::eviction() {
     }
   }
 
-  if (totalUsed_ >= static_cast<int64_t>(waterMark_)) {
-    evictByCache = totalUsed_ - waterMark_;
-  }
-
-  auto actualEvict = std::min(
-    static_cast<int64_t>(std::max(evictByCache, evictByDisk)),
-    totalUsed_
-  );
-
-  if (actualEvict <= 0) {
-    return;
-  }
-
-  isFull_ = true;
-
-  // Evict from cold tiers first in reverse order
-  for (int i = coldTiers_.size() - 1; i >= 0; i--) {
-    auto* tier = coldTiers_[i];
-    while (actualEvict > 0 && !tier->empty() && !exit_) {
-      auto name = tier->victim();
-      auto freed = truncateAndUnlink(name);
-      tier->remove(name);
-      if (freed >= 0) actualEvict -= freed;
-      photon::thread_yield();
+  int64_t actualEvict;
+  {
+    SCOPED_LOCK(m_lock_);
+    if (totalUsed_ >= static_cast<int64_t>(waterMark_)) {
+      evictByCache = totalUsed_ - waterMark_;
     }
-  }
 
-  if (!lru_.empty() && !exit_) {
-    LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
+    actualEvict = std::min(
+      static_cast<int64_t>(std::max(evictByCache, evictByDisk)),
+      totalUsed_
+    );
+
+    if (actualEvict <= 0) {
+      return;
+    }
+
+    isFull_ = true;
+
+    for (auto i = coldTiers_.size(); i > 0 && actualEvict > 0 && !exit_; --i) {
+      auto* tier = coldTiers_[i - 1];
+      while (actualEvict > 0 && !tier->empty() && !exit_) {
+        auto freed = evictColdVictim(tier, tier->victim());
+        if (freed >= 0) actualEvict -= freed;
+      }
+    }
+
+    if (!lru_.empty() && !exit_) {
+      LOG_AUDIT("eviction", VALUE(actualEvict), VALUE(evictByCache), VALUE(evictByDisk), VALUE(totalUsed_));
+    }
   }
 
   uint64_t empty_files_sequence = 0;
-  while (actualEvict > 0 && !lru_.empty() && !exit_) {
-    auto fileIter = lru_.back();
-    const auto& fileName = fileIter->first;
-    auto lruEntry = fileIter->second.get();
-    auto fileSize = lruEntry->size;
-    if (lruEntry->openCount == 0){
-      lru_.mark_key_cleared(fileIter->second->lruIter);
-    } else {
-      lru_.access(fileIter->second->lruIter);
-    }
-    //as soon as possible truncate and unlink
-    if (0 == fileSize) {
-        if (0 == fileIter->second->openCount) {
-            afterFtrucate(fileIter);
+  while (actualEvict > 0 && !exit_) {
+    std::string fileName;
+    uint64_t fileSize;
+    {
+      SCOPED_LOCK(m_lock_);
+      if (lru_.empty() || totalUsed_ <= 0) break;
+      auto fileIter = lru_.back();
+      fileName = std::string(fileIter->first);
+      auto lruEntry = fileIter->second.get();
+      fileSize = lruEntry->size;
+      if (lruEntry->openCount == 0) {
+        lru_.mark_key_cleared(lruEntry->lruIter);
+      } else {
+        lru_.access(lruEntry->lruIter);
+      }
+      if (0 == fileSize) {
+        if (0 == lruEntry->openCount) {
+          afterFtrucate(fileIter);
         } else {
           empty_files_sequence++;
-          if (empty_files_sequence == lru_.size()) {
+          if (empty_files_sequence >= lru_.size()) {
             LOG_ERROR("eviction: all ` LRU entries have size=0 with openCount>0, "
               "cannot make progress. actualEvict=`, totalUsed=`",
               lru_.size(), actualEvict, totalUsed_);
             break;
           }
         }
-        continue;
+        continue;  // releases m_lock_ via SCOPED_LOCK scope
+      }
+      empty_files_sequence = 0;
     }
-
-    empty_files_sequence = 0;
-    int err = 0;
-    auto cacheStore = static_cast<FileCacheStore*>(open(fileName, O_RDWR, 0644));
-    if (cacheStore) {
-      DEFER(cacheStore->release());
-      photon::scoped_rwlock rl(cacheStore->rw_lock(), photon::WLOCK);
-      err = cacheStore->evict(0);
-      lruEntry->truncate_done = false;
-    }
-
-    if (err) {
-      ERRNO e;
-      LOG_ERROR("truncate(0) failed, name : `, ret : `, error code : `", fileName, err, e);
-    }
-    afterFtrucate(fileIter);
+    // open()+WLOCK+finalize with m_lock_ released.
+    evictOpenedFile(fileName);
     actualEvict -= fileSize;
     photon::thread_yield();
   }
@@ -392,6 +401,7 @@ uint64_t FileCachePool::calcWaterMark(uint64_t capacity, uint64_t maxFreeSpace) 
     capacity > maxFreeSpace ? capacity - maxFreeSpace : 0);
 }
 
+// With m_lock_ held.
 bool FileCachePool::afterFtrucate(FileNameMap::iterator iter) {
   auto lruEntry = iter->second.get();
   totalUsed_ -= static_cast<int64_t>(lruEntry->size);
@@ -432,6 +442,7 @@ int FileCachePool::insertFile(std::string_view file) {
   }
   auto fileSize = st.st_blocks * kDiskBlockSize;
 
+  SCOPED_LOCK(m_lock_);
   auto lruIter = lru_.push_front(fileIndex_.end());
   auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
   auto iter = fileIndex_.emplace(file, std::move(entry)).first;
@@ -459,6 +470,7 @@ void FileCachePool::adaptThresholds() {
   tierHits_.fill(0);
 }
 
+// With m_lock_ held.
 void FileCachePool::demoteToCold() {
   while (lru_.size() > thresholds_[0].value) {
     auto tailIt = lru_.back();
@@ -478,6 +490,7 @@ void FileCachePool::demoteToCold() {
   }
 }
 
+// With m_lock_ held.
 void FileCachePool::promoteToHot(std::string_view filename) {
   auto find = fileIndex_.find(filename);
   if (find != fileIndex_.end()) {
@@ -511,6 +524,18 @@ void FileCachePool::promoteToHot(std::string_view filename) {
   lru_.front() = iter;
 }
 
+// With m_lock_ held.
+ssize_t FileCachePool::evictColdVictim(ColdCacheTier* tier, std::string_view name) {
+  auto freed = truncateAndUnlink(name);
+  tier->remove(name);
+  if (freed >= 0) {
+    totalUsed_ -= freed;
+    if (totalUsed_ < 0) totalUsed_ = 0;
+  }
+  return freed;
+}
+
+// I/O only: does NOT touch totalUsed_ and does NOT require m_lock_.
 ssize_t FileCachePool::truncateAndUnlink(std::string_view filename) {
   struct stat st = {};
   uint64_t fileSize = 0;
@@ -523,8 +548,6 @@ ssize_t FileCachePool::truncateAndUnlink(std::string_view filename) {
     if (err) {
       LOG_ERRNO_RETURN(0, -1, "truncate(0) failed, name : `", filename);
     }
-    totalUsed_ -= static_cast<int64_t>(fileSize);
-    if (totalUsed_ < 0) totalUsed_ = 0;
   }
   int err = mediaFs_->unlink(filename.data());
   if (err) {

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -17,6 +17,7 @@ limitations under the License.
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -104,7 +105,8 @@ public:
         uint32_t lruIter;
         int openCount;
         uint64_t size;
-        bool truncate_done;
+        // May concurrently be modified in store write path.
+        std::atomic<bool> truncate_done;
     };
 
     // Normally, fileIndex(std::map) always keep growing, so its iterators always
@@ -117,7 +119,10 @@ public:
     void removeOpenFile(FileNameMap::iterator iter);
     void forceRecycle();
     void updateLru(FileNameMap::iterator iter);
-    int64_t updateSpace(FileNameMap::iterator iter, uint64_t size);
+    // Updates size accounting for `iter`, doing the fstat inside m_lock_ so
+    // "read on-disk size + store it" is atomic against concurrent writers to the
+    // same file.
+    int64_t updateSpace(FileNameMap::iterator iter, photon::fs::IFile* localFile);
 
     // True if the media filesystem supports fiemap. Decided once at Init()
     // time by probing a named file. When false, FileCacheStore tracks filled
@@ -154,14 +159,22 @@ protected:
     uint64_t lastDiskCheckUs_ = 0;
 
     photon::Timer *timer_;
-    bool running_;
-    bool exit_;
+    std::atomic<bool> running_;
+    std::atomic<bool> exit_;
 
-    bool isFull_;
+    std::atomic<bool> isFull_;
+
+    // Guards all pool metadata.
+    photon::mutex m_lock_;
 
     bool fiemapSupported_ = false;
     void probeFiemap();
 
+    // Opens+truncates+finalizes. MUST be called without m_lock_.
+    bool evictOpenedFile(const std::string& name);
+    // Acquires m_lock_ and finalizes eviction bookkeeping.
+    bool finalizeEvicted(const std::string& name);
+    // With m_lock_ held.
     virtual bool afterFtrucate(FileNameMap::iterator iter);
 
     int traverseDir(const std::string &root);
@@ -203,6 +216,7 @@ protected:
 
     void promoteToHot(std::string_view filename);
     ssize_t truncateAndUnlink(std::string_view filename);
+    ssize_t evictColdVictim(ColdCacheTier* tier, std::string_view name);
 
     friend struct FileCachePoolTest;
 };

--- a/fs/cache/full_file_cache/cache_store.cpp
+++ b/fs/cache/full_file_cache/cache_store.cpp
@@ -84,11 +84,15 @@ ssize_t FileCacheStore::do_pwritev(const struct iovec *iov, int iovcnt, off_t of
     }
     lruEntry->truncate_done = true;
   }
-  ScopedRangeLock lock(rangeLock_, offset, view.sum());
-  SCOPE_AUDIT_THRESHOLD(10UL * 1000, "file:write", AU_FILEOP("", offset, ret));
-  ret = localFile_->pwritev(iov, iovcnt, offset);
-  if (ret > 0 && !fiemapSupported_) {
-    addFilledRange(offset, ret);
+  {
+    ScopedRangeLock lock(rangeLock_, offset, view.sum());
+    SCOPE_AUDIT_THRESHOLD(10ULL * 1000, "file:write", AU_FILEOP("", offset, ret));
+    ret = localFile_->pwritev(iov, iovcnt, offset);
+  }
+  if (ret > 0) {
+    if (!fiemapSupported_) addFilledRange(offset, ret);
+    cachePool_->updateLru(iterator_);
+    cachePool_->updateSpace(iterator_, localFile_);
   }
   return ret;
 }
@@ -100,18 +104,8 @@ ssize_t FileCacheStore::do_pwritev2(const struct iovec *iov, int iovcnt, off_t o
   }
 
   auto ret = do_pwritev(iov, iovcnt, offset);
-  if (ret < 0 && ENOSPC == errno) {
+  if ((ret < 0 && ENOSPC == errno) || cacheIsFull()) {
     cachePool_->forceRecycle();
-  }
-
-  if (ret > 0) {
-    struct stat st = {};
-    auto err = localFile_->fstat(&st);
-    if (err) {
-      LOG_ERRNO_RETURN(0, ret, "fstat failed")
-    }
-    cachePool_->updateLru(iterator_);
-    cachePool_->updateSpace(iterator_, kDiskBlockSize * st.st_blocks);
   }
   return ret;
 }

--- a/fs/cache/full_file_cache/quota_pool.h
+++ b/fs/cache/full_file_cache/quota_pool.h
@@ -21,6 +21,8 @@ limitations under the License.
 namespace photon {
 namespace fs {
 
+// TODO: support multi-threaded (multi-vCPU) access.
+// Unlike the base FileCachePool, QuotaFilePool is NOT thread-safe yet.
 class QuotaFilePool : public FileCachePool {
   public:
     typedef FileCachePool::FileNameMap::iterator FileIterator;

--- a/fs/cache/full_file_cache/quota_store.cpp
+++ b/fs/cache/full_file_cache/quota_store.cpp
@@ -67,14 +67,9 @@ ssize_t QuotaFileStore::do_pwritev2(const struct iovec *iov, int iovcnt, off_t o
   }
 
   if (ret > 0) {
-    struct stat st = {};
-    auto err = localFile_->fstat(&st);
-    if (err) {
-      LOG_ERRNO_RETURN(0, ret, "fstat failed")
-    }
     dirPool->updateDirLru(iterator_);
     cachePool_->updateLru(iterator_);
-    auto diff = dirPool->updateSpace(iterator_, QuotaFilePool::kDiskBlockSize * st.st_blocks);
+    auto diff = dirPool->updateSpace(iterator_, localFile_);
     dirPool->updateDirSpace(iterator_, diff);
   }
   return ret;

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include <photon/fs/localfs.h>
 #include <photon/fs/aligned-file.h>
 #include <photon/thread/thread.h>
+#include <photon/thread/std-compat.h>
 #include <photon/common/io-alloc.h>
 #include <photon/fs/cache/cache.h>
 
@@ -769,6 +770,7 @@ struct FileCachePoolTest {
   static size_t active_size(FileCachePool *p) { return p->lru_.size(); }
   static size_t inactive_size(FileCachePool *p) { return p->inactiveTier_.size(); }
   static size_t idle_size(FileCachePool *p) { return p->idleTier_.size(); }
+  static int64_t total_used(FileCachePool *p) { return p->totalUsed_; }
   static bool active(FileCachePool *p, std::string_view n) {
     return p->fileIndex_.find(n) != p->fileIndex_.end();
   }
@@ -1471,6 +1473,94 @@ TEST(CachePool, eviction_with_deleted_cache_dir) {
     auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
     ASSERT_NE(nullptr, store);
     store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+    store->release();
+  }
+}
+
+// Multi-vCPU stress: every thread does a random mix of open/write/read/evict/
+// forceRecycle at random offsets over a shared small file set, hammering one
+// FileCachePool across N vCPUs. This maximizes per-file rw_lock contention and
+// interleaving (read-vs-evict RLOCK/WLOCK, evict-while-open, write-vs-evict,
+// concurrent do_open->demoteToCold). Must not crash, hang, corrupt metadata,
+// or drift totalUsed_ negative.
+TEST(CachePool, concurrent_stress) {
+  const int kVcpus = 6;
+  const int kThreads = 24;
+  const int kIters = 1000;
+  const int kNameCount = 6;          // small set => heavy per-file contention
+  const size_t kPage = 4 * 1024;
+  const size_t kFileSize = 1 << 20;  // 1 MiB logical size per file
+  const size_t kMaxWrite = 64 * 1024;
+  const int kOffSlots = kFileSize / kMaxWrite;
+
+  std::string root = "/mnt/tmp/ease/cache/concurrent_stress/";
+  SetupTestDir(root);
+  // psync: plain syscalls, safe across vCPUs without a per-vCPU IO engine.
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ull * 1024 * 1024, cacheAllocator, 0);
+  auto cachePool = roCachedFs->get_pool();
+  auto pool = dynamic_cast<FileCachePool*>(cachePool);
+  ASSERT_NE(nullptr, pool);
+  DEFER({ delete cacheAllocator; delete roCachedFs; });
+
+  ASSERT_EQ(0, photon_std::work_pool_init(kVcpus, photon::INIT_EVENT_DEFAULT,
+                                          photon::INIT_IO_NONE));
+  DEFER(photon_std::work_pool_fini());
+
+  // open(O_CREAT) must always succeed; a null store signals a real problem.
+  std::atomic<int> open_failures{0};
+  auto worker = [&](int tid) {
+    std::mt19937 rng(0x9e3779b9u ^ (uint32_t)tid);  // per-thread, no shared rand()
+    IOVector buffer(*cacheAllocator);
+    buffer.push_back(kMaxWrite);
+    for (int it = 0; it < kIters; it++) {
+      std::string name = "/f_" + std::to_string(rng() % kNameCount);
+      auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+      if (!store) { open_failures.fetch_add(1); continue; }
+      DEFER(store->release());
+      store->set_actual_size(kFileSize);
+      off_t off = (off_t)(rng() % kOffSlots) * kMaxWrite;  // 64K-aligned
+      switch (rng() % 10) {
+        case 0: case 1: case 2: case 3: case 4:  // write (ENOSPC ok)
+          store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), off, 0);
+          break;
+        case 5: case 6: case 7:                  // read
+          store->do_preadv2(buffer.iovec(), buffer.iovcnt(), off, 0);
+          break;
+        case 8:                                  // evict while we hold it open
+          cachePool->evict(name.c_str());
+          break;
+        default:                                 // full recycle sweep
+          pool->forceRecycle();
+      }
+    }
+  };
+
+  std::vector<photon_std::thread> threads;
+  for (int i = 0; i < kThreads; i++) threads.emplace_back(worker, i);
+  for (auto& t : threads) t.join();
+
+  // Drain, then check invariants once quiesced.
+  pool->forceRecycle();
+  EXPECT_EQ(0, open_failures.load());
+  EXPECT_GE(FileCachePoolTest::total_used(pool), 0);
+  // Each name lives in at most one tier.
+  size_t totalEntries = FileCachePoolTest::active_size(pool) +
+                        FileCachePoolTest::inactive_size(pool) +
+                        FileCachePoolTest::idle_size(pool);
+  EXPECT_LE(totalEntries, (size_t)kNameCount);
+  // Every file must still be openable/usable after the storm.
+  IOVector buf(*cacheAllocator);
+  buf.push_back(kPage);
+  for (int i = 0; i < kNameCount; i++) {
+    std::string name = "/f_" + std::to_string(i);
+    auto store = cachePool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    ASSERT_NE(nullptr, store);
+    store->set_actual_size(kFileSize);
+    EXPECT_GE(store->do_preadv2(buf.iovec(), buf.iovcnt(), 0, 0), 0);
     store->release();
   }
 }


### PR DESCRIPTION
> feat(cache): make FileCachePool thread-safe for multi-vCPU access (#1555)

* feat(cache): make FileCachePool thread-safe for multi-vCPU access

Guard all FileCachePool metadata (fileIndex_, lru_, cold tiers, totalUsed_,
tuning state) with a coarse photon::mutex (m_lock_) so one pool can be shared
across multiple photon vCPUs (OS threads).

Invariants:
- m_lock_ is held only across in-memory ops; never across open()/do_open() or
  forceRecycle()/eviction(), keeping the lock order rw_lock -> m_lock_ one-way
  (avoids ABBA with ObjectCache's per-item mutex and non-reentrant self-deadlock).
- eviction/evict snapshot a victim under m_lock_, release it, do the I/O
  (open()+WLOCK truncate), then re-lock to finalize.
- the write path accounts size under the store rw_lock (updateSpace fstats under
  m_lock_) so it can't drift against eviction's WLOCK+truncate; forceRecycle()
  is deferred to do_pwritev2 after rw_lock is released.
- running_/exit_/isFull_ and LruEntry::truncate_done become std::atomic.

Add a multi-vCPU concurrency stress test (CachePool.concurrent_stress).

QuotaFilePool is left unchanged and documented as not-yet-thread-safe (it is
currently unwired: the factory always builds a plain FileCachePool).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

* check total used in eviction loop

---------

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- eef65fb012f83dcc0fa4aa9ec3d8997131160aaf: fs/cache/full_file_cache/cache_store.cpp