### PR TITLE
fix(alog): prevent child deadlock on rotation lock across fork()

### DIFF
--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include <mutex>
 #include <condition_variable>
 #include <unistd.h>
+#include <pthread.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -269,6 +270,21 @@ void LogFormatter::put_integer_dec(ALogBuffer& buf, ALogInteger x)
     }
 }
 
+// Protects log file rotation. It used to be a function-local static in
+// write(), but if fork() happened while a thread was rotating, the child
+// would inherit the mutex in locked state forever. So it is hoisted here
+// and serialized against fork() with pthread_atfork(): prepare acquires
+// the lock (waiting for any in-flight rotation), and both parent and
+// child release it after fork().
+static mutex log_file_lock;
+
+__attribute__((constructor))
+static void __register_log_file_lock_atfork() {
+    pthread_atfork([] { log_file_lock.lock(); },
+                   [] { log_file_lock.unlock(); },
+                   [] { log_file_lock.unlock(); });
+}
+
 class LogOutputFile final : public BaseLogOutput {
 public:
     uint64_t log_file_size_limit = 0;
@@ -299,7 +315,6 @@ public:
         if (log_file_name && log_file_size_limit) {
             log_file_size += length;
             if (log_file_size > log_file_size_limit) {
-                static mutex log_file_lock;
                 lock_guard<mutex> guard(log_file_lock);
                 if (log_file_size > log_file_size_limit) {
                     log_file_rotate();

--- a/common/test/test_alog.cpp
+++ b/common/test/test_alog.cpp
@@ -24,9 +24,13 @@ limitations under the License.
 #include <photon/net/utils-stdstring.h>
 #include <chrono>
 #include <vector>
+#include <atomic>
+#include <thread>
 #include <stdint.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/wait.h>
+#include <signal.h>
 #include "../../test/ci-tools.h"
 #include "../../test/gtest.h"
 
@@ -175,6 +179,45 @@ TEST(ALog, log_to_file) {
     auto sv = estring_view(buffer, length - 1); // excluding the trailing '\n'
     EXPECT_TRUE(sv.ends_with(HELLO));
     ::close(fd);
+}
+
+static bool wait_child_exited(pid_t pid, int timeout_sec) {
+    for (int i = 0; i < timeout_sec * 100; ++i) {
+        int st;
+        if (::waitpid(pid, &st, WNOHANG) == pid)
+            return WIFEXITED(st) && WEXITSTATUS(st) == 0;
+        ::usleep(10 * 1000);
+    }
+    ::kill(pid, SIGKILL);
+    ::waitpid(pid, nullptr, 0);
+    return false;
+}
+
+TEST(ALog, fork_during_rotation) {
+    const char* fn = "/tmp/test_alog_fork.log";
+    // minimum rotate limit is 1MB
+    ASSERT_EQ(0, log_output_file(fn, 1024 * 1024, 3));
+    DEFER(log_output_file_close());
+    // keep triggering rotation in background, so that fork() below
+    // is likely to happen while the rotation lock is held
+    std::atomic<bool> stop{false};
+    std::thread writer([&] {
+        while (!stop)
+            LOG_INFO("background writer keeps rotating the log file, padding padding padding padding");
+    });
+    DEFER({ stop = true; writer.join(); });
+    for (int i = 0; i < 8; ++i) {
+        pid_t pid = fork();
+        ASSERT_GE(pid, 0);
+        if (pid == 0) {
+            // child: write enough to trigger a rotation of its own;
+            // it deadlocks here if the rotation lock was inherited locked
+            for (int j = 0; j < 16 * 1024; ++j)
+                LOG_INFO("child writer must not deadlock on the rotation lock, padding padding padding");
+            ::_exit(0);
+        }
+        EXPECT_TRUE(wait_child_exited(pid, 10)) << "child " << pid << " deadlocked";
+    }
 }
 
 TEST(ALog, float_point)


### PR DESCRIPTION
## Problem

The log rotation path in `LogOutputFile::write()` guards rotation with a function-local `static std::mutex`. POSIX `fork()` clones only the calling thread, so if a fork happens while another thread is holding this mutex during rotation, the child inherits the mutex in a permanently locked state — the owner thread does not exist in the child. The next time the child's log size exceeds the rotate limit, it deadlocks forever.

The existing `pthread_atfork(nullptr, nullptr, &reset_all_handle)` in `photon.cpp` only resets fds / event engines and does not cover this lock.

## Fix

Standard three-phase `pthread_atfork` protection:

- Hoist the mutex from function-local static to file scope so the atfork callbacks can reference it.
- Register via `__attribute__((constructor))`:
  - *prepare*: acquire the lock before fork, waiting out any in-flight rotation, so at the instant of fork the lock is held by the forking thread itself;
  - *parent* / *child*: release it after fork. Since the holder is the forking thread, unlocking on both sides is well-defined.

As a side benefit, the prepare phase also guarantees the child never observes a half-done rotation (rename/reopen in progress).

## Test

Added `ALog.fork_during_rotation` regression test: a background thread keeps writing to force frequent rotations while the main thread forks 8 times; each child writes ~2MB to force its own rotation. If the lock were inherited locked, the child would deadlock, which is caught by a 10s `waitpid` timeout.

All 24 tests in `test-alog` pass.