### PR TITLE
fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -1,7 +1,10 @@
 name: Linux ARM
 
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -1,7 +1,10 @@
 name: Linux x86_64
 
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci.macos.yml
+++ b/.github/workflows/ci.macos.yml
@@ -1,7 +1,10 @@
 name: macOS-matrix
 
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
## Problem

The CI workflows trigger on the `unlabeled` PR event so that removing the `needs-manual-merge` label re-runs CI. However, removing **any** label creates a new workflow run, which enters the shared concurrency group (`workflow-ref`) and — with `cancel-in-progress: true` — cancels the in-progress CI run **before** the job-level `if` conditions are evaluated. The new run then skips all its jobs, so a running CI gets cancelled for nothing.

## Fix

Make the concurrency group dynamic: runs triggered by removing an irrelevant label (anything other than `needs-manual-merge`) are diverted into a separate `-noop` group, where they are skipped within seconds without touching real CI runs.

| Event | Group | Behavior |
|-------|-------|----------|
| push / open / reopen | main group | unchanged: cancels older run, re-runs |
| remove `needs-manual-merge` | main group | unchanged: triggers CI |
| remove any other label | `-noop` group | skipped, no longer cancels running CI |

The job-level `if` conditions are kept as a second line of defense.

Applied to all three workflows: Linux ARM, Linux x86_64, macOS.