### PR TITLE
[Backport][main to 0.9] | fix(estring): correct tolower_fast8 upper bound from 'X' to 'Z' (#1616)

### DIFF
--- a/common/estring.cpp
+++ b/common/estring.cpp
@@ -171,7 +171,7 @@ inline uint64_t check_cases(uint64_t x, char a, char z) {
 }
 
 inline uint64_t tolower_fast8(uint64_t x) {
-    uint64_t is_upper = check_cases(x, 'A', 'X');
+    uint64_t is_upper = check_cases(x, 'A', 'Z');
     return x | (is_upper >> 2);
 }
 

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -1464,6 +1464,16 @@ TEST(tolowerupper, basic) {
     EXPECT_GT(stricmp_fast("xxxxxxxxxxxjkl;", "xxxxxxxxxxxJKL:"), 0);
     EXPECT_LT(stricmp_fast("xxxxxxxxxxxaccc", "xxxxxxxxxxxBBBB"), 0);
 
+    // regression for SIMD path (len >= 8) mishandling 'Y'/'Z', see issue #1615
+    EXPECT_EQ(stricmp_fast("ABCDEFGY", "abcdefgy"), 0);
+    EXPECT_EQ(stricmp_fast("ABCDEFGZ", "abcdefgz"), 0);
+    EXPECT_EQ(stricmp_fast("RESPONSE-CONTENT-TYPE", "response-content-type"), 0);
+    char buf[9];
+    tolower_fast(buf, "ABCDEFGZ", 8);
+    EXPECT_EQ(std::string_view(buf), "abcdefgz");
+    toupper_fast(buf, "abcdefgz", 8);
+    EXPECT_EQ(std::string_view(buf), "ABCDEFGZ");
+
     auto sign = [](int x) { return (x > 0) ? 1 :
                                    (x < 0 ? -1 : 0);
     };


### PR DESCRIPTION
> fix(estring): correct tolower_fast8 upper bound from 'X' to 'Z' (#1616)

check_cases(x, 'A', 'X') excluded 'Y' (0x59) and 'Z' (0x5A) from the
uppercase mask, so the SIMD path of tolower_fast8 left those two bytes
unchanged. Every case-insensitive helper that dispatches into the 8-byte
branch (len >= 8) was affected: stricmp_fast, estring_view::icmp /
istarts_with / iends_with, and tolower_fast(char*, const char*, size_t).

Downstream effect: comparisons like "RESPONSE-CONTENT-TYPE" vs
"response-content-type" returned non-zero, silently losing
case-insensitivity for HTTP header keys and query parameters containing
'Y' or 'Z'. The sibling toupper_fast8 already used the correct bounds
('a', 'z'), which hid the typo under symmetry review.

Add regression coverage in tolowerupper.basic for the SIMD path.

Fixes #1615
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.