### PR TITLE
[Backport][0.7 to 0.6] | | fix(net,io): don't confuse a 0-length iovec element or an error with EOF (#1602) (#1603) (#1604) (#1607)

### DIFF
--- a/io/aio-wrapper.cpp
+++ b/io/aio-wrapper.cpp
@@ -319,8 +319,10 @@ retry:
         for (auto& x: ptr_array(iov, iovcnt))
         {
             ssize_t ret = posixaio_pread(fd, x.iov_base, x.iov_len, offset + rst);
-            if (ret < 0)
-                LOG_ERRNO_RETURN(-1, 0, "failed to posixaio_preadv");
+            if (ret < 0) {
+                if (rst > 0) break;     // report the partial read, instead of the error
+                LOG_ERRNO_RETURN(0, -1, "failed to posixaio_preadv");
+            }
             if (ret < (ssize_t)x.iov_len)
                 return rst + ret;
             rst += ret;
@@ -333,8 +335,10 @@ retry:
         for (auto& x: ptr_array(iov, iovcnt))
         {
             ssize_t ret = posixaio_pwrite(fd, x.iov_base, x.iov_len, offset + rst);
-            if (ret < 0)
-                LOG_ERRNO_RETURN(-1, 0, "failed to posixaio_pwrite()");
+            if (ret < 0) {
+                if (rst > 0) break;     // report the partial write, instead of the error
+                LOG_ERRNO_RETURN(0, -1, "failed to posixaio_pwrite()");
+            }
             if (ret < (ssize_t)x.iov_len)
                 return rst + ret;
             rst += ret;

--- a/net/basic_socket.h
+++ b/net/basic_socket.h
@@ -120,9 +120,20 @@ __FORCE_INLINE__ ssize_t doio_n(void *&buf, size_t &count, IOCB iocb) {
     return n;
 }
 
+// a 0-length element would make the iocb of doiov_n() transfer 0 byte and
+// return 0, which is indistinguishable from EOF, so such elements are skipped.
+// Before the first iocb, at least one element is kept, so that iocbs relying on
+// iov[0] always have a valid one; after that the view is allowed to become
+// empty, which simply ends the loop.
+__FORCE_INLINE__ void skip_empty_iov(iovector_view &v, int keep) {
+    while (v.iovcnt > keep && v.front().iov_len == 0)
+        v.pop_front();
+}
+
 template <typename IOCB>
 __FORCE_INLINE__ ssize_t doiov_n(iovector_view &v, IOCB iocb) {
     ssize_t count = 0;
+    skip_empty_iov(v, 1);
     while (v.iovcnt > 0) {
         ssize_t ret = iocb();
         if (ret < 0) return ret;
@@ -133,6 +144,7 @@ __FORCE_INLINE__ ssize_t doiov_n(iovector_view &v, IOCB iocb) {
         auto extracted = v.extract_front(bytes);
         assert(extracted == bytes);
         _unused(extracted);
+        skip_empty_iov(v, 0);
     }
     return count;
 }

--- a/net/kernel_socket.cpp
+++ b/net/kernel_socket.cpp
@@ -478,6 +478,10 @@ protected:
     }
 
     ssize_t do_sendmsg(int sockfd, const struct msghdr* message, int flags, uint64_t timeout) override {
+        // a 0-byte zerocopy send is not acknowledged by the kernel, and
+        // zerocopy_confirm() below would wait for its notification in vain
+        if (iovector_view(message->msg_iov, (int)message->msg_iovlen).sum() == 0)
+            return 0;
         ssize_t n = photon::net::sendmsg(sockfd, message, flags | ZEROCOPY_FLAG, timeout);
         if (n < 0)
             return n;

--- a/net/security-context/sasl-stream.cpp
+++ b/net/security-context/sasl-stream.cpp
@@ -171,9 +171,11 @@ class SaslSocketStream : public ForwardSocketStream {
     ssize_t writev(const struct iovec *iov, int iovcnt) override {
         ssize_t count = 0;
         for (auto v : iovector_view((iovec *)iov, iovcnt)) {
+            if (v.iov_len == 0) continue;   // a 0-length write returns 0, which looks like EOF
             auto ret = write(v.iov_base, v.iov_len);
-            if (ret <= 0) return ret;
+            if (ret <= 0) return count > 0 ? count : ret;
             count += ret;
+            if (ret < (ssize_t)v.iov_len) break;    // EOF in the middle
         }
         return count;
     }
@@ -185,9 +187,11 @@ class SaslSocketStream : public ForwardSocketStream {
     ssize_t readv(const struct iovec *iov, int iovcnt) override {
         ssize_t count = 0;
         for (auto v : iovector_view((iovec *)iov, iovcnt)) {
+            if (v.iov_len == 0) continue;   // a 0-length read returns 0, which looks like EOF
             auto ret = read(v.iov_base, v.iov_len);
-            if (ret <= 0) return ret;
+            if (ret <= 0) return count > 0 ? count : ret;
             count += ret;
+            if (ret < (ssize_t)v.iov_len) break;    // EOF in the middle
         }
         return count;
     }

--- a/net/test/test.cpp
+++ b/net/test/test.cpp
@@ -774,6 +774,85 @@ TEST(ZeroCopySocket, basic) {
 }
 #endif
 
+// a 0-length element in iov[] must not be mistaken for EOF, otherwise writev()
+// would transfer less bytes than requested, and silently so
+template <typename Wrap>
+static void test_writev_empty_iov(ISocketServer* server, ISocketClient* client, const Wrap& wrap) {
+    static char a[100], b[50];
+    const std::vector<std::pair<const char*, std::vector<iovec>>> cases = {
+        {"none", {{a, 100}, {b, 50}}},
+        {"head", {{a, 0}, {a, 100}, {b, 50}}},
+        {"mid",  {{a, 100}, {a, 0}, {b, 50}}},
+        {"tail", {{a, 100}, {b, 50}, {a, 0}}},
+        {"all",  {{a, 0}, {b, 0}}},
+    };
+
+    size_t received = 0;
+    photon::semaphore done(0);
+    auto handler = [&](ISocketStream* stream) -> int {
+        auto s = wrap(stream, SecurityRole::Server);
+        DEFER(if (s != stream) delete s);
+        char buf[4096];
+        ssize_t n;
+        while ((n = s->recv(buf, sizeof(buf))) > 0) received += n;
+        done.signal(1);
+        return 0;
+    };
+    server->set_handler(handler);
+    ASSERT_EQ(0, server->bind(0, net::IPAddr("127.0.0.1")));
+    ASSERT_EQ(0, server->listen());
+    ASSERT_EQ(0, server->start_loop());
+    auto ep = server->getsockname();
+
+    for (auto& c : cases) {
+        auto& iov = c.second;
+        size_t sum = iovector_view((iovec*) iov.data(), (int) iov.size()).sum();
+        received = 0;
+        auto conn = client->connect(ep);
+        ASSERT_NE(nullptr, conn);
+        conn->timeout(5UL * 1000 * 1000);   // fail instead of hanging forever
+        auto s = wrap(conn, SecurityRole::Client);
+        EXPECT_EQ((ssize_t) sum, s->writev(iov.data(), (int) iov.size())) << c.first;
+        if (s != conn) delete s;
+        delete conn;
+        ASSERT_EQ(0, done.wait(1, 10UL * 1000 * 1000));
+        EXPECT_EQ(sum, received) << c.first;
+    }
+}
+
+static ISocketStream* no_wrap(ISocketStream* s, SecurityRole) { return s; }
+
+TEST(writev, empty_iov) {
+    auto server = new_tcp_socket_server();
+    DEFER(delete server);
+    auto client = new_tcp_socket_client();
+    DEFER(delete client);
+    test_writev_empty_iov(server, client, no_wrap);
+}
+
+TEST(writev, empty_iov_tls) {
+    auto ctx = new_tls_context(cert_str, key_str, passphrase_str);
+    DEFER(delete ctx);
+    auto server = new_tcp_socket_server();
+    DEFER(delete server);
+    auto client = new_tcp_socket_client();
+    DEFER(delete client);
+    test_writev_empty_iov(server, client, [&](ISocketStream* s, SecurityRole role) {
+        return new_tls_stream(ctx, s, role, false);
+    });
+}
+
+#ifdef __linux__
+TEST(writev, empty_iov_zerocopy) {
+    if (!zerocopy_available()) return;
+    auto server = new_tcp_socket_server();
+    DEFER(delete server);
+    auto client = new_zerocopy_tcp_client();
+    DEFER(delete client);
+    test_writev_empty_iov(server, client, no_wrap);
+}
+#endif
+
 int main(int argc, char** arg) {
     if (photon::init(photon::INIT_EVENT_DEFAULT, photon::INIT_IO_NONE))
         return -1;


### PR DESCRIPTION
> [Backport][0.8 to 0.7] | fix(net,io): don't confuse a 0-length iovec element or an error with EOF (#1602) (#1603) (#1604) (#1607)

* fix(net,io): don't confuse a 0-length iovec element or an error with EOF (#1602) (#1603) (#1604)

* fix(net): don't mistake 0-length iovec elements for EOF in writev()

BufStepV drove doio_loop() by `iovcnt > 0` instead of the number of
remaining bytes, and iovector_view::extract_front(0) pops nothing, so a
0-length element could stay at the head of the view and make the next
iocb transfer 0 byte. doio_loop() takes a return of 0 for EOF, hence:

- TLS streams silently truncated writev()/readv(): send(iov, iovcnt)
  only serves iov[0], so a 0-length head returned 0 right away. Of a
  100+0+50 bytes writev() only 100 bytes got transferred, and only 0
  when the empty element came first, with no error and errno intact.
- ZeroCopy streams hung: the extra 0-byte sendmsg(MSG_ZEROCOPY) bumped
  m_num_calls, but no completion notification ever arrives for it, so
  zerocopy_confirm() waited forever, or until the stream timeout.
- SASL streams returned 0 and discarded the bytes already transferred,
  as a 0-length segment made write() return 0, and `ret <= 0` dropped
  the accumulated `count`.

Make BufStepV skip 0-length elements, so that the iocb is never invoked
with a 0-byte request. This covers all ten BufStepV users, and also
drops the useless 0-byte sendmsg on plain TCP sockets. Before the first
iocb one element is kept, as iocbs serving only iov[0] need a valid one.

Also guard ZeroCopySocketStream::do_sendmsg() against 0-byte messages,
which BufStepV cannot reach when send(iov, iovcnt) is called directly,
and fix SASL writev()/readv() separately, as they don't use BufStepV.

Plain TCP sockets were not affected: sendmsg() returns 0 only once the
whole remaining array sums to 0, at which point the accumulated count
already equals the requested total.

Add writev.empty_iov{,_tls,_zerocopy}, covering a 0-length element at
the head, in the middle and at the tail, plus an all-empty array,
checking both the return value and the bytes seen by the peer.

Validated: the new tests fail without this fix (TLS 150 -> 100 and
150 -> 0, ZeroCopy timing out) and pass with it; the socket, TLS, RPC
and HTTP suites are unaffected. The SASL change is not compile-tested
here, as gsasl is unavailable and ENABLE_SASL is off.

Fixes #1601.

* fix(io): report errors of posixaio preadv()/pwritev() instead of 0

posixaio::preadv() / pwritev() turned a failed pread/pwrite into a
return value of 0, which callers read as EOF or "nothing transferred"
rather than as an error. LOG_ERRNO_RETURN(-1, 0, ...) also overwrote
the errno set by the callee with the meaningless value -1, erasing the
last clue about what actually went wrong.

Return -1 when nothing has been transferred yet, and pass 0 as
new_errno so that the callee's errno survives. When part of the iov[]
array has already been transferred, return the accumulated count, as
preadv(2) and pwritev(2) do; this is also the idiom the preadv() /
pwritev() of windows_compat.cpp and iocp.cpp already follow.

The 0-length elements of iov[] are not affected: the loop advances on
`ret < iov_len`, which is the correct predicate, and lets a 0-length
element through. Found while auditing the iovec iteration paths for
the confusion between a 0-length element and a 0-byte I/O result.

Validated: test-syncio, which drives posixaio through do_test_aio,
plus test-fs, test-exportfs, test-socket and test-tls all pass.

Co-authored-by: Coldwings <coldwings@me.com>

* fix(net): resolve backport conflicts for the 0-length iovec fix

Re-express the fix in the idiom of 0.7, which predates the socket
refactoring that introduced doio_loop() and its step functors.

- net/basic_socket.h: keep doiov_n() and port the 0-length skipping into
  it, instead of importing BufStepV / DOIO_LOOP, which have no user on
  this branch and would have left doiov_n() unfixed. The keep=1 before
  the first iocb and keep=0 afterwards follow the upstream BufStepV, so
  all 8 doiov_n() call sites get the fix: readv()/writev() of
  KernelSocketStream and of TLS streams, readv_n(), zerocopy_n() and
  sendv_n().
- net/kernel_socket.cpp: guard 0-byte zerocopy sends, keeping the
  uint64_t timeout of this branch, as the Timeout class is not used here.
- net/test/test.cpp: bind(0, IPAddr("127.0.0.1")) instead of
  bind_v4localhost(), which ISocketServer does not have here; port 0
  keeps the ephemeral port. Drop the TEST(iostream, UDS) hunk that the
  cherry-pick carried along as context, as net/iostream.h and
  new_iostream() do not exist on this branch.

Validated: the whole socket suite passes, 24 tests, including the new
writev.empty_iov{,_tls,_zerocopy}; the TLS and ZeroCopy ones are the
cases that were broken, so they confirm the doiov_n() port behaves as
the upstream BufStepV.

Note: `cmake --build build --target test-socket` fails on this branch for
an unrelated pre-existing reason, as test/ci-tools.cpp uses cpu_set_t and
pthread_setaffinity_np without including <sched.h> / <pthread.h>, which
breaks on a modern glibc. That file is untouched here; test.cpp was
compiled and linked separately to validate.

---------

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.