### PR TITLE
fix(estring): correct tolower_fast8 upper bound from 'X' to 'Z' (#1615)

### DIFF
--- a/common/estring.cpp
+++ b/common/estring.cpp
@@ -180,7 +180,7 @@ inline uint64_t check_cases(uint64_t x, char a, char z) {
 }
 
 inline uint64_t tolower_fast8(uint64_t x) {
-    uint64_t is_upper = check_cases(x, 'A', 'X');
+    uint64_t is_upper = check_cases(x, 'A', 'Z');
     return x | (is_upper >> 2);
 }
 

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -1513,6 +1513,16 @@ TEST(tolowerupper, basic) {
     EXPECT_GT(stricmp_fast("xxxxxxxxxxxjkl;", "xxxxxxxxxxxJKL:"), 0);
     EXPECT_LT(stricmp_fast("xxxxxxxxxxxaccc", "xxxxxxxxxxxBBBB"), 0);
 
+    // regression for SIMD path (len >= 8) mishandling 'Y'/'Z', see issue #1615
+    EXPECT_EQ(stricmp_fast("ABCDEFGY", "abcdefgy"), 0);
+    EXPECT_EQ(stricmp_fast("ABCDEFGZ", "abcdefgz"), 0);
+    EXPECT_EQ(stricmp_fast("RESPONSE-CONTENT-TYPE", "response-content-type"), 0);
+    char buf[9];
+    tolower_fast(buf, "ABCDEFGZ", 8);
+    EXPECT_EQ(std::string_view(buf), "abcdefgz");
+    toupper_fast(buf, "abcdefgz", 8);
+    EXPECT_EQ(std::string_view(buf), "ABCDEFGZ");
+
     auto sign = [](int x) { return (x > 0) ? 1 :
                                    (x < 0 ? -1 : 0);
     };


### PR DESCRIPTION
## Problem

In `common/estring.cpp`, the SIMD helper `tolower_fast8` called `check_cases(x, 'A', 'X')` with the wrong upper bound. `'X'` is `0x58`, so the uppercase mask excluded `'Y'` (`0x59`) and `'Z'` (`0x5A`). Those two bytes were left unchanged by the `len >= 8` (8-byte) code path.

This affected every case-insensitive helper that dispatches into the SIMD branch:
- `photon::stricmp_fast`, and therefore `estring_view::icmp` / `istarts_with` / `iends_with`
- `photon::tolower_fast(char*, const char*, size_t)`

Single-character `Y`/`y` passed because inputs shorter than 8 bytes go through the scalar `tolower_fast(char)` path; only the SIMD branch exhibited the bug. The sibling `toupper_fast8` already used correct bounds (`'a'`, `'z'`), which hid the typo under symmetry review.

Downstream this surfaced as HTTP `Content-Type` header-key comparisons losing case-insensitivity, and OSS `response-content-type` query overrides being silently missed for uppercased forms.

## Solution

One-character fix: `check_cases(x, 'A', 'X')` → `check_cases(x, 'A', 'Z')`.

## Test

Added regression coverage to `tolowerupper.basic` in `common/test/test.cpp` exercising the SIMD path with `'Y'`/`'Z'` (`stricmp_fast`, `tolower_fast`, `toupper_fast`, including `RESPONSE-CONTENT-TYPE`). Verified the new assertions fail before the fix and pass after; the full `tolowerupper.*` suite passes.

Fixes #1615
