### PR TITLE
fix(thread): hide _photon_thread_die from dynamic export

### DIFF
--- a/common/checksum/crc.cpp
+++ b/common/checksum/crc.cpp
@@ -216,17 +216,32 @@ inline __attribute__((always_inline)) uint32_t crc32c(uint32_t crc, uint64_t dat
 #endif
 
 // CRC32C hardware instructions for ARM
+//
+// Call the compiler builtins directly instead of going through arm_acle.h:
+// the arm_acle.h shipped with gcc-9 on Ubuntu 18.04 leaks an unclosed
+// extern "C" scope into every C++ file that includes it.
+#ifdef __clang__
+#define PHOTON_CRC32CB __builtin_arm_crc32cb
+#define PHOTON_CRC32CH __builtin_arm_crc32ch
+#define PHOTON_CRC32CW __builtin_arm_crc32cw
+#define PHOTON_CRC32CD __builtin_arm_crc32cd
+#else
+#define PHOTON_CRC32CB __builtin_aarch64_crc32cb
+#define PHOTON_CRC32CH __builtin_aarch64_crc32ch
+#define PHOTON_CRC32CW __builtin_aarch64_crc32cw
+#define PHOTON_CRC32CD __builtin_aarch64_crc32cx
+#endif
 inline __attribute__((always_inline)) uint32_t crc32c(uint32_t crc, uint8_t data) {
-    return __crc32cb(crc, data);
+    return PHOTON_CRC32CB(crc, data);
 }
 inline __attribute__((always_inline)) uint32_t crc32c(uint32_t crc, uint16_t data) {
-    return __crc32ch(crc, data);
+    return PHOTON_CRC32CH(crc, data);
 }
 inline __attribute__((always_inline)) uint32_t crc32c(uint32_t crc, uint32_t data) {
-    return __crc32cw(crc, data);
+    return PHOTON_CRC32CW(crc, data);
 }
 inline __attribute__((always_inline)) uint32_t crc32c(uint32_t crc, uint64_t data) {
-    return __crc32cd(crc, data);
+    return PHOTON_CRC32CD(crc, data);
 }
 
 #else

--- a/common/checksum/mm_intrin_neon.h
+++ b/common/checksum/mm_intrin_neon.h
@@ -23,7 +23,6 @@ limitations under the License.
 #ifdef __aarch64__
 
 #include <arm_neon.h>
-#include <arm_acle.h>
 #include <cstdint>
 
 // =============================================================================
@@ -217,11 +216,5 @@ __m128i _mm_clmulepi64_si128_impl(__m128i a, __m128i b) {
 }
 
 #define _mm_clmulepi64_si128(a, b, imm) _mm_clmulepi64_si128_impl<imm>(a, b)
-
-// =============================================================================
-// CRC32C hardware instructions
-// =============================================================================
-// Both GCC and modern Clang (including Apple Clang 17+) provide __crc32c* via arm_acle.h
-#include <arm_acle.h>
 
 #endif // __aarch64__

--- a/thread/thread.cpp
+++ b/thread/thread.cpp
@@ -1029,7 +1029,7 @@ R"(
         __builtin_unreachable();
     }
 
-    extern "C" __attribute__((noreturn, used))
+    extern "C" __attribute__((noreturn, used, visibility("hidden")))
     void _photon_thread_die(thread* th) asm("_photon_thread_die");
     void _photon_thread_die(thread* th) {
         assert(th == CURRENT);


### PR DESCRIPTION
_photon_thread_stub issues a direct `call _photon_thread_die` (`b _photon_thread_die` on aarch64). With default visibility the symbol is preemptible, so the direct PC32/branch relocation is rejected when linking libphoton.so with binutils < 2.31 (e.g. Ubuntu 18.04):

  relocation R_X86_64_PC32 against symbol _photon_thread_die can not be
  used when making a shared object; recompile with -fPIC

All the other asm symbols referenced this way are already hidden: the DEF_ASM_FUNC macro emits `.hidden` and _asan_start has visibility("hidden"). Give _photon_thread_die the same treatment; it is only referenced from within thread.cpp.