### PR TITLE
[Backport][main to 0.9] | feat(cache): optional async cache-dir scan at FileCachePool init (#1590)

### DIFF
--- a/fs/cache/cache.cpp
+++ b/fs/cache/cache.cpp
@@ -32,7 +32,8 @@ ICachedFileSystem *new_full_file_cached_fs(IFileSystem *srcFs, IFileSystem *medi
                                            uint64_t periodInUs, uint64_t diskAvailInBytes,
                                            IOAlloc *allocator, int quotaDirLevel,
                                            CacheFnTransFunc fn_trans_func,
-                                           uint64_t storeCacheTTLUsecs) {
+                                           uint64_t storeCacheTTLUsecs,
+                                           bool asyncInit) {
     if (refillUnit % 4096 != 0 || !is_power_of_2(refillUnit)) {
         LOG_ERROR_RETURN(EINVAL, nullptr, "refill Unit need to be aligned to 4KB and power of 2")
     }
@@ -40,8 +41,8 @@ ICachedFileSystem *new_full_file_cached_fs(IFileSystem *srcFs, IFileSystem *medi
         allocator = new IOAlloc;
     }
     FileCachePool *pool = nullptr;
-    pool = new FileCachePool(mediaFs, capacityInGB, periodInUs, diskAvailInBytes, 
-                             refillUnit, storeCacheTTLUsecs);
+    pool = new FileCachePool(mediaFs, capacityInGB, periodInUs, diskAvailInBytes,
+                             refillUnit, storeCacheTTLUsecs, asyncInit);
     pool->Init();
     return new_cached_fs(srcFs, pool, 4096, allocator, fn_trans_func);
 }

--- a/fs/cache/cache.h
+++ b/fs/cache/cache.h
@@ -117,7 +117,8 @@ ICachedFileSystem *new_full_file_cached_fs(IFileSystem *srcFs,
                                            uint64_t diskAvailInBytes, IOAlloc *allocator,
                                            int quotaDirLevel,
                                            CacheFnTransFunc fn_trans_func = nullptr,
-                                           uint64_t storeCacheTTLUsecs = 10'000'000);
+                                           uint64_t storeCacheTTLUsecs = 10'000'000,
+                                           bool asyncInit = false);
 
 /**
  * @param blk_size The proper size for cache metadata and IO efficiency. Large writes to cache media

--- a/fs/cache/full_file_cache/cache_pool.cpp
+++ b/fs/cache/full_file_cache/cache_pool.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include <photon/common/alog-stdstring.h>
 #include <photon/common/enumerable.h>
 #include <photon/common/utility.h>
+#include <photon/thread/thread11.h>
 #include <photon/fs/fiemap.h>
 #include <photon/fs/path.h>
 
@@ -41,7 +42,7 @@ const int64_t kEvictionMark = 5ll * kGB;
 
 FileCachePool::FileCachePool(IFileSystem* mediaFs, uint64_t capacityInGB,
     uint64_t periodInUs, uint64_t diskAvailInBytes, uint64_t refillUnit,
-    uint64_t storeCacheTTLUsecs)
+    uint64_t storeCacheTTLUsecs, bool asyncInit)
     : ICachePool(0, 128, -1U, false, storeCacheTTLUsecs),
       mediaFs_(mediaFs),
       capacityInGB_(capacityInGB),
@@ -52,7 +53,8 @@ FileCachePool::FileCachePool(IFileSystem* mediaFs, uint64_t capacityInGB,
       timer_(nullptr),
       running_(false),
       exit_(false),
-      isFull_(false) {
+      isFull_(false),
+      asyncInit_(asyncInit) {
     int64_t capacityInBytes = capacityInGB_ * kGB;
     waterMark_ = calcWaterMark(capacityInBytes, kMaxFreeSpace);
     // keep this relation : waterMark < riskMark < capacity
@@ -71,14 +73,28 @@ FileCachePool::~FileCachePool() {
     }
     delete timer_;
   }
+  // Join the scan before freeing.
+  if (scanJoin_) {
+    photon::thread_interrupt(scanThread_, EINTR);
+    photon::thread_join(scanJoin_);
+    scanJoin_ = nullptr;
+    scanThread_ = nullptr;
+  }
   this->stores_clear();
   delete mediaFs_;
 }
 
 void FileCachePool::Init() {
   probeFiemap();
-  traverseDir("/");
-  timer_ = new photon::Timer(periodInUs_, {this, FileCachePool::timerHandler}, true, 8UL * 1024 * 1024);
+  timer_ = new photon::Timer(periodInUs_, {this, FileCachePool::timerHandler}, true, 8ULL * 1024 * 1024);
+  // Scanning stat()s every cached file (seconds for a large cache).
+  if (asyncInit_) {
+    scanThread_ = photon::thread_create11(&FileCachePool::backgroundScan, this);
+    scanJoin_ = photon::thread_enable_join(scanThread_);
+  } else {
+    traverseDir("/");
+    scanDone_ = true;
+  }
 }
 
 void FileCachePool::probeFiemap() {
@@ -128,10 +144,16 @@ ICacheStore* FileCachePool::do_open(std::string_view pathname, int flags, mode_t
 
   auto find = fileIndex_.find(pathname);
   if (find == fileIndex_.end()) {
+    struct stat st = {};
+    uint64_t fileSize = 0;
+    if (localFile->fstat(&st) == 0) {
+      fileSize = st.st_blocks * kDiskBlockSize;
+    }
     auto lruIter = lru_.push_front(fileIndex_.end());
-    std::unique_ptr<LruEntry> entry(new LruEntry{lruIter, 1, 0});
+    std::unique_ptr<LruEntry> entry(new LruEntry{lruIter, 1, fileSize});
     find = fileIndex_.emplace(pathname, std::move(entry)).first;
     lru_.front() = find;
+    totalUsed_ += fileSize;
   } else {
     lru_.access(find->second->lruIter);
     find->second->openCount++;
@@ -428,10 +450,22 @@ bool FileCachePool::afterFtrucate(FileNameMap::iterator iter) {
 }
 
 int FileCachePool::traverseDir(const std::string& root) {
+  int count = 0;
   for (auto file : enumerable(Walker(mediaFs_, root))) {
+    if (exit_) break;
     insertFile(file);
+    ++count;
+    if (count % 1'000 == 0) photon::thread_yield();
   }
+  LOG_INFO("` files under path `", count, root);
   return 0;
+}
+
+void FileCachePool::backgroundScan() {
+  auto start = photon::now;
+  traverseDir("/");
+  scanDone_ = true;
+  LOG_INFO("cache index scan finished, elapsed us: `", photon::now - start);
 }
 
 int FileCachePool::insertFile(std::string_view file) {
@@ -443,10 +477,14 @@ int FileCachePool::insertFile(std::string_view file) {
   auto fileSize = st.st_blocks * kDiskBlockSize;
 
   SCOPED_LOCK(m_lock_);
-  auto lruIter = lru_.push_front(fileIndex_.end());
-  auto entry = std::unique_ptr<LruEntry>(new LruEntry{lruIter, 0, fileSize});
-  auto iter = fileIndex_.emplace(file, std::move(entry)).first;
-  lru_.front() = iter;
+  // Skip files already tracked.
+  if (fileIndex_.find(file) != fileIndex_.end()) {
+    return 0;
+  }
+  for (auto* tier : coldTiers_) {
+    if (tier->contains(file)) return 0;
+  }
+  coldTiers_[0]->insert(file);
   totalUsed_ += fileSize;
 
   demoteToCold();
@@ -479,13 +517,12 @@ void FileCachePool::demoteToCold() {
     coldTiers_[0]->insert(tailIt->first);
     lru_.remove(tailIt->second->lruIter);
     fileIndex_.erase(tailIt);
-
-    for (size_t i = 1; i < coldTiers_.size(); i++) {
-      if (coldTiers_[i-1]->size() > thresholds_[i].value) {
-        auto key = coldTiers_[i-1]->victim();
-        coldTiers_[i]->insert(key);
-        coldTiers_[i-1]->remove(key);
-      } else break;
+  }
+  for (size_t i = 1; i < coldTiers_.size(); i++) {
+    while (coldTiers_[i-1]->size() > thresholds_[i].value) {
+      auto key = coldTiers_[i-1]->victim();
+      coldTiers_[i]->insert(key);
+      coldTiers_[i-1]->remove(key);
     }
   }
 }

--- a/fs/cache/full_file_cache/cache_pool.h
+++ b/fs/cache/full_file_cache/cache_pool.h
@@ -79,8 +79,8 @@ private:
 class FileCachePool : public photon::fs::ICachePool {
 public:
     FileCachePool(photon::fs::IFileSystem *mediaFs, uint64_t capacityInGB, uint64_t periodInUs,
-                  uint64_t diskAvailInBytes, uint64_t refillUnit, 
-                  uint64_t storeCacheTTLUsecs = 10'000'000);
+                  uint64_t diskAvailInBytes, uint64_t refillUnit,
+                  uint64_t storeCacheTTLUsecs = 10'000'000, bool asyncInit = false);
     ~FileCachePool();
 
     static const uint64_t kDiskBlockSize = 512; // stat(2)
@@ -179,6 +179,15 @@ protected:
 
     int traverseDir(const std::string &root);
     virtual int insertFile(std::string_view file);
+
+    // Traversing dir in background thread so a large
+    // cache reuse does not block startup.
+    void backgroundScan();
+    bool asyncInit_ = false;
+    // The background scan thread.
+    photon::thread *scanThread_ = nullptr;
+    photon::join_handle *scanJoin_ = nullptr;
+    std::atomic<bool> scanDone_{false};  // set when the scan finishes
 
     typedef photon::fs::LRU<FileNameMap::iterator, uint32_t> LRUContainer;
     LRUContainer lru_;

--- a/fs/cache/test/cache_test.cpp
+++ b/fs/cache/test/cache_test.cpp
@@ -780,7 +780,19 @@ struct FileCachePoolTest {
   static bool idle(FileCachePool *p, std::string_view n) {
     return p->idleTier_.contains(n);
   }
+  static bool scan_done(FileCachePool *p) { return p->scanDone_.load(); }
 };
+
+// Poll until the background index scan finishes (or timeout). Returns true on
+// completion.
+static bool WaitScanDone(FileCachePool *pool, uint64_t timeoutUs = 30'000'000) {
+  uint64_t waited = 0;
+  while (!FileCachePoolTest::scan_done(pool) && waited < timeoutUs) {
+    photon::thread_usleep(1000);
+    waited += 1000;
+  }
+  return FileCachePoolTest::scan_done(pool);
+}
 
 // Open through the pool then immediately release.
 static bool openClose(ICachePool* pool, const char* name) {
@@ -1563,6 +1575,178 @@ TEST(CachePool, concurrent_stress) {
     EXPECT_GE(store->do_preadv2(buf.iovec(), buf.iovcnt(), 0, 0), 0);
     store->release();
   }
+}
+
+// Populate `root` with `fileNum` cached files (one page each) through a
+// throwaway cache pool, then tear that pool down leaving the files on disk.
+// The returned totalUsed_ (blocks) lets callers assert the reused index.
+static int64_t PopulateCacheDir(const std::string& root, int fileNum,
+                                IOAlloc* allocator) {
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ull * 1024 * 1024, allocator, 0, nullptr, 1000);
+  auto pool = dynamic_cast<FileCachePool*>(roCachedFs->get_pool());
+  EXPECT_NE(nullptr, pool);
+  EXPECT_TRUE(WaitScanDone(pool));  // empty dir: finishes immediately
+
+  IOVector buffer(*allocator);
+  buffer.push_back(4 * 1024);
+  for (int i = 0; i < fileNum; i++) {
+    std::string name = "/f_" + std::to_string(i);
+    auto store = pool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+    EXPECT_NE(nullptr, store);
+    if (store) {
+      store->set_actual_size(4 * 1024);
+      store->do_pwritev2(buffer.iovec(), buffer.iovcnt(), 0, 0);
+      store->release();
+    }
+  }
+  int64_t used = FileCachePoolTest::total_used(pool);
+  delete roCachedFs;  // leaves the media files on disk for reuse
+  return used;
+}
+
+// Reuse an existing cache dir: Init() must return without blocking on the
+// per-file stat scan, and the background scan must rebuild the full index.
+TEST(CachePool, reuse_async_scan_rebuilds_index) {
+  std::string root = "/mnt/tmp/ease/cache/reuse_async_scan/";
+  SetupTestDir(root);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  DEFER(delete cacheAllocator);
+
+  const int fileNum = 500;
+  int64_t expectedUsed = PopulateCacheDir(root, fileNum, cacheAllocator);
+  ASSERT_GT(expectedUsed, 0);
+
+  // Reuse the same dir.
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ull * 1024 * 1024, cacheAllocator, 0, nullptr, 1000,
+      /*asyncInit=*/true);
+  auto pool = dynamic_cast<FileCachePool*>(roCachedFs->get_pool());
+  ASSERT_NE(nullptr, pool);
+  DEFER(delete roCachedFs);
+
+  ASSERT_TRUE(WaitScanDone(pool));
+  using T = FileCachePoolTest;
+  // Every populated file is indexed exactly once, accounting matches.
+  size_t entries = T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool);
+  EXPECT_EQ((size_t)fileNum, entries);
+  EXPECT_EQ(expectedUsed, T::total_used(pool));
+  for (int i = 0; i < fileNum; i++) {
+    std::string name = "/f_" + std::to_string(i);
+    EXPECT_TRUE(T::active(pool, name) || T::inactive(pool, name) || T::idle(pool, name));
+  }
+}
+
+// The background scan races with do_open() over multiple vCPUs on the same
+// files. Dedup in insertFile() must prevent double-counting / leaked lru_
+// nodes: each file ends up indexed exactly once.
+TEST(CachePool, reuse_scan_concurrent_open_no_double_count) {
+  std::string root = "/mnt/tmp/ease/cache/reuse_concurrent_open/";
+  SetupTestDir(root);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  DEFER(delete cacheAllocator);
+
+  const int fileNum = 800;
+  int64_t expectedUsed = PopulateCacheDir(root, fileNum, cacheAllocator);
+  ASSERT_GT(expectedUsed, 0);
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  // asyncInit=true: this test exercises the scan racing do_open() across vCPUs.
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ull * 1024 * 1024, cacheAllocator, 0, nullptr,
+      10'000'000, /*asyncInit=*/true);
+  auto pool = dynamic_cast<FileCachePool*>(roCachedFs->get_pool());
+  ASSERT_NE(nullptr, pool);
+  DEFER(delete roCachedFs);
+
+  // Hammer open() across vCPUs while the scan is still populating the index.
+  const int kVcpus = 4;
+  const int kThreads = 8;
+  ASSERT_EQ(0, photon_std::work_pool_init(kVcpus, photon::INIT_EVENT_DEFAULT,
+                                          photon::INIT_IO_NONE));
+  DEFER(photon_std::work_pool_fini());
+
+  std::atomic<int> open_failures{0};
+  auto worker = [&](int tid) {
+    for (int i = 0; i < fileNum; i++) {
+      std::string name = "/f_" + std::to_string(i);
+      auto store = pool->open(name.c_str(), O_CREAT | O_RDWR, 0644);
+      if (!store) { open_failures.fetch_add(1); continue; }
+      store->release();
+    }
+  };
+  std::vector<photon_std::thread> threads;
+  for (int i = 0; i < kThreads; i++) threads.emplace_back(worker, i);
+  for (auto& t : threads) t.join();
+
+  ASSERT_TRUE(WaitScanDone(pool));
+  pool->forceRecycle();  // quiesce
+
+  using T = FileCachePoolTest;
+  EXPECT_EQ(0, open_failures.load());
+  // No duplicates: total tracked entries never exceeds the real file count.
+  size_t entries = T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool);
+  EXPECT_EQ((size_t)fileNum, entries);
+  EXPECT_GE(T::total_used(pool), 0);
+}
+
+// Destroying the pool while the background scan is still running must join the
+// scan thread cleanly (no crash / use-after-free / hang).
+TEST(CachePool, reuse_destruct_during_scan) {
+  std::string root = "/mnt/tmp/ease/cache/reuse_destruct/";
+  SetupTestDir(root);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  DEFER(delete cacheAllocator);
+
+  const int fileNum = 2000;  // large enough that the scan is still in flight
+  ASSERT_GT(PopulateCacheDir(root, fileNum, cacheAllocator), 0);
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ull * 1024 * 1024, cacheAllocator, 0, nullptr, 1000,
+      /*asyncInit=*/true);
+  auto pool = dynamic_cast<FileCachePool*>(roCachedFs->get_pool());
+  ASSERT_NE(nullptr, pool);
+  // Let the scan start and process some files (yields to the scan thread), but
+  // do NOT wait for it to finish, so the dtor joins a scan still in flight.
+  photon::thread_usleep(2000);
+  delete roCachedFs;  // must not crash or hang
+}
+
+// Default (asyncInit omitted): Init() must scan synchronously, so the moment it
+// returns the index is fully rebuilt -- scan_done() is already true WITHOUT any
+// waiting, and every populated file is accounted for.
+TEST(CachePool, reuse_sync_scan_is_default) {
+  std::string root = "/mnt/tmp/ease/cache/reuse_sync_default/";
+  SetupTestDir(root);
+  auto cacheAllocator = new AlignedAlloc(4 * 1024);
+  DEFER(delete cacheAllocator);
+
+  const int fileNum = 800;
+  int64_t expectedUsed = PopulateCacheDir(root, fileNum, cacheAllocator);
+  ASSERT_GT(expectedUsed, 0);
+
+  auto mediaFs = new_localfs_adaptor(root.c_str(), ioengine_psync);
+  auto alignFs = new_aligned_fs_adaptor(mediaFs, 4 * 1024, true, true);
+  // No asyncInit argument -> defaults to synchronous.
+  auto roCachedFs = new_full_file_cached_fs(nullptr, alignFs, 1024 * 1024,
+      1, 1000 * 1000 * 1, 128ull * 1024 * 1024, cacheAllocator, 0);
+  auto pool = dynamic_cast<FileCachePool*>(roCachedFs->get_pool());
+  ASSERT_NE(nullptr, pool);
+  DEFER(delete roCachedFs);
+
+  using T = FileCachePoolTest;
+  // Already done at Init() return -- no WaitScanDone() needed.
+  EXPECT_TRUE(T::scan_done(pool));
+  size_t entries = T::active_size(pool) + T::inactive_size(pool) + T::idle_size(pool);
+  EXPECT_EQ((size_t)fileNum, entries);
+  EXPECT_EQ(expectedUsed, T::total_used(pool));
 }
 
 }


### PR DESCRIPTION
> feat(cache): optional async cache-dir scan at FileCachePool init (#1590)

Reusing an on-disk cache makes Init() synchronously stat() every cached
file to rebuild fileIndex_/lru_/totalUsed_. With 10^5–10^6 files this
blocks startup for seconds while the cache is unusable.

Add an opt-in asyncInit flag (default false, preserving current
synchronous behavior) that moves the directory traversal to a single
background photon thread so Init() returns immediately and the cache
serves right away. During the scan totalUsed_ is transiently
undercounted; watermark eviction only under-evicts (safe) and real disk
pressure is still caught by the existing statvfs path.

Key correctness points:
- probeFiemap() stays synchronous in Init(): FileCacheStore reads
  fiemapSupported() at construction, and do_open may race the scan.
- insertFile() dedups under m_lock_ (fileIndex_ + cold-tier check) so a
  do_open that races the scan over the same file can't double-count
  totalUsed_ or leak an lru_ node.
- ~FileCachePool joins the scan thread (interrupt + join) before
  stores_clear()/delete mediaFs_ to avoid use-after-free.

Tests: reuse_async_scan_rebuilds_index, reuse_scan_concurrent_open_no_
double_count (4 vCPUs), reuse_destruct_during_scan, and
reuse_sync_scan_is_default.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- dbe6c10f88fe73a8cf09d7b9cbd71fac26294a7c: fs/cache/full_file_cache/cache_pool.cpp