### PR TITLE
[Backport][0.9 to 0.8] | fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574) (#1576)

### DIFF
--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -1,5 +1,15 @@
 name: Linux ARM
 
+<<<<<<< HEAD
+=======
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  cancel-in-progress: true
+
+>>>>>>> 6e668a6 (fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574) (#1576))
 on:
   pull_request:
     types: [opened, synchronize, reopened, unlabeled]

--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -1,7 +1,5 @@
 name: Linux ARM
 
-<<<<<<< HEAD
-=======
 # Runs triggered by removing an irrelevant label would have all jobs skipped, but they
 # still enter the concurrency group and would cancel an in-progress CI run. Divert them
 # into a separate '-noop' group so they never interfere with real CI runs.
@@ -9,7 +7,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
 
->>>>>>> 6e668a6 (fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574) (#1576))
 on:
   pull_request:
     types: [opened, synchronize, reopened, unlabeled]

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -1,5 +1,15 @@
 name: Linux x86_64
 
+<<<<<<< HEAD
+=======
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  cancel-in-progress: true
+
+>>>>>>> 6e668a6 (fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574) (#1576))
 on:
   pull_request:
     types: [opened, synchronize, reopened, unlabeled]

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -1,7 +1,5 @@
 name: Linux x86_64
 
-<<<<<<< HEAD
-=======
 # Runs triggered by removing an irrelevant label would have all jobs skipped, but they
 # still enter the concurrency group and would cancel an in-progress CI run. Divert them
 # into a separate '-noop' group so they never interfere with real CI runs.
@@ -9,7 +7,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
 
->>>>>>> 6e668a6 (fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574) (#1576))
 on:
   pull_request:
     types: [opened, synchronize, reopened, unlabeled]

--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -1,6 +1,3 @@
-<<<<<<< HEAD:.github/workflows/ci.macos.arm.yml
-name: macOS ARM
-=======
 name: macOS-matrix
 
 # Runs triggered by removing an irrelevant label would have all jobs skipped, but they
@@ -9,7 +6,6 @@ name: macOS-matrix
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
   cancel-in-progress: true
->>>>>>> 6e668a6 (fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574) (#1576)):.github/workflows/ci.macos.yml
 
 on:
   pull_request:

--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -1,4 +1,15 @@
+<<<<<<< HEAD:.github/workflows/ci.macos.arm.yml
 name: macOS ARM
+=======
+name: macOS-matrix
+
+# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
+# still enter the concurrency group and would cancel an in-progress CI run. Divert them
+# into a separate '-noop' group so they never interfere with real CI runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  cancel-in-progress: true
+>>>>>>> 6e668a6 (fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574) (#1576)):.github/workflows/ci.macos.yml
 
 on:
   pull_request:


### PR DESCRIPTION
> fix(ci): stop irrelevant unlabeled events from cancelling in-progress CI runs (#1574) (#1576)

Removing any label creates a new workflow run, which enters the shared concurrency group and cancels the in-progress CI before job-level 'if' conditions are evaluated. Divert runs triggered by removing an irrelevant label (anything other than needs-manual-merge) into a separate '-noop' concurrency group, so they get skipped without interfering with real CI runs.

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- 6e668a65442706bd4974c26330ae319b4c727719: .github/workflows/ci.linux.arm.yml,.github/workflows/ci.linux.x86_64.yml,.github/workflows/ci.macos.arm.yml