### PR TITLE
fix(rpc): fix use-after-free when wait timeout races with collect

### DIFF
--- a/rpc/out-of-order-execution.cpp
+++ b/rpc/out-of-order-execution.cpp
@@ -128,12 +128,20 @@ namespace rpc {
                 if (args.phase == OooPhase::WAITING)
                     LOG_ERROR_RETURN(EINVAL, -1, "context already in waiting");
                 for (bool hold_lock = false; !hold_lock;) {
-                    switch (args.phase) {                        
+                    switch (args.phase) {
                         case OooPhase::COLLECTED:
                             // result alread collected before wait
                             if (args.th != CURRENT)
                                 LOG_ERROR_RETURN(EINVAL, -1, "context is not issued by current thread");
                             return args.ret;
+                        case OooPhase::COLLECTING:
+                            // A reader owns our context and is collecting our
+                            // response right now. We must not tear it down; wait
+                            // until it reaches COLLECTED (the reader wakes us via
+                            // thread_interrupt after setting COLLECTED under
+                            // phaselock, so this wakeup cannot be lost).
+                            m_wait.wait(args.phaselock);
+                            break;
                         case OooPhase::ISSUED:
                             args.th = photon::CURRENT;
                             args.phase = OooPhase::WAITING;
@@ -150,13 +158,26 @@ namespace rpc {
                                     return args.ret;
                                 }
                                 if (ret == -1) {
-                                    // or just timed out
+                                    // Timed out. A reader may nonetheless have
+                                    // claimed our context between the timeout
+                                    // firing and now. Probe the map: erasing our
+                                    // tag succeeds only if no reader has taken
+                                    // ownership yet -- then it is safe to give up.
+                                    // If the tag is already gone, a reader owns us
+                                    // and is collecting into our buffer, so we must
+                                    // wait for COLLECTED rather than tear the
+                                    // context down (which would use-after-free it).
+                                    bool reclaimed;
                                     {
                                         SCOPED_LOCK(m_mutex_map);
-                                        m_map.erase(args.tag);
+                                        reclaimed = (m_map.erase(args.tag) != 0);
                                         m_cond_collected.notify_one();
                                     }
-                                    LOG_ERROR_RETURN(ETIMEDOUT, -1, "waiting for completion timeout");
+                                    if (reclaimed)
+                                        LOG_ERROR_RETURN(ETIMEDOUT, -1, "waiting for completion timeout");
+                                    while (args.phase != OooPhase::COLLECTED)
+                                        m_wait.wait(args.phaselock);
+                                    return args.ret;
                                 }
                                 break;
                             }
@@ -198,6 +219,18 @@ namespace rpc {
                     }
                     targ = it->second;
                     m_map.erase(it);
+                }
+
+                // Mark the context as being collected BEFORE the (possibly
+                // suspending) do_collect(). Once the tag has been erased above,
+                // this reader owns the context; a concurrently timing-out owner
+                // observes COLLECTING (or an already-erased tag) and waits for
+                // COLLECTED instead of tearing the context down, otherwise
+                // do_collect() and the phase update below would use-after-free
+                // the context and its receive buffer.
+                {
+                    SCOPED_LOCK(targ->phaselock);
+                    targ->phase = OooPhase::COLLECTING;
                 }
 
                 // collect with mutex_r

--- a/rpc/out-of-order-execution.h
+++ b/rpc/out-of-order-execution.h
@@ -46,7 +46,12 @@ namespace rpc {
         BEFORE_ISSUE = 0,
         ISSUED = 1,
         WAITING = 2,
-        COLLECTED = 3
+        // A reader has taken ownership of the context and is collecting its
+        // response (running do_collect). The owning thread must NOT tear the
+        // context down while in this phase, or the reader use-after-frees the
+        // context and its receive buffer.
+        COLLECTING = 3,
+        COLLECTED = 4
     };
     struct OutOfOrderContext
     {


### PR DESCRIPTION
## Problem

In `OooEngine`, a single reader claims requests by erasing their tags from `m_map`, then calls
`do_collect()` to scatter the received body. For large bodies, `do_collect()` (e.g. `do_recv_body`
doing a `readv`) suspends on the socket until data arrives — only afterwards is the context marked
`COLLECTED`.

Meanwhile, the owning thread waits with its own deadline. If the deadline fires **during the collect
window**, the old timeout branch unconditionally erases the tag (no-op — the reader already took it)
and returns `ETIMEDOUT`, letting the caller destroy its stack-local `OooArgs` and receive buffer.
The reader then resumes `do_collect()`, scattering body data into the freed buffer and dereferencing
the dangling context to set `COLLECTED` / read `th` — a textbook use-after-free.

## Reproduction

`ooo-bug-poc.cpp`: single-process PoC that drives the real OOO engine over loopback TCP.

Two concurrent client requests share one connection / one engine:
- **reader** issues first, holds `m_mutex_r`, blocks reading the response header (its own reply never arrives)
- **victim** issues second, can't get the reader lock, waits with a shorter deadline (300ms)
- Server only replies to victim's tag — sends header immediately, then sleeps 800ms before sending body

### Without fix (bug)

Crashes without ASAN (core dump). With ASAN — `heap-use-after-free`:

```
[reader ] issued request (tag=1), became the sole reader
[victim ] issued request (tag=2), waiting with 300ms deadline
[server ] sent header for tag=2, now holding 800ms before body
[server ] body for tag=2 sent
[reader ] finished collecting VICTIM body: 8388608 bytes at +959ms
[victim ] wait_completion returned ret=-1 errno=110 at +300ms       ← timed out
```

```
==3908276==ERROR: AddressSanitizer: heap-use-after-free on address 0x71f469fec800
WRITE of size 98304 at 0x71f469fec800 thread T0
    #0 __interceptor_recv.part.0
    #6 do_collect                                    ooo-bug-poc.cpp:125
    #9 OooEngine::wait_completion                    out-of-order-execution.cpp:204
   #10 ooo_wait_completion                           out-of-order-execution.cpp:255
   #11 reader_thread                                 ooo-bug-poc.cpp:151

0x71f469fec800 is located 0 bytes inside of 8388608-byte region [0x71f469fec800,0x71f46a7ec800)
freed by thread T0 here:
    victim_thread                                    ooo-bug-poc.cpp:176
```

Victim is told ETIMEDOUT at +300ms and frees its buffer, but the reader doesn't finish writing
until +959ms. ASAN precisely captures: the reader's `do_collect` → `recv()` writes into victim's
freed 8MB heap region.

### With fix

```
[reader ] issued request (tag=1), became the sole reader
[victim ] issued request (tag=2), waiting with 300ms deadline
[server ] sent header for tag=2, now holding 800ms before body
[server ] body for tag=2 sent
[reader ] finished collecting VICTIM body: 8388608 bytes at +959ms
[victim ] wait_completion returned ret=8388608 errno=4 at +959ms   ← success
→ NO BUG: owner waited for the in-progress collect and got the data.
```

## Fix

1. **New `COLLECTING` phase**: set by the reader under `phaselock` after erasing the tag from
   `m_map` and before the (possibly suspending) `do_collect()`.
2. **Timeout path checks `reclaimed`**: `m_map.erase(tag)` returning 0 means the reader already
   took ownership — wait for `COLLECTED` instead of returning `ETIMEDOUT`.
3. **`COLLECTING` case in wait switch**: if the waiter enters and finds phase is `COLLECTING`,
   block on `m_wait` until `COLLECTED`.

## Verification

| | Without fix (bug) | With fix |
|---|---|---|
| No ASAN | `ret=-1` (ETIMEDOUT) + core dump | `ret=8388608` (8MB body received) |
| With ASAN | `heap-use-after-free`: reader's `do_collect` → `recv()` writes into victim's freed 8MB heap region | No errors, returns normally |

## PoC

<details>
<summary>ooo-bug-poc.cpp</summary>

```cpp
// Single-process PoC for "wait timeout races with collect" use-after-free in
// the RPC out-of-order execution engine.
//
// Server and client run in the same Photon event loop (server as a background
// coroutine), communicating over loopback TCP, driving the real engine in
// rpc/out-of-order-execution.cpp.
//
// Two concurrent client requests share one connection / one engine:
//   - "reader" issues first, becomes the sole reader (holds m_mutex_r), then
//     blocks reading the response header.  Its own reply never arrives.
//   - "victim" issues second, can't get the reader lock, waits with a shorter
//     deadline.
// The server only replies to victim's tag — sends header immediately, then
// deliberately delays before sending body, exceeding victim's deadline.
// So the reader gets stuck in do_collect() writing into victim's buffer while
// victim's wait deadline has already fired.
//
// Buggy engine: victim's wait returns ETIMEDOUT early (real RPC stub would
//   destroy stack-local OooArgs and response buffer here), but reader is still
//   writing that buffer, and later marks the context COLLECTED → use-after-free.
// Fixed engine: victim detects the in-progress collect, waits for COLLECTED,
//   then returns normally with full body data — nothing is destroyed prematurely.
//
// Can be run under ASAN to verify.

#include <cstdio>
#include <cstdlib>
#include <cerrno>
#include <vector>
#include <unistd.h>

#include <photon/photon.h>
#include <photon/net/socket.h>
#include <photon/thread/thread.h>
#include <photon/thread/thread11.h>
#include <photon/common/utility.h>
#include <photon/rpc/rpc.h>
#include <photon/rpc/out-of-order-execution.h>

using namespace photon;
using namespace photon::rpc;

static const uint16_t PORT             = 9528;
static const uint32_t FUNC_READER      = 1;
static const uint32_t FUNC_VICTIM      = 2;
static const uint32_t BODY_SIZE        = 8u * 1024 * 1024;
static const uint64_t VICTIM_TIMEOUT_US = 300 * 1000;
static const uint64_t SERVER_HOLD_US    = 800 * 1000;

static int read_request(net::ISocketStream* s, Header& h) {
    if (s->read(&h, sizeof(h)) != (ssize_t)sizeof(h)) return -1;
    if (h.size) {
        std::vector<char> body(h.size);
        if (s->read(body.data(), h.size) != (ssize_t)h.size) return -1;
    }
    return 0;
}

static void serve_conn(net::ISocketStream* s) {
    std::vector<char> body(BODY_SIZE, (char)0xCD);
    for (;;) {
        Header h;
        if (read_request(s, h) < 0) { printf("[server] connection closed\n"); return; }
        printf("[server] received request function=%lu tag=%lu\n",
               (unsigned long)h.function.function, (unsigned long)h.tag);
        if (h.function.function != FUNC_READER) {
            // Only reply to victim.  Reader's request is ignored.
        }
        if (h.function.function != FUNC_VICTIM) continue;

        Header r;
        r.size = BODY_SIZE;
        r.function = h.function;
        r.tag = h.tag;
        printf("[server] sent header for tag=%lu, now holding %lums before body\n",
               (unsigned long)r.tag, (unsigned long)(SERVER_HOLD_US / 1000));
        s->write(&r, sizeof(r));
        thread_usleep(SERVER_HOLD_US);
        s->write(body.data(), body.size());
        printf("[server] body for tag=%lu sent\n", (unsigned long)r.tag);
    }
}

static void server_main(net::ISocketServer* server) {
    auto conn = server->accept();
    if (!conn) return;
    printf("[server] accepted connection\n");
    serve_conn(conn);
    delete conn;
}

struct Ctx : OutOfOrderContext {
    uint32_t role = 0;
    char* buf = nullptr;
};

static net::ISocketStream* g_stream = nullptr;
static Header g_last_hdr;
static uint64_t g_start = 0;
static Ctx* g_cv = nullptr;

static volatile int g_victim_ret = -12345;
static volatile int g_victim_errno = 0;
static volatile uint64_t g_victim_return_ms = 0;
static volatile uint64_t g_collect_done_ms = 0;
static volatile long g_collect_bytes = -1;

static uint64_t ms() { return (now - g_start) / 1000; }

static int do_issue(void*, OutOfOrderContext* a) {
    Ctx* c = (Ctx*)a;
    Header h;
    h.size = 0;
    h.function = FunctionID((uint64_t)c->role);
    h.tag = a->tag;
    return g_stream->write(&h, sizeof(h)) == (ssize_t)sizeof(h) ? 0 : -1;
}

static int do_completion(void*, OutOfOrderContext* a) {
    g_stream->timeout(10UL * 1000 * 1000);
    if (g_stream->read(&g_last_hdr, sizeof(g_last_hdr)) != (ssize_t)sizeof(g_last_hdr)) return -1;
    a->tag = g_last_hdr.tag;
    return 0;
}

static int do_collect(void*, OutOfOrderContext* a) {
    Ctx* c = (Ctx*)a;
    g_stream->timeout(30UL * 1000 * 1000);
    ssize_t n = g_stream->read(c->buf, g_last_hdr.size);
    if (c->role == FUNC_VICTIM) {
        g_collect_bytes = (long)n;
        g_collect_done_ms = ms();
        printf("[reader ] finished collecting VICTIM body: %zd bytes at +%lums\n",
               n, (unsigned long)g_collect_done_ms);
    }
    return (int)n;
}

static void bind_cbs(Ctx* c, OutOfOrder_Execution_Engine* e) {
    c->engine = e;
    c->do_issue.bind(nullptr, &do_issue);
    c->do_completion.bind(nullptr, &do_completion);
    c->do_collect.bind(nullptr, &do_collect);
}

static void reader_thread(OutOfOrder_Execution_Engine* e) {
    Ctx* c = new Ctx;
    bind_cbs(c, e);
    c->role = FUNC_READER;
    c->timeout = Timeout(10UL * 1000 * 1000);
    c->buf = (char*)malloc(BODY_SIZE);
    ooo_issue_operation(*c);
    printf("[reader ] issued request (tag=%lu), became the sole reader\n", (unsigned long)c->tag);
    ooo_wait_completion(*c);
}

static void victim_thread(OutOfOrder_Execution_Engine* e) {
    Ctx* c = new Ctx;
    g_cv = c;
    bind_cbs(c, e);
    c->role = FUNC_VICTIM;
    c->timeout = Timeout(VICTIM_TIMEOUT_US);
    c->buf = (char*)malloc(BODY_SIZE);
    ooo_issue_operation(*c);
    printf("[victim ] issued request (tag=%lu), waiting with %lums deadline\n",
           (unsigned long)c->tag, (unsigned long)(VICTIM_TIMEOUT_US / 1000));
    errno = 0;
    int ret = ooo_wait_completion(*c);
    g_victim_errno = errno;
    g_victim_ret = ret;
    g_victim_return_ms = ms();
    printf("[victim ] wait_completion returned ret=%d errno=%d at +%lums\n",
           ret, g_victim_errno, (unsigned long)g_victim_return_ms);
    // Simulate real RPC stub: free resources immediately on timeout.
    // If engine is buggy, reader is still writing into buf — ASAN catches it.
    if (ret < 0) {
        free(c->buf);
        c->buf = nullptr;
        delete c;
        g_cv = nullptr;
    } else {
        thread_sleep(5);
    }
}

int main() {
    if (photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE)) return -1;
    DEFER(photon::fini());

    auto server = net::new_tcp_socket_server();
    if (!server) return -1;
    DEFER(delete server);
    if (server->bind_v4any(PORT) < 0 || server->listen() < 0) { printf("bind/listen failed\n"); return -1; }
    printf("[server] listening on 127.0.0.1:%u\n", PORT);
    thread_create11(server_main, server);
    thread_usleep(200 * 1000);

    auto client = net::new_tcp_socket_client();
    if (!client) return -1;
    DEFER(delete client);
    g_stream = client->connect(net::EndPoint("127.0.0.1", PORT));
    if (!g_stream) { printf("[client] connect failed\n"); return 2; }
    DEFER(delete g_stream);

    auto engine = new_ooo_execution_engine();
    g_start = now;

    thread_create11(reader_thread, engine);
    thread_usleep(150 * 1000);
    thread_create11(victim_thread, engine);

    thread_usleep(1600 * 1000);

    bool bug = (g_victim_ret < 0) && (g_collect_bytes == (long)BODY_SIZE);
    bool filled = g_cv && g_cv->buf && (unsigned char)g_cv->buf[BODY_SIZE - 1] == 0xCD;

    printf("\n==================== Result ====================\n");
    printf("victim wait_completion : ret=%d errno=%d at +%lums\n",
           g_victim_ret, g_victim_errno, (unsigned long)g_victim_return_ms);
    printf("reader collect (victim): %ld bytes, finished at +%lums\n",
           g_collect_bytes, (unsigned long)g_collect_done_ms);
    printf("victim context phase   : %d (COLLECTED), buffer filled=%d\n",
           g_cv ? (int)g_cv->phase : -1, (int)filled);
    printf("------------------------------------------------\n");
    if (bug) {
        printf("BUG CONFIRMED — use-after-free race exists:\n");
        printf("  * owner (victim) was told ETIMEDOUT at +%lums;\n", (unsigned long)g_victim_return_ms);
        printf("  * the sole reader continued writing %u bytes body into victim's buffer at +%lums\n",
               BODY_SIZE, (unsigned long)g_collect_done_ms);
        printf("    and marked the context COLLECTED — after the owner gave up.\n");
        printf("  In a real RPC stub, owner's OooArgs + buffer are freed at +%lums,\n",
               (unsigned long)g_victim_return_ms);
        printf("  so those writes land on freed memory => use-after-free.\n");
    } else if (g_victim_ret == (int)BODY_SIZE) {
        printf("NO BUG (fixed): owner waited for the in-progress collect.\n");
        printf("  wait_completion returned successfully at +%lums (%d bytes),\n",
               (unsigned long)g_victim_return_ms, g_victim_ret);
        printf("  after the collect completed. Nothing was destroyed while\n");
        printf("  the reader was still writing.\n");
    } else {
        printf("INCONCLUSIVE — timing didn't match expectations; try increasing sleep times.\n");
    }
    printf("================================================\n");
    fflush(stdout);
    _exit(bug ? 1 : 0);
}
```

</details>
