### PR TITLE
[Backport][0.9 to 0.8] | fix(estring): correct tolower_fast8 upper bound from 'X' to 'Z' (#1616) (#1618)

### DIFF
--- a/common/estring.cpp
+++ b/common/estring.cpp
@@ -157,4 +157,87 @@ static_assert(
 static_assert(
     std::is_same<estring&, decltype(std::declval<estring>() += std::declval<std::string_view>())>::value,
     "estring += std::string_view should return estring"
+<<<<<<< HEAD
 );
+=======
+);
+
+namespace photon {
+
+inline uint64_t check_cases(uint64_t x, char a, char z) {
+    uint64_t all_bytes = 0x0101010101010101;
+    uint64_t heptets = x & (0x7f * all_bytes);
+    uint64_t is_ascii = ~x & (0x80 * all_bytes);
+    uint64_t is_gt_Z = heptets + (0x7f - z) * all_bytes;
+    uint64_t is_ge_A = heptets + (0x80 - a) * all_bytes;
+    return (is_ge_A ^ is_gt_Z) & is_ascii;
+}
+
+inline uint64_t tolower_fast8(uint64_t x) {
+    uint64_t is_upper = check_cases(x, 'A', 'Z');
+    return x | (is_upper >> 2);
+}
+
+inline uint64_t toupper_fast8(uint64_t x) {
+    uint64_t is_lower = check_cases(x, 'a', 'z');
+    return x ^ (is_lower >> 2);
+}
+
+template<typename F1, typename F8> inline
+void convert_case(char* out, const char* in, size_t len, F1 f1, F8 f8) {
+    if (unlikely(len == 0))
+        len = strlen(in);
+    if (unlikely(len < 8)) {
+        for (size_t i = 0; i < len; i++)
+            out[i] = f1(in[i]);
+    } else {
+        for (size_t i = 0; i < len/8*8; i+=8)
+            *(uint64_t*)&out[i] = f8(*(uint64_t*)&in[i]);
+        *(uint64_t*)&out[len-8] = f8(*(uint64_t*)&in[len-8]);
+    }
+    out[len] = '\0';
+}
+
+void tolower_fast(char* out, const char* in, size_t len) {
+    convert_case(out, in, len,
+        [](char x)     { return tolower_fast(x); },
+        [](uint64_t x) { return tolower_fast8(x); });
+}
+
+void toupper_fast(char* out, const char* in, size_t len) {
+    convert_case(out, in, len,
+        [](char x)     { return toupper_fast(x); },
+        [](uint64_t x) { return toupper_fast8(x); });
+}
+
+inline uint64_t icmp8(const char* a, const char* b) {
+    auto ca = tolower_fast8(*(uint64_t*)a);
+    auto cb = tolower_fast8(*(uint64_t*)b);
+    return __builtin_bswap64(ca) - __builtin_bswap64(cb);
+}
+inline int spaceship(uint64_t x) {
+    uint32_t high = x >> 32, low = x & 0xffffffff;
+    return int(high | (low >> 1) | (low & 1));
+}
+int stricmp_fast(std::string_view a, std::string_view b) {
+    size_t i = 0, len = std::min(a.size(), b.size());
+    if (unlikely(len < 8)) {
+        for (; i < len; i++) {
+            auto ca = tolower_fast(a[i]);
+            auto cb = tolower_fast(b[i]);
+            if (auto x = ca - cb)
+                return x;
+        }
+        return spaceship(a.size() - b.size());
+    }
+    for (; i < len/8*8; i+=8)
+        if (auto x = icmp8(&a[i], &b[i]))
+            return spaceship(x);
+    if (likely(i < len)) // len >= 8
+        if (auto x = icmp8(&a[len-8], &b[len-8]))
+            return spaceship(x);
+    return spaceship(a.size() - b.size());
+}
+
+}
+>>>>>>> 730b0c1 (fix(estring): correct tolower_fast8 upper bound from 'X' to 'Z' (#1616) (#1618))

--- a/common/test/test.cpp
+++ b/common/test/test.cpp
@@ -1289,6 +1289,62 @@ TEST(PooledAllocator, allocFailed) {
     EXPECT_EQ(nullptr, p2);
 }
 
+<<<<<<< HEAD
+=======
+TEST(tolowerupper, basic) {
+    EXPECT_EQ(tolower_fast('A'), 'a');
+    EXPECT_EQ(tolower_fast('3'), '3');
+    EXPECT_EQ(tolower_fast('Z'), 'z');
+    EXPECT_EQ(toupper_fast('a'), 'A');
+    EXPECT_EQ(toupper_fast('3'), '3');
+    EXPECT_EQ(toupper_fast('z'), 'Z');
+
+    EXPECT_LT(stricmp_fast("abCd", "ABcD2"), 0);
+    EXPECT_LT(stricmp_fast("abCd1", "ABcD2"), 0);
+    EXPECT_EQ(stricmp_fast("abC1dEf2%^&", "ABc1DeF2%^&"), 0);
+    EXPECT_GT(stricmp_fast("xxxxxxxxxxxjkl;", "xxxxxxxxxxxJKL:"), 0);
+    EXPECT_LT(stricmp_fast("xxxxxxxxxxxaccc", "xxxxxxxxxxxBBBB"), 0);
+
+    // regression for SIMD path (len >= 8) mishandling 'Y'/'Z', see issue #1615
+    EXPECT_EQ(stricmp_fast("ABCDEFGY", "abcdefgy"), 0);
+    EXPECT_EQ(stricmp_fast("ABCDEFGZ", "abcdefgz"), 0);
+    EXPECT_EQ(stricmp_fast("RESPONSE-CONTENT-TYPE", "response-content-type"), 0);
+    char buf[9];
+    tolower_fast(buf, "ABCDEFGZ", 8);
+    EXPECT_EQ(std::string_view(buf), "abcdefgz");
+    toupper_fast(buf, "abcdefgz", 8);
+    EXPECT_EQ(std::string_view(buf), "ABCDEFGZ");
+
+    auto sign = [](int x) { return (x > 0) ? 1 :
+                                   (x < 0 ? -1 : 0);
+    };
+    const char* headers[] = {"Host", "Content-Length", "Range", "User-Agent", "Connection"};
+    for (auto h1: headers)
+        for (auto h2: headers) {
+            if (sign(stricmp_fast(h1, h2)) != sign(strcasecmp(h1, h2))) {
+                LOG_DEBUG(VALUE(h1), VALUE(h2));
+                EXPECT_EQ(sign(stricmp_fast(h1, h2)), sign(strcasecmp(h1, h2)));
+            }
+    }
+}
+
+const static char S1[]="ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+                  S2[]="abcdefghijklmnopqrstuvwxyz";
+TEST(tolowerupper, perf_strncasecmp) {
+    for (int i = 10000000; i; --i) {
+        auto ret = strncasecmp(S1, S2, LEN(S1) - 1);
+        asm volatile(""::"r"(ret));
+    }
+}
+
+TEST(tolowerupper, perf_photon_stricmp) {
+    for (int i = 10000000; i; --i) {
+        auto ret = stricmp_fast(S1, S2);
+        asm volatile(""::"r"(ret));
+    }
+}
+
+>>>>>>> 730b0c1 (fix(estring): correct tolower_fast8 upper bound from 'X' to 'Z' (#1616) (#1618))
 TEST(update_now, after_idle_sleep) {
     thread_yield();  // update now
     auto before = photon::now;


### PR DESCRIPTION
> fix(estring): correct tolower_fast8 upper bound from 'X' to 'Z' (#1616) (#1618)

check_cases(x, 'A', 'X') excluded 'Y' (0x59) and 'Z' (0x5A) from the
uppercase mask, so the SIMD path of tolower_fast8 left those two bytes
unchanged. Every case-insensitive helper that dispatches into the 8-byte
branch (len >= 8) was affected: stricmp_fast, estring_view::icmp /
istarts_with / iends_with, and tolower_fast(char*, const char*, size_t).

Downstream effect: comparisons like "RESPONSE-CONTENT-TYPE" vs
"response-content-type" returned non-zero, silently losing
case-insensitivity for HTTP header keys and query parameters containing
'Y' or 'Z'. The sibling toupper_fast8 already used the correct bounds
('a', 'z'), which hid the typo under symmetry review.

Add regression coverage in tolowerupper.basic for the SIMD path.

Fixes #1615

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- 730b0c1d57848a3bb73d6acdc01614eab699113a: common/estring.cpp,common/test/test.cpp