### PR TITLE
fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream

### DIFF
--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -17,7 +17,7 @@ function(build_from_src dep)
         ExternalProject_Add(
                 aio
                 URL ${PHOTON_AIO_SOURCE}
-                URL_MD5 605237f35de238dfacc83bcae406d95d
+                URL_MD5 7d5be185f20eeaae15e267419950aaf7
                 UPDATE_DISCONNECTED ON
                 BUILD_IN_SOURCE ON
                 CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ photon_option(PHOTON_ENABLE_KCP          BOOL   OFF   "enable kcp")
 
 # Download locations for build-from-source (used when PHOTON_BUILD_DEPENDENCIES is ON).
 photon_option(PHOTON_BUILD_DEPENDENCIES  BOOL   OFF   "")
-photon_source(AIO_SOURCE        "https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz")
+photon_source(AIO_SOURCE        "https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz")
 photon_source(ZLIB_SOURCE       "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz")
 photon_source(OPENSSL_SOURCE    "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz")
 photon_source(CURL_SOURCE       "https://github.com/curl/curl/releases/download/curl-7_88_1/curl-7.88.1.tar.gz")

--- a/doc/docs/introduction/how-to-build.md
+++ b/doc/docs/introduction/how-to-build.md
@@ -186,7 +186,7 @@ cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 -D PHOTON_BUILD_TESTING=ON \
 -D PHOTON_BUILD_DEPENDENCIES=ON \
 -D PHOTON_ENABLE_URING=ON \
--D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_AIO_SOURCE=https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz \
 -D PHOTON_ZLIB_SOURCE=https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz \
 -D PHOTON_URING_SOURCE=https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz \
 -D PHOTON_CURL_SOURCE=https://github.com/curl/curl/releases/download/curl-7_88_1/curl-7.88.1.tar.gz \
@@ -201,7 +201,7 @@ cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 ```bash
 cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 -D PHOTON_BUILD_DEPENDENCIES=ON \
--D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_AIO_SOURCE=https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz \
 -D PHOTON_CURL_SOURCE="" \
 -D PHOTON_OPENSSL_SOURCE=""
 ```

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/introduction/how-to-build.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/introduction/how-to-build.md
@@ -190,7 +190,7 @@ cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 -D PHOTON_BUILD_TESTING=ON \
 -D PHOTON_BUILD_DEPENDENCIES=ON \
 -D PHOTON_ENABLE_URING=ON \
--D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_AIO_SOURCE=https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz \
 -D PHOTON_ZLIB_SOURCE=https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz \
 -D PHOTON_URING_SOURCE=https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz \
 -D PHOTON_CURL_SOURCE=https://github.com/curl/curl/releases/download/curl-7_88_1/curl-7.88.1.tar.gz \
@@ -207,7 +207,7 @@ cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 ```bash
 cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 -D PHOTON_BUILD_DEPENDENCIES=ON \
--D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_AIO_SOURCE=https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz \
 -D PHOTON_CURL_SOURCE="" \
 -D PHOTON_OPENSSL_SOURCE=""
 ```


### PR DESCRIPTION
## Summary

Migrate the build-from-source download location of `libaio` from the now-defunct `pagure.io` archive endpoint to the maintainer's upstream repository on Codeberg (`jmoyer/libaio`), using its static release asset.

## Changes

- `CMakeLists.txt`: change the default `PHOTON_AIO_SOURCE` to `https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz`.
- `CMake/build-from-src.cmake`: update the pinned `URL_MD5` from `605237f35de238dfacc83bcae406d95d` (old git-archive tarball) to `7d5be185f20eeaae15e267419950aaf7` (the release tarball).
- `doc/docs/introduction/how-to-build.md` and its Chinese i18n counterpart: update the example `PHOTON_AIO_SOURCE` URLs.

## Motivation

`pagure.io` code hosting was sunset in mid-2026, which broke the `.../archive/...` download path previously used to build libaio from source. Any build with `PHOTON_BUILD_DEPENDENCIES=ON` that relied on the default libaio source could no longer fetch the tarball.

libaio is not a Fedora-entity project, so it was **not** migrated to `forge.fedoraproject.org` (verified: the forge has no libaio repo). Its upstream git repository now lives on Codeberg at `jmoyer/libaio`, maintained by Jeff Moyer. That repository publishes a **static release asset** for `libaio-0.3.113`, which is preferred over a dynamically generated git-archive tarball because its checksum is stable and safe to pin via `URL_MD5`.

The release asset was verified to be byte-identical to the previous canonical release tarball (size 49980, `md5 7d5be185...`, and its `sha512 65c30a10...` matches the repo's published `.sha512sum`). It still extracts to `libaio-0.3.113/` with the same `Makefile`/`src/` layout, so the `ExternalProject_Add` build command needs no adjustment.

## References

- pagure.io sunset notice (Pagure archive): Fedora-entity repos moved to forge.fedoraproject.org; other projects moved to Codeberg / GitLab / GitHub.
- New source (maintainer's upstream, Codeberg): https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz
- Published checksum: https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz.sha512sum
