### PR TITLE
[Backport][0.9 to 0.8] | extfs: fix default mkfs UUID and support customized buffer size (#1581) (#1583)

### DIFF
--- a/fs/extfs/extfs.cpp
+++ b/fs/extfs/extfs.cpp
@@ -1287,11 +1287,11 @@ class ExtFileSystem : public photon::fs::IFileSystem, public photon::fs::IFileSy
 public:
     ext2_filsys fs;
     io_manager extfs_io_manager;
-    ExtFileSystem(photon::fs::IFile *_image_file, bool buffer = true) : ino_cache(kMinimalInoLife) {
+    ExtFileSystem(photon::fs::IFile *_image_file, uint32_t buffer_size, uint32_t block_size) : ino_cache(kMinimalInoLife) {
         ExtFileSystem::mutex.lock();
         DEFER(ExtFileSystem::mutex.unlock());
-        if (buffer) {
-            buffer_file = new_buffer_file(_image_file);
+        if (buffer_size) {
+            buffer_file = new BufferFile(_image_file, buffer_size, block_size);
             extfs_io_manager = new_io_manager(buffer_file);
         } else {
             extfs_io_manager = new_io_manager(_image_file);
@@ -1508,7 +1508,11 @@ int ExtFile::flush_buffer() {
 }
 
 photon::fs::IFileSystem *new_extfs(photon::fs::IFile *file, bool buffer) {
-    auto extfs = new ExtFileSystem(file, buffer);
+    return new_extfs_with_buffer(file, buffer ? 8<<20 : 0, 128<<10);
+}
+
+photon::fs::IFileSystem *new_extfs_with_buffer(photon::fs::IFile *file, uint32_t buffer_size, uint32_t block_size) {
+    auto extfs = new ExtFileSystem(file, buffer_size, block_size);
     if (extfs->fs == nullptr) {
         delete extfs;
         return nullptr;

--- a/fs/extfs/extfs.h
+++ b/fs/extfs/extfs.h
@@ -16,11 +16,18 @@ limitations under the License.
 #pragma once
 #include <cstdint>
 #include <photon/fs/filesystem.h>
+#include <stdint.h>
 
 namespace photon {
 namespace fs {
 
+
+// when buffer is true, defaults to 8MB buffer size and 128KB block size
 photon::fs::IFileSystem *new_extfs(photon::fs::IFile *file, bool buffer = true);
+
+photon::fs::IFileSystem *new_extfs_with_buffer(photon::fs::IFile *file,
+                                               uint32_t buffer_size = 8 << 20,
+                                               uint32_t block_size = 128 << 10);
 
 // make extfs on an prezeroed IFile,
 // should be truncated to specified size in advance

--- a/fs/extfs/mkfs.cpp
+++ b/fs/extfs/mkfs.cpp
@@ -25,7 +25,7 @@ limitations under the License.
 #include <string>
 #include <fcntl.h>
 
-constexpr char DEFAULT_UUID[] = "bdf7bb2e-c231-43ce-87c2-photonextdev";
+constexpr char DEFAULT_UUID[] = "bdf7bb2e-c231-43ce-87c2-deadbeefcafe";
 
 int mkdir_lost_found(ext2_filsys fs) {
     std::string name = "lost+found";
@@ -94,8 +94,10 @@ int do_mkfs(io_manager manager, size_t size, char *uuid) {
         LOG_ERRNO_RETURN(0, -1, "error while setting up superblock ", VALUE(ret));
     }
 
-    uuid4_parse(uuid, (char*)(fs->super->s_uuid));
-    uuid4_parse(uuid, (char*)(fs_param.s_hash_seed));
+    if (uuid4_parse(uuid, (char*)(fs->super->s_uuid)) != 0) {
+        LOG_ERROR_RETURN(EINVAL, -1, "invalid uuid `", uuid);
+    }
+    memcpy(fs_param.s_hash_seed, fs->super->s_uuid, 16);
     fs->super->s_kbytes_written = 1;
     fs->super->s_def_hash_version = EXT2_HASH_HALF_MD4;
     fs->super->s_max_mnt_count = -1;


### PR DESCRIPTION
> extfs: fix default mkfs UUID and support customized buffer size (#1581) (#1583)

* extfs: fix mkfs default uuid



* extfs: support customized buffer



---------

Signed-off-by: zhuangbowei.zbw <zhuangbowei.zbw@alibaba-inc.com>
Co-authored-by: ZAwei <zhuangbowei.zbw@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- fa10813ee0bf09be0521ffba7b136156fbbf3f7d: fs/extfs/extfs.cpp