### PR TITLE
[Backport][main to 0.9] | feat(ecosystem): add bucket create/delete APIs and crc64 outputs for copy ops (#1606)

### DIFF
--- a/ecosystem/oss.cpp
+++ b/ecosystem/oss.cpp
@@ -134,7 +134,7 @@ class OssUrl {
     if (escaped) m_raw_object = object;
 
     m_url_size = m_url.size();
-    m_bucket = {(is_http ? 7ul : 8ul), bucket.size()};
+    m_bucket = {(is_http ? 7ull : 8ull), bucket.size()};
     m_object = {m_bucket.offset() + bucket.size() + endpoint.size() + 1 + 1,
                 escaped_obj.size()};  // start without prefix /
   }
@@ -540,7 +540,7 @@ int OssClient::walk_list_results(const SimpleDOM::Node& list_bucket_result,
     auto type = NodeStrValue(child["Type"]);
 
     if (!key.has_value() || !size.has_value() || !mtime.has_value() ||
-        !etag.has_value() || !type.has_value())
+        !etag.has_value())
       LOG_ERROR_RETURN(EINVAL, -1,
                        "unexpected response: missing required fields");
 

--- a/ecosystem/oss.cpp
+++ b/ecosystem/oss.cpp
@@ -309,6 +309,12 @@ static int verify_crc64_if_needed(HTTP_STACK_OP& op, std::string_view object,
   return 0;
 }
 
+static bool get_resp_crc64(HTTP_STACK_OP& op, uint64_t* crc64) {
+  auto it = op.resp.headers.find("x-oss-hash-crc64ecma");
+  if (it == op.resp.headers.end()) return false;
+  return estring_view(it.second()).to_uint64_check(crc64);
+}
+
 static ssize_t body_writer_cb(void* iov_view, photon::net::http::Request* req) {
   auto view = static_cast<iovector_view*>(iov_view);
   auto ret = req->writev(view->iov, view->iovcnt);
@@ -335,6 +341,10 @@ class OssClientImpl : public Client {
   OssClientImpl(const ClientOptions& options, Authenticator* authenticator);
   ~OssClientImpl();
 
+  int put_bucket(std::string_view agent_bucket);
+
+  int delete_bucket();
+
   int list_objects(std::string_view prefix, ListObjectsCallback cb,
                    ListObjectsParameters = {}, std::string* marker = nullptr);
 
@@ -358,7 +368,7 @@ class OssClientImpl : public Client {
                         ObjectUploadOptions& opts);
 
   int copy_object(std::string_view src_object, std::string_view dst_object,
-                  bool overwrite = false, bool set_mime = false);
+                  ObjectCopyOptions& opts);
 
   int init_multipart_upload(std::string_view object, void** context);
 
@@ -367,7 +377,8 @@ class OssClientImpl : public Client {
                       ObjectUploadOptions& opts);
 
   int upload_part_copy(void* context, off_t offset, size_t count,
-                       int part_number, std::string_view from = {});
+                       int part_number, std::string_view from,
+                       ObjectPartCopyOptions& opts);
 
   int complete_multipart_upload(void* context, ObjectUploadOptions& opts);
 
@@ -407,8 +418,8 @@ class OssClientImpl : public Client {
                          ListObjectsCallback cb, bool delimiters, int maxKeys,
                          std::string* marker);
 
-  int do_copy_object(OssUrl& src_oss_url, OssUrl& dst_oss_url, bool overwrite,
-                     bool set_mime);
+  int do_copy_object(OssUrl& src_oss_url, OssUrl& dst_oss_url,
+                     ObjectCopyOptions& opts);
   int do_delete_object(OssUrl& oss_url);
 
   int do_delete_objects(estring_view bucket, estring_view prefix,
@@ -637,18 +648,18 @@ int OssClient::do_list_objects_v1(std::string_view bucket,
 }
 
 int OssClient::do_copy_object(OssUrl& src_oss_url, OssUrl& dst_oss_url,
-                              bool overwrite, bool set_mime) {
+                              ObjectCopyOptions& opts) {
   DEFINE_ONSTACK_OP(m_client, Verb::PUT, dst_oss_url.url());
 
   estring oss_copy_source =
       estring("/").appends(src_oss_url.bucket(), "/", src_oss_url.object(true));
   op.req.headers.insert(OSS_HEADER_KEY_X_OSS_COPY_SOURCE, oss_copy_source);
-  if (!overwrite) {
+  if (!opts.overwrite) {
     op.req.headers.insert(OSS_HEADER_KEY_X_OSS_FORBID_OVERWRITE, "true");
   }
 
   std::string_view dst_type{};  // use the same content type as the source
-  if (set_mime) {
+  if (opts.set_mime) {
     auto src_type = lookup_mime_type(src_oss_url.object());
     auto new_dst_type = lookup_mime_type(dst_oss_url.object());
     if (src_type != new_dst_type) dst_type = new_dst_type;
@@ -658,7 +669,13 @@ int OssClient::do_copy_object(OssUrl& src_oss_url, OssUrl& dst_oss_url,
     }
   }
 
-  return sign_and_call(op, Verb::PUT, dst_oss_url);
+  opts.crc64.reset();
+  int r = sign_and_call(op, Verb::PUT, dst_oss_url);
+  if (r < 0) return r;
+
+  uint64_t crc64;
+  if (get_resp_crc64(op, &crc64)) opts.crc64.set(crc64);
+  return 0;
 }
 
 int OssClient::do_delete_object(OssUrl& oss_url) {
@@ -759,7 +776,10 @@ int OssClient::rename_object(std::string_view src_path,
   OssUrl src_oss_url(m_endpoint, m_bucket, src_path, m_is_http);
   OssUrl dst_oss_url(m_endpoint, m_bucket, dst_path, m_is_http);
 
-  if (do_copy_object(src_oss_url, dst_oss_url, true, set_mime) < 0) return -1;
+  ObjectCopyOptions opts;
+  opts.overwrite = true;
+  opts.set_mime = set_mime;
+  if (do_copy_object(src_oss_url, dst_oss_url, opts) < 0) return -1;
   return do_delete_object(src_oss_url);
 }
 
@@ -787,6 +807,20 @@ int OssClient::get_symlink(std::string_view obj, std::string& target) {
   target = photon::net::http::url_unescape(
       op.resp.headers[OSS_HEADER_KEY_X_OSS_SYMLINK_TARGET]);
   return r;
+}
+
+int OssClient::put_bucket(std::string_view agent_bucket) {
+  OssUrl oss_url(m_endpoint, m_bucket, {}, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.url());
+  if (!agent_bucket.empty())
+    op.req.headers.insert(OSS_HEADER_KEY_X_OSS_AGENTIC_BUCKET, agent_bucket);
+  return sign_and_call(op, Verb::PUT, oss_url);
+}
+
+int OssClient::delete_bucket() {
+  OssUrl oss_url(m_endpoint, m_bucket, {}, m_is_http);
+  DEFINE_ONSTACK_OP(m_client, Verb::DELETE, oss_url.url());
+  return sign_and_call(op, Verb::DELETE, oss_url);
 }
 
 int OssClient::delete_objects(const std::vector<std::string_view>& objects,
@@ -1299,12 +1333,12 @@ ssize_t OssClient::append_object(std::string_view object,
 }
 
 int OssClient::copy_object(std::string_view src_object,
-                           std::string_view dst_object, bool overwrite,
-                           bool set_mime) {
+                           std::string_view dst_object,
+                           ObjectCopyOptions& opts) {
   OssUrl src_oss_url(m_endpoint, m_bucket, src_object, m_is_http);
   OssUrl dst_oss_url(m_endpoint, m_bucket, dst_object, m_is_http);
 
-  return do_copy_object(src_oss_url, dst_oss_url, overwrite, set_mime);
+  return do_copy_object(src_oss_url, dst_oss_url, opts);
 }
 
 struct oss_multipart_context {
@@ -1388,7 +1422,8 @@ ssize_t OssClient::upload_part(void* context, size_t cnt,
 }
 
 int OssClient::upload_part_copy(void* context, off_t offset, size_t count,
-                                int part_number, std::string_view from) {
+                                int part_number, std::string_view from,
+                                ObjectPartCopyOptions& opts) {
   assert(context);
   oss_multipart_context* ctx = (oss_multipart_context*)context;
   assert(!ctx->upload_id.empty());
@@ -1415,8 +1450,12 @@ int OssClient::upload_part_copy(void* context, off_t offset, size_t count,
   DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.append_params(query_params));
   op.req.headers.insert(OSS_HEADER_KEY_X_OSS_COPY_SOURCE, oss_copy_source);
   op.req.headers.insert(OSS_HEADER_KEY_X_OSS_COPY_SOURCE_RANGE, range);
+  opts.crc64.reset();
   int r = sign_and_call(op, Verb::PUT, oss_url, query_params);
   if (r < 0) return r;
+
+  uint64_t crc64;
+  if (get_resp_crc64(op, &crc64)) opts.crc64.set(crc64);
 
   auto reader = get_xml_node(op);
   if (!reader) LOG_ERROR_RETURN(EINVAL, -1, "failed to parse xml resp_body");

--- a/ecosystem/oss.h
+++ b/ecosystem/oss.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <sys/uio.h>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace photon {
@@ -90,6 +91,37 @@ struct ObjectHeaderMeta : public ObjectMeta {
   DEFINE_OPTIONAL_FIELD(uint64_t, crc64, 1 << 5)
 
 #undef DEFINE_OPTIONAL_FIELD
+};
+
+template <typename T>
+class OptValue {
+ public:
+  bool has_value() const { return has_value_; }
+  const T& value() const { return value_; }
+  void set(T v) {
+    value_ = std::move(v);
+    has_value_ = true;
+  }
+  void reset() {
+    value_ = {};
+    has_value_ = false;
+  }
+  explicit operator bool() const { return has_value_; }
+
+ private:
+  T value_{};
+  bool has_value_ = false;
+};
+
+struct ObjectCopyOptions {
+  bool overwrite = false;
+  bool set_mime = false;
+
+  OptValue<uint64_t> crc64;
+};
+
+struct ObjectPartCopyOptions {
+  OptValue<uint64_t> crc64;
 };
 
 struct ListObjectsParameters {
@@ -166,6 +198,10 @@ using BodyReader = TempDelegate<ssize_t, IStream* /*input*/>;
 
 class Client : public Object {
  public:
+  virtual int put_bucket(std::string_view agent_bucket = {}) = 0;
+
+  virtual int delete_bucket() = 0;
+
   virtual int list_objects(std::string_view prefix, ListObjectsCallback cb,
                            ListObjectsParameters = {},
                            std::string* marker = nullptr) = 0;
@@ -245,9 +281,17 @@ class Client : public Object {
                                 off_t position,
                                 ObjectUploadOptions& opts) = 0;
 
+  int copy_object(std::string_view src_object, std::string_view dst_object,
+                  bool overwrite = false, bool set_mime = false) {
+    ObjectCopyOptions opts;
+    opts.overwrite = overwrite;
+    opts.set_mime = set_mime;
+    return copy_object(src_object, dst_object, opts);
+  }
+
   virtual int copy_object(std::string_view src_object,
-                          std::string_view dst_object, bool overwrite = false,
-                          bool set_mime = false) = 0;
+                          std::string_view dst_object,
+                          ObjectCopyOptions& opts) = 0;
 
   virtual int init_multipart_upload(std::string_view object,
                                     void** context) = 0;
@@ -281,8 +325,15 @@ class Client : public Object {
                               int part_number, BodyWriter writer,
                               ObjectUploadOptions& opts) = 0;
 
+  int upload_part_copy(void* context, off_t offset, size_t count,
+                       int part_number, std::string_view from = {}) {
+    ObjectPartCopyOptions opts;
+    return upload_part_copy(context, offset, count, part_number, from, opts);
+  }
+
   virtual int upload_part_copy(void* context, off_t offset, size_t count,
-                               int part_number, std::string_view from = {}) = 0;
+                               int part_number, std::string_view from,
+                               ObjectPartCopyOptions& opts) = 0;
 
   // if expected_crc64 is specified, we will compare the value with the
   // returned object crc64 to validate the object integrity.
@@ -311,8 +362,14 @@ class Client : public Object {
     }
 
     int copy(off_t offset, size_t count, int part_number,
+             std::string_view from, ObjectPartCopyOptions& opts) {
+      return _client->upload_part_copy(_ctx, offset, count, part_number, from,
+                                       opts);
+    }
+    int copy(off_t offset, size_t count, int part_number,
              std::string_view from = {}) {
-      return _client->upload_part_copy(_ctx, offset, count, part_number, from);
+      ObjectPartCopyOptions opts;
+      return copy(offset, count, part_number, from, opts);
     }
 
     int complete(uint64_t* expected_crc64) {

--- a/ecosystem/oss_constants.h
+++ b/ecosystem/oss_constants.h
@@ -25,6 +25,7 @@ static const char OSS_HEADER_KEY_X_OSS_METADATA_DIRECTIVE[] = "x-oss-metadata-di
 static const char OSS_HEADER_KEY_X_OSS_RANGE_BEHAVIOR[]     = "x-oss-range-behavior";
 static const char OSS_HEADER_KEY_X_OSS_FORBID_OVERWRITE[]   = "x-oss-forbid-overwrite";
 static const char OSS_HEADER_KEY_X_OSS_SYMLINK_TARGET[]   = "x-oss-symlink-target";
+static const char OSS_HEADER_KEY_X_OSS_AGENTIC_BUCKET[]   = "x-oss-agentic-bucket";
 
 static const char OSS_PARAM_KEY_CONTINUATION_TOKEN[]        = "continuation-token";
 static const char OSS_PARAM_KEY_OBJECT_META[]     = "objectMeta";

--- a/ecosystem/test/test_oss.cpp
+++ b/ecosystem/test/test_oss.cpp
@@ -97,6 +97,7 @@ class BasicAuthOssTest : public ::testing::Test {
 
   void list_objects();
   void put_and_get_meta();
+  void bucket_operations();
   void copy_and_rename();
   void append_and_get();
   void multipart();
@@ -152,6 +153,53 @@ class CustomCachedAuthOssTest : public CachedAuthOssTest {
     ASSERT_NE(client, nullptr) << "Failed to create OSS client";
   }
 };
+
+void BasicAuthOssTest::bucket_operations() {
+  auto suffix =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
+  estring bucket_name;
+  bucket_name.appends("photon-test-", suffix);
+
+  ClientOptions opts;
+  opts.bucket = bucket_name;
+  opts.endpoint = FLAGS_endpoint;
+  opts.region = FLAGS_region;
+  auto auth = new_basic_oss_authenticator({FLAGS_ak, FLAGS_sk, ""});
+  Client* bclient = new_oss_client(opts, auth);
+  ASSERT_NE(bclient, nullptr);
+  DEFER(delete bclient);
+  // best-effort cleanup in case an assertion fails mid-test
+  DEFER({
+    bclient->delete_object("bucket_operations/testfile");
+    bclient->delete_bucket();
+  });
+
+  int ret = bclient->put_bucket();
+  ASSERT_EQ(ret, 0);
+
+  // the new bucket is usable right away
+  char buf[3] = {1};
+  iovec iov{buf, 3};
+  auto crc64 = crc64ecma(buf, 3, 0);
+  ret = bclient->put_object("bucket_operations/testfile", &iov, 1, &crc64);
+  ASSERT_EQ(ret, 3);
+
+  // deleting a non-empty bucket must fail
+  ret = bclient->delete_bucket();
+  ASSERT_EQ(ret, -1);
+
+  ret = bclient->delete_object("bucket_operations/testfile");
+  ASSERT_EQ(ret, 0);
+
+  ret = bclient->delete_bucket();
+  ASSERT_EQ(ret, 0);
+
+  // the bucket is gone now
+  ret = bclient->put_object("bucket_operations/testfile", &iov, 1);
+  ASSERT_EQ(ret, -1);
+}
 
 void BasicAuthOssTest::list_objects() {
   std::vector<std::string> test_objects = {
@@ -345,6 +393,15 @@ void BasicAuthOssTest::copy_and_rename() {
   ASSERT_EQ(ret, 0);
   ret = client->copy_object(src, dst, false, true);
   ASSERT_EQ(ret, -1);  // overwrite is not allowed
+
+  auto dst2 = get_real_test_path("copy_and_rename_object/dst2.mp4");
+  ObjectCopyOptions copy_opts;
+  copy_opts.overwrite = true;
+  copy_opts.set_mime = true;
+  ret = client->copy_object(dst, dst2, copy_opts);
+  ASSERT_EQ(ret, 0);
+  EXPECT_TRUE(copy_opts.crc64.has_value());
+
   ret = client->rename_object(src, dst);
   ASSERT_EQ(ret, 0);
 }
@@ -397,8 +454,10 @@ void BasicAuthOssTest::multipart() {
     ASSERT_TRUE(false);
   }
   for (int i = 0; i < 5; i++) {
-    ret = ctx.copy(i * buf_size, buf_size, i + 1, path);
+    ObjectPartCopyOptions pc_opts;
+    ret = ctx.copy(i * buf_size, buf_size, i + 1, path, pc_opts);
     ASSERT_EQ(ret, 0);
+    EXPECT_TRUE(pc_opts.crc64.has_value());
   }
   ret = ctx.complete(nullptr);
   ASSERT_EQ(ret, 0);
@@ -898,6 +957,7 @@ void BasicAuthOssTest::buf_multipart() {
 }
 
 TEST_F(BasicAuthOssTest, list_objects) { list_objects(); }
+TEST_F(BasicAuthOssTest, bucket_operations) { bucket_operations(); }
 TEST_F(BasicAuthOssTest, multipart) { multipart(); }
 TEST_F(BasicAuthOssTest, append_and_get) { append_and_get(); }
 TEST_F(BasicAuthOssTest, put_and_get_meta) { put_and_get_meta(); }


### PR DESCRIPTION
> feat(ecosystem): add bucket create/delete APIs and crc64 outputs for copy ops (#1606)

- add Client::put_bucket/delete_bucket performing bucket-level PUT/DELETE,
  with an optional x-oss-agentic-bucket header on PutBucket
- add ObjectCopyOptions/ObjectPartCopyOptions whose crc64 output is an
  OptValue<uint64_t> parsed from the x-oss-hash-crc64ecma response header
- the options-based copy_object/upload_part_copy are the new pure-virtual
  interfaces; legacy signatures remain as non-virtual wrappers
- tests: bucket_operations case plus crc64 checks in copy/multipart tests
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.