### PR TITLE
fix(net,io): don't confuse a 0-length iovec element or an error with EOF

### DIFF
--- a/io/aio-wrapper.cpp
+++ b/io/aio-wrapper.cpp
@@ -319,8 +319,10 @@ retry:
         for (auto& x: ptr_array(iov, iovcnt))
         {
             ssize_t ret = posixaio_pread(fd, x.iov_base, x.iov_len, offset + rst);
-            if (ret < 0)
-                LOG_ERRNO_RETURN(-1, 0, "failed to posixaio_preadv");
+            if (ret < 0) {
+                if (rst > 0) break;     // report the partial read, instead of the error
+                LOG_ERRNO_RETURN(0, -1, "failed to posixaio_preadv");
+            }
             if (ret < (ssize_t)x.iov_len)
                 return rst + ret;
             rst += ret;
@@ -333,8 +335,10 @@ retry:
         for (auto& x: ptr_array(iov, iovcnt))
         {
             ssize_t ret = posixaio_pwrite(fd, x.iov_base, x.iov_len, offset + rst);
-            if (ret < 0)
-                LOG_ERRNO_RETURN(-1, 0, "failed to posixaio_pwrite()");
+            if (ret < 0) {
+                if (rst > 0) break;     // report the partial write, instead of the error
+                LOG_ERRNO_RETURN(0, -1, "failed to posixaio_pwrite()");
+            }
             if (ret < (ssize_t)x.iov_len)
                 return rst + ret;
             rst += ret;

--- a/net/basic_socket.h
+++ b/net/basic_socket.h
@@ -136,12 +136,22 @@ struct BufStep {
 
 struct BufStepV {
     iovector_view& v;
-    BufStepV(iovector_view& v) : v(v) { }
+    // a 0-length element would make the iocb of doio_loop() transfer 0 byte and
+    // return 0, which is indistinguishable from EOF, so such elements are
+    // skipped. Before the first iocb, at least one element is kept, so that
+    // iocbs relying on iov[0] always have a valid one; after that the view is
+    // allowed to become empty, which simply ends the loop.
+    BufStepV(iovector_view& v) : v(v) { skip_empty(1); }
     bool operator()(size_t ret, size_t n) __INLINE__ {
         auto extracted = v.extract_front(ret);
         assert(extracted == ret);
         _unused(extracted);
+        skip_empty(0);
         return v.iovcnt > 0;
+    }
+    void skip_empty(int keep) __INLINE__ {
+        while (v.iovcnt > keep && v.front().iov_len == 0)
+            v.pop_front();
     }
 };
 

--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -500,6 +500,10 @@ protected:
     }
 
     ssize_t do_sendmsg(int sockfd, const struct msghdr* message, int flags, Timeout timeout) override {
+        // a 0-byte zerocopy send is not acknowledged by the kernel, and
+        // zerocopy_confirm() below would wait for its notification in vain
+        if (iovector_view(message->msg_iov, (int)message->msg_iovlen).sum() == 0)
+            return 0;
         ssize_t n = photon::net::sendmsg(sockfd, message, flags | ZEROCOPY_FLAG, timeout);
         if (n < 0)
             return n;

--- a/net/security-context/sasl-stream.cpp
+++ b/net/security-context/sasl-stream.cpp
@@ -171,9 +171,11 @@ class SaslSocketStream : public ForwardSocketStream {
     ssize_t writev(const struct iovec *iov, int iovcnt) override {
         ssize_t count = 0;
         for (auto v : iovector_view((iovec *)iov, iovcnt)) {
+            if (v.iov_len == 0) continue;   // a 0-length write returns 0, which looks like EOF
             auto ret = write(v.iov_base, v.iov_len);
-            if (ret <= 0) return ret;
+            if (ret <= 0) return count > 0 ? count : ret;
             count += ret;
+            if (ret < (ssize_t)v.iov_len) break;    // EOF in the middle
         }
         return count;
     }
@@ -185,9 +187,11 @@ class SaslSocketStream : public ForwardSocketStream {
     ssize_t readv(const struct iovec *iov, int iovcnt) override {
         ssize_t count = 0;
         for (auto v : iovector_view((iovec *)iov, iovcnt)) {
+            if (v.iov_len == 0) continue;   // a 0-length read returns 0, which looks like EOF
             auto ret = read(v.iov_base, v.iov_len);
-            if (ret <= 0) return ret;
+            if (ret <= 0) return count > 0 ? count : ret;
             count += ret;
+            if (ret < (ssize_t)v.iov_len) break;    // EOF in the middle
         }
         return count;
     }

--- a/net/test/test.cpp
+++ b/net/test/test.cpp
@@ -822,6 +822,85 @@ TEST(ZeroCopySocket, basic) {
 }
 #endif
 
+// a 0-length element in iov[] must not be mistaken for EOF, otherwise writev()
+// would transfer less bytes than requested, and silently so
+template <typename Wrap>
+static void test_writev_empty_iov(ISocketServer* server, ISocketClient* client, const Wrap& wrap) {
+    static char a[100], b[50];
+    const std::vector<std::pair<const char*, std::vector<iovec>>> cases = {
+        {"none", {{a, 100}, {b, 50}}},
+        {"head", {{a, 0}, {a, 100}, {b, 50}}},
+        {"mid",  {{a, 100}, {a, 0}, {b, 50}}},
+        {"tail", {{a, 100}, {b, 50}, {a, 0}}},
+        {"all",  {{a, 0}, {b, 0}}},
+    };
+
+    size_t received = 0;
+    photon::semaphore done(0);
+    auto handler = [&](ISocketStream* stream) -> int {
+        auto s = wrap(stream, SecurityRole::Server);
+        DEFER(if (s != stream) delete s);
+        char buf[4096];
+        ssize_t n;
+        while ((n = s->recv(buf, sizeof(buf))) > 0) received += n;
+        done.signal(1);
+        return 0;
+    };
+    server->set_handler(handler);
+    ASSERT_EQ(0, server->bind_v4localhost());
+    ASSERT_EQ(0, server->listen());
+    ASSERT_EQ(0, server->start_loop());
+    auto ep = server->getsockname();
+
+    for (auto& c : cases) {
+        auto& iov = c.second;
+        size_t sum = iovector_view((iovec*) iov.data(), (int) iov.size()).sum();
+        received = 0;
+        auto conn = client->connect(ep);
+        ASSERT_NE(nullptr, conn);
+        conn->timeout(5UL * 1000 * 1000);   // fail instead of hanging forever
+        auto s = wrap(conn, SecurityRole::Client);
+        EXPECT_EQ((ssize_t) sum, s->writev(iov.data(), (int) iov.size())) << c.first;
+        if (s != conn) delete s;
+        delete conn;
+        ASSERT_EQ(0, done.wait(1, 10UL * 1000 * 1000));
+        EXPECT_EQ(sum, received) << c.first;
+    }
+}
+
+static ISocketStream* no_wrap(ISocketStream* s, SecurityRole) { return s; }
+
+TEST(writev, empty_iov) {
+    auto server = new_tcp_socket_server();
+    DEFER(delete server);
+    auto client = new_tcp_socket_client();
+    DEFER(delete client);
+    test_writev_empty_iov(server, client, no_wrap);
+}
+
+TEST(writev, empty_iov_tls) {
+    auto ctx = new_tls_context(cert_str, key_str, passphrase_str);
+    DEFER(delete ctx);
+    auto server = new_tcp_socket_server();
+    DEFER(delete server);
+    auto client = new_tcp_socket_client();
+    DEFER(delete client);
+    test_writev_empty_iov(server, client, [&](ISocketStream* s, SecurityRole role) {
+        return new_tls_stream(ctx, s, role, false);
+    });
+}
+
+#ifdef __linux__
+TEST(writev, empty_iov_zerocopy) {
+    if (!zerocopy_available()) return;
+    auto server = new_tcp_socket_server();
+    DEFER(delete server);
+    auto client = new_zerocopy_tcp_client();
+    DEFER(delete client);
+    test_writev_empty_iov(server, client, no_wrap);
+}
+#endif
+
 const static char LINE[] = "hello iostream over socket stream!";
 
 void iostream_uds_server() {


### PR DESCRIPTION
## Summary

Two defects around what a return value of `0` means in iovec-based I/O:

1. **A 0-length element in `iov[]` was interpreted as EOF** by the shared `doio_loop()` helper, causing **silent data truncation** on TLS streams, a **bogus `0` return** on SASL streams, and a **hang** on ZeroCopy streams. This affects `readv()` as much as `writev()`.
2. **`posixaio::preadv()` / `pwritev()` reported a failed `pread`/`pwrite` as `0`**, which callers read as EOF rather than as an error, and overwrote the callee's `errno` with the meaningless value `-1`.

Plain kernel TCP sockets were not affected, nor were the many paths that already advance on `ret < iov_len` — that predicate is the correct one and lets a 0-length element through.

## Changes

- **`net/basic_socket.h`** — `BufStepV` now skips 0-length elements, so the iocb is never invoked with a 0-byte request. `BufStepV` drove `doio_loop()` by `iovcnt > 0` rather than by the remaining byte count, and `iovector_view::extract_front(0)` pops nothing, so a 0-length element could stay at the head of the view and make the next iocb transfer 0 byte — which `doio_loop()` takes for EOF. This one change covers all ten `BufStepV` users (kernel socket, TLS, rsocket, `st.cpp`, `basic_socket.cpp`), on both the read and the write side, and also drops the useless 0-byte `sendmsg` on plain TCP sockets. Before the first iocb one element is deliberately kept, because iocbs that serve only `iov[0]` need a valid one.
- **`net/kernel_socket.cpp`** — `ZeroCopySocketStream::do_sendmsg()` returns early for a 0-byte message. Defence in depth: `BufStepV` cannot reach the path where `send(iov, iovcnt)` or `send(buf, 0)` is called directly, which hangs just the same.
- **`net/security-context/sasl-stream.cpp`** — fixed separately, as `writev()` / `readv()` there don't use `BufStepV`: skip 0-length segments, and stop discarding the already accumulated `count` when a segment returns `<= 0`.
- **`io/aio-wrapper.cpp`** — `posixaio::preadv()` / `pwritev()` now return `-1` when nothing has been transferred yet, keeping the callee's `errno` (`new_errno = 0`), and return the accumulated count once part of `iov[]` has been transferred, as `preadv(2)` / `pwritev(2)` do. This matches the idiom the `preadv()` / `pwritev()` of `windows_compat.cpp` and `iocp.cpp` already follow.
- **`net/test/test.cpp`** — added `writev.empty_iov`, `writev.empty_iov_tls` and `writev.empty_iov_zerocopy`, covering a 0-length element at the head, in the middle and at the tail, plus an all-empty array, asserting both the return value and the bytes seen by the peer.

## Motivation

Zero-length `iovec` entries are legal for `writev(2)` / `sendmsg(2)` and are routinely produced by generic serialization or framing code that emits an empty body or an empty header block; the WebSocket send path in this repository is one such producer. The TLS failure mode is the most dangerous one: `writev()` returns a short count with no error and `errno` untouched, so a caller that only checks `ret < 0` silently corrupts its stream. For a 100 + 0 + 50 bytes `writev()` the peer received 100 bytes, or 0 when the empty element came first.

The ZeroCopy variant is worse in a different way: the extra 0-byte `sendmsg(MSG_ZEROCOPY)` bumps `m_num_calls`, but no completion notification arrives for it, so `zerocopy_confirm()` waits for a counter that never advances — a permanent hang with the default (infinite) stream timeout.

The `posixaio` defect is the same confusion seen from the other side: an error is emitted as `0`, so a caller that treats `0` as EOF stops early and believes it reached the end of the file. It is reachable through `new_localfile_adaptor(fd, ioengine_posixaio)`.

## References

- Fixes #1601, which has the full analysis and the measured numbers.
- Validated: the new tests fail without this fix (TLS `150 -> 100` and `150 -> 0`; ZeroCopy times out) and pass with it. Plain TCP correctness was re-checked with `SO_SNDBUF=4096` plus a slow reader to force partial sends. `test-syncio`, which drives `posixaio` through `do_test_aio`, plus `test-fs`, `test-exportfs`, `test-socket` and `test-tls` all pass. The 5 pre-existing `ctest` failures on this platform (`test-throttle`, `test-iouring`, `test-curl`, `test-rpc-message`, `cache_test`) reproduce identically on the parent commit.
- Not compile-tested locally: the SASL change, as gsasl is unavailable here and `ENABLE_SASL` is off. It needs CI with SASL enabled.
- Audited and intentionally left unchanged, as they need separate design decisions rather than a mechanical fix: the HTTP/2 `read_data()` loop in `net/http/streams.cpp`, which spends an `iov[]` slot on a 0-length element and does not check `ret < to_read`; the iov rebuild in `ecosystem/oss.cpp`, which propagates 0-length entries into it; the unchecked `IOVector::push_back()` return value in `net/http/websocket.cpp`; and `KcpSocketStream::send(iov, iovcnt)`, where `ikcp_send(.., 0)` may turn a 0-length segment into an `EIO` failure. Verified as already correct, and left alone: `memory-stream`, `windows_compat.cpp`, `iocp.cpp`, `fs/aligned-file.cpp`, `fs/cache/cached_fs.cpp`, `fs/virtual-file.cpp`, `common/ring.cpp` and `net/curl.h`'s `IOVWriter`.
