### PR TITLE
[Backport][main to 0.9] | fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574)

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -1,7 +1,10 @@
 name: Linux ARM
 
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -1,7 +1,10 @@
 name: Linux x86_64
 
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/ci.macos.yml
+++ b/.github/workflows/ci.macos.yml
@@ -1,7 +1,10 @@
 name: macOS-matrix
 
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
> fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574)

Removing any label creates a new workflow run, which enters the shared concurrency group and cancels the in-progress CI before job-level 'if' conditions are evaluated. Divert runs triggered by removing an irrelevant label (anything other than needs-manual-merge) into a separate '-noop' concurrency group, so they get skipped without interfering with real CI runs.
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.