### PR TITLE
fix(oss): skip chunked trailing bytes after End frame in batch_get_objects

### DIFF
--- a/ecosystem/oss.cpp
+++ b/ecosystem/oss.cpp
@@ -1221,6 +1221,14 @@ int OssClient::batch_get_objects(std::vector<GetObjectParameters>& params) {
       read_good_cnt++;
     } else {
       auto result = frame.read_end(stream);
+      // The End frame is the last one; skip the trailing bytes of the
+      // chunked body (terminating chunk 0\r\n\r\n) if necessary, so that
+      // close() sees a finished body and the keep-alive connection can
+      // be pooled for reuse instead of being dropped.
+      // TODO: remove this workaround once ChunkedBodyReadStream consumes
+      // the terminating chunk automatically on exact-sized reads.
+      char drain_buf[64];
+      op.resp.read(drain_buf, sizeof(drain_buf));
       LOG_DEBUG("End frame status code ` request cnt ` success cnt `",
                 result.status_code, result.request_count, result.success_count);
       if (read_good_cnt != result.success_count) {


### PR DESCRIPTION
## Problem

`batch_get_objects()` sometimes rebuilds the TCP connection after a call,
so the connection pool does not work well.

The reason: it reads each frame with an exact size. Depending on how TCP
segments split, the last chunk (`0\r\n\r\n`) may not be parsed. Then
`close()` thinks the body is not finished, and the connection is dropped
instead of going back to the pool.

This should be handled by `ChunkedBodyReadStream` itself. Its
Content-Length counterpart, `BodyReadStream`, already does this: its
`close()` skips the remaining body bytes so the caller never needs to
care. The chunked stream should do the same for the last chunk.

## Workaround

Read once more after the End frame. This consumes the last chunk, so
`close()` sees a finished body and the connection can be reused.
A TODO is added to remove this later.

## Suggestion

The real fix should be in `ChunkedBodyReadStream`, but its code is a
little complex for me and is better refactored first. I can work on the
refactoring later when I have time.
