### PR TITLE
[Backport][0.8 to 0.7] | fix(alog): prevent child deadlock on rotation lock across fork() (#1573) (#1575) (#1577)

### DIFF
--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include <mutex>
 #include <condition_variable>
 #include <unistd.h>
+#include <pthread.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -203,6 +204,7 @@ void LogFormatter::put_integer_dec(ALogBuffer& buf, ALogInteger x)
     }
 }
 
+<<<<<<< HEAD
 __attribute__((constructor)) static void __initial_timezone() { tzset(); }
 static time_t dayid = 0, minuteid = 0, tsdelta = 0;
 static struct tm alog_time = {0};
@@ -229,6 +231,21 @@ static struct tm* alog_update_time(time_t now0) {
         alog_time.tm_hour = hor;
     }
     return &alog_time;
+=======
+// Protects log file rotation. It used to be a function-local static in
+// write(), but if fork() happened while a thread was rotating, the child
+// would inherit the mutex in locked state forever. So it is hoisted here
+// and serialized against fork() with pthread_atfork(): prepare acquires
+// the lock (waiting for any in-flight rotation), and both parent and
+// child release it after fork().
+static mutex log_file_lock;
+
+__attribute__((constructor))
+static void __register_log_file_lock_atfork() {
+    pthread_atfork([] { log_file_lock.lock(); },
+                   [] { log_file_lock.unlock(); },
+                   [] { log_file_lock.unlock(); });
+>>>>>>> 92b6c62 (fix(alog): prevent child deadlock on rotation lock across fork() (#1573) (#1575) (#1577))
 }
 
 class LogOutputFile final : public BaseLogOutput {
@@ -261,7 +278,6 @@ public:
         if (log_file_name && log_file_size_limit) {
             log_file_size += length;
             if (log_file_size > log_file_size_limit) {
-                static mutex log_file_lock;
                 lock_guard<mutex> guard(log_file_lock);
                 if (log_file_size > log_file_size_limit) {
                     log_file_rotate();

--- a/common/alog.cpp
+++ b/common/alog.cpp
@@ -204,7 +204,6 @@ void LogFormatter::put_integer_dec(ALogBuffer& buf, ALogInteger x)
     }
 }
 
-<<<<<<< HEAD
 __attribute__((constructor)) static void __initial_timezone() { tzset(); }
 static time_t dayid = 0, minuteid = 0, tsdelta = 0;
 static struct tm alog_time = {0};
@@ -231,7 +230,8 @@ static struct tm* alog_update_time(time_t now0) {
         alog_time.tm_hour = hor;
     }
     return &alog_time;
-=======
+}
+
 // Protects log file rotation. It used to be a function-local static in
 // write(), but if fork() happened while a thread was rotating, the child
 // would inherit the mutex in locked state forever. So it is hoisted here
@@ -245,7 +245,6 @@ static void __register_log_file_lock_atfork() {
     pthread_atfork([] { log_file_lock.lock(); },
                    [] { log_file_lock.unlock(); },
                    [] { log_file_lock.unlock(); });
->>>>>>> 92b6c62 (fix(alog): prevent child deadlock on rotation lock across fork() (#1573) (#1575) (#1577))
 }
 
 class LogOutputFile final : public BaseLogOutput {

--- a/common/test/test_alog.cpp
+++ b/common/test/test_alog.cpp
@@ -24,9 +24,13 @@ limitations under the License.
 #include <photon/net/utils-stdstring.h>
 #include <chrono>
 #include <vector>
+#include <atomic>
+#include <thread>
 #include <stdint.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/wait.h>
+#include <signal.h>
 #include "../../test/ci-tools.h"
 
 class LogOutputTest : public ILogOutput {
@@ -173,6 +177,45 @@ TEST(ALog, log_to_file) {
     // compare, buffer will followed tailing enter in the end of line
     EXPECT_EQ(0, strncmp(HELLO, &buffer[length - strlen(HELLO) - 1], strlen(HELLO)));
     ::close(fd);
+}
+
+static bool wait_child_exited(pid_t pid, int timeout_sec) {
+    for (int i = 0; i < timeout_sec * 100; ++i) {
+        int st;
+        if (::waitpid(pid, &st, WNOHANG) == pid)
+            return WIFEXITED(st) && WEXITSTATUS(st) == 0;
+        ::usleep(10 * 1000);
+    }
+    ::kill(pid, SIGKILL);
+    ::waitpid(pid, nullptr, 0);
+    return false;
+}
+
+TEST(ALog, fork_during_rotation) {
+    const char* fn = "/tmp/test_alog_fork.log";
+    // minimum rotate limit is 1MB
+    ASSERT_EQ(0, log_output_file(fn, 1024 * 1024, 3));
+    DEFER(log_output_file_close());
+    // keep triggering rotation in background, so that fork() below
+    // is likely to happen while the rotation lock is held
+    std::atomic<bool> stop{false};
+    std::thread writer([&] {
+        while (!stop)
+            LOG_INFO("background writer keeps rotating the log file, padding padding padding padding");
+    });
+    DEFER({ stop = true; writer.join(); });
+    for (int i = 0; i < 8; ++i) {
+        pid_t pid = fork();
+        ASSERT_GE(pid, 0);
+        if (pid == 0) {
+            // child: write enough to trigger a rotation of its own;
+            // it deadlocks here if the rotation lock was inherited locked
+            for (int j = 0; j < 16 * 1024; ++j)
+                LOG_INFO("child writer must not deadlock on the rotation lock, padding padding padding");
+            ::_exit(0);
+        }
+        EXPECT_TRUE(wait_child_exited(pid, 10)) << "child " << pid << " deadlocked";
+    }
 }
 
 TEST(ALog, float_point)


### PR DESCRIPTION
> fix(alog): prevent child deadlock on rotation lock across fork() (#1573) (#1575) (#1577)

The log rotation mutex was a function-local static in write(). If fork() happened while another thread was rotating, the child inherited the mutex permanently locked and deadlocked on its next rotation. Hoist the lock to file scope and serialize it against fork() with pthread_atfork(): prepare acquires it (waiting out any in-flight rotation), and both parent and child release it afterwards. Add a fork-during-rotation regression test.

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- 92b6c62d6509e92e9199ad1b9fee1b3c3f060390: common/alog.cpp