### PR TITLE
[Backport][main to 0.9] | feat(ecosystem): support path-style requests in OSS client (#1625)

### DIFF
--- a/ecosystem/oss.cpp
+++ b/ecosystem/oss.cpp
@@ -113,30 +113,34 @@ std::string_view lookup_mime_type(std::string_view name) {
 class OssUrl {
  public:
   estring m_url, m_raw_object;
-  uint64_t m_url_size;
   rstring_view16 m_bucket, m_object;
   OssUrl() = default;
   OssUrl(std::string_view endpoint, std::string_view bucket,
-         std::string_view object, bool is_http) {
+         std::string_view object, bool is_http, bool path_style) {
     assert(!bucket.empty());
-    init(endpoint, bucket, object, is_http);
+    init(endpoint, bucket, object, is_http, path_style);
   }
   void init(std::string_view endpoint, std::string_view bucket,
-            std::string_view object, bool is_http) {
+            std::string_view object, bool is_http, bool path_style) {
     bool has_slash = (object.size() > 0 && object[0] == '/');
     if (has_slash) object = object.substr(1);
 
     auto escaped_obj = photon::net::http::url_escape(object);
-    m_url.appends(photon::net::http::http_or_s(is_http), bucket, ".", endpoint,
-                  "/", escaped_obj);
+    auto scheme = photon::net::http::http_or_s(is_http);
+    if (path_style) {
+      m_url.appends(scheme, endpoint, "/", bucket, "/", escaped_obj);
+      m_bucket = {scheme.size() + endpoint.size() + 1, bucket.size()};
+      m_object = {m_bucket.offset() + bucket.size() + 1,
+                  escaped_obj.size()};  // start without prefix /
+    } else {
+      m_url.appends(scheme, bucket, ".", endpoint, "/", escaped_obj);
+      m_bucket = {scheme.size(), bucket.size()};
+      m_object = {m_bucket.offset() + bucket.size() + endpoint.size() + 1 + 1,
+                  escaped_obj.size()};  // start without prefix /
+    }
 
     auto escaped = escaped_obj.size() > object.size();
     if (escaped) m_raw_object = object;
-
-    m_url_size = m_url.size();
-    m_bucket = {(is_http ? 7ull : 8ull), bucket.size()};
-    m_object = {m_bucket.offset() + bucket.size() + endpoint.size() + 1 + 1,
-                escaped_obj.size()};  // start without prefix /
   }
   estring_view bucket() const { return m_url | m_bucket; }
   estring_view object(bool url_escaped = false) const {
@@ -401,6 +405,12 @@ class OssClientImpl : public Client {
   void set_credentials(CredentialParameters&& credentials);
 
  private:
+  OssUrl make_oss_url(std::string_view object) {
+    return make_oss_url(object, m_bucket);
+  }
+  OssUrl make_oss_url(std::string_view object, std::string_view bucket) {
+    return {m_endpoint, bucket, object, m_is_http, m_oss_options.path_style};
+  }
   int append_auth_headers(photon::net::http::Verb v, const OssUrl& oss_url,
                           photon::net::http::Headers& headers,
                           const StringKV& query_params = {},
@@ -587,7 +597,7 @@ int OssClient::do_list_objects_v2(std::string_view bucket, std::string_view pref
     query_params.insert({OSS_PARAM_KEY_CONTINUATION_TOKEN, escaped_marker});
   if (!start_after.empty())
     query_params.insert({OSS_PARAM_KEY_START_AFTER, escaped_start_after});
-  OssUrl oss_url(m_endpoint, bucket, {}, m_is_http);
+  auto oss_url = make_oss_url({}, bucket);
   DEFINE_ONSTACK_OP(m_client, Verb::GET, oss_url.append_params(query_params));
   int r = sign_and_call(op, Verb::GET, oss_url, query_params);
   if (r < 0) return r;
@@ -629,7 +639,7 @@ int OssClient::do_list_objects_v1(std::string_view bucket,
   if (!_mark.empty())
     query_params.insert({OSS_PARAM_KEY_MARKER, escaped_marker});
 
-  OssUrl oss_url(m_endpoint, bucket, {}, m_is_http);
+  auto oss_url = make_oss_url({}, bucket);
   DEFINE_ONSTACK_OP(m_client, Verb::GET, oss_url.append_params(query_params));
   int r = sign_and_call(op, Verb::GET, oss_url, query_params);
   if (r < 0) return r;
@@ -727,7 +737,7 @@ int OssClient::do_delete_objects(estring_view bucket, estring_view prefix,
                          {(void*)req_list.data(), req_list.size()},
                          {(void*)req_tail.data(), req_tail.size()}};
   iovector_view body_view(iov, 3);
-  OssUrl oss_url(m_endpoint, bucket, "/", m_is_http);
+  auto oss_url = make_oss_url("/", bucket);
   auto md5 = md5_base64(body_view);
 
   DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
@@ -773,8 +783,8 @@ retry:
 
 int OssClient::rename_object(std::string_view src_path,
                              std::string_view dst_path, bool set_mime) {
-  OssUrl src_oss_url(m_endpoint, m_bucket, src_path, m_is_http);
-  OssUrl dst_oss_url(m_endpoint, m_bucket, dst_path, m_is_http);
+  auto src_oss_url = make_oss_url(src_path);
+  auto dst_oss_url = make_oss_url(dst_path);
 
   ObjectCopyOptions opts;
   opts.overwrite = true;
@@ -788,7 +798,7 @@ int OssClient::put_symlink(std::string_view obj, std::string_view target) {
                                         {
                                             {OSS_PARAM_KEY_SYMLINK, ""},
                                         });
-  OssUrl oss_url(m_endpoint, m_bucket, obj, m_is_http);
+  auto oss_url = make_oss_url(obj);
   DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.append_params(query_params));
   auto escaped_tgt = photon::net::http::url_escape(target);
   op.req.headers.insert(OSS_HEADER_KEY_X_OSS_SYMLINK_TARGET, escaped_tgt);
@@ -800,7 +810,7 @@ int OssClient::get_symlink(std::string_view obj, std::string& target) {
                                         {
                                             {OSS_PARAM_KEY_SYMLINK, ""},
                                         });
-  OssUrl oss_url(m_endpoint, m_bucket, obj, m_is_http);
+  auto oss_url = make_oss_url(obj);
   DEFINE_ONSTACK_OP(m_client, Verb::GET, oss_url.append_params(query_params));
   int r = sign_and_call(op, Verb::GET, oss_url, query_params);
   if (r < 0) return r;
@@ -810,7 +820,7 @@ int OssClient::get_symlink(std::string_view obj, std::string& target) {
 }
 
 int OssClient::put_bucket(std::string_view agent_bucket) {
-  OssUrl oss_url(m_endpoint, m_bucket, {}, m_is_http);
+  auto oss_url = make_oss_url({});
   DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.url());
   if (!agent_bucket.empty())
     op.req.headers.insert(OSS_HEADER_KEY_X_OSS_AGENTIC_BUCKET, agent_bucket);
@@ -818,7 +828,7 @@ int OssClient::put_bucket(std::string_view agent_bucket) {
 }
 
 int OssClient::delete_bucket() {
-  OssUrl oss_url(m_endpoint, m_bucket, {}, m_is_http);
+  auto oss_url = make_oss_url({});
   DEFINE_ONSTACK_OP(m_client, Verb::DELETE, oss_url.url());
   return sign_and_call(op, Verb::DELETE, oss_url);
 }
@@ -859,7 +869,7 @@ int OssClient::list_objects(std::string_view prefix, ListObjectsCallback cb,
 }
 
 int OssClient::head_object(std::string_view object, ObjectHeaderMeta& meta) {
-  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+  auto oss_url = make_oss_url(object);
   DEFINE_ONSTACK_OP(m_client, Verb::HEAD, oss_url.url());
   int r = sign_and_call(op, Verb::HEAD, oss_url);
   if (r < 0) return r;
@@ -931,7 +941,7 @@ ssize_t OssClient::get_object_range(std::string_view obj_path, off_t offset,
 
   bool invalidate_cache = false;
 retry:
-  OssUrl oss_url(m_endpoint, m_bucket, obj_path, m_is_http);
+  auto oss_url = make_oss_url(obj_path);
   DEFINE_ONSTACK_OP(m_client, Verb::GET, oss_url.url());
   op.req.headers.insert(OSS_HEADER_KEY_X_OSS_RANGE_BEHAVIOR, "standard");
   op.req.headers.range(offset, offset + cnt - 1);
@@ -1166,7 +1176,7 @@ int OssClient::batch_get_objects(std::vector<GetObjectParameters>& params) {
                          {(void*)req_tail.data(), req_tail.size()}};
   iovector_view body_view(iov, 3);
 
-  OssUrl oss_url(m_endpoint, m_bucket, "/", m_is_http);
+  auto oss_url = make_oss_url("/");
   auto md5 = md5_base64(body_view);
 
   DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
@@ -1278,7 +1288,7 @@ int OssClient::batch_get_objects(std::vector<GetObjectParameters>& params) {
 
 ssize_t OssClient::put_object(std::string_view object, size_t cnt,
                               BodyWriter writer, ObjectUploadOptions& opts) {
-  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+  auto oss_url = make_oss_url(object);
   auto content_type = lookup_mime_type(object);
 
   DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.url());
@@ -1308,7 +1318,7 @@ ssize_t OssClient::append_object(std::string_view object,
   iovector_view view((struct iovec*)iov, iovcnt);
   auto cnt = view.sum();
 
-  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+  auto oss_url = make_oss_url(object);
 
   estring position_str = std::to_string(position);
 
@@ -1335,8 +1345,8 @@ ssize_t OssClient::append_object(std::string_view object,
 int OssClient::copy_object(std::string_view src_object,
                            std::string_view dst_object,
                            ObjectCopyOptions& opts) {
-  OssUrl src_oss_url(m_endpoint, m_bucket, src_object, m_is_http);
-  OssUrl dst_oss_url(m_endpoint, m_bucket, dst_object, m_is_http);
+  auto src_oss_url = make_oss_url(src_object);
+  auto dst_oss_url = make_oss_url(dst_object);
 
   return do_copy_object(src_oss_url, dst_oss_url, opts);
 }
@@ -1349,7 +1359,7 @@ struct oss_multipart_context {
 };
 
 int OssClient::init_multipart_upload(std::string_view object, void** context) {
-  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+  auto oss_url = make_oss_url(object);
 
   DEFINE_CONST_STATIC_ORDERED_STRING_KV(query_params,
                                         {// must appear in dictionary order!
@@ -1393,7 +1403,7 @@ ssize_t OssClient::upload_part(void* context, size_t cnt,
                            {{OSS_PARAM_KEY_PART_NUMBER, part_nums_str},
                             {OSS_PARAM_KEY_UPLOAD_ID, ctx->upload_id}});
 
-  OssUrl oss_url(m_endpoint, m_bucket, ctx->obj_path, m_is_http);
+  auto oss_url = make_oss_url(ctx->obj_path);
 
   DEFINE_ONSTACK_OP(m_client, Verb::PUT, oss_url.append_params(query_params));
 
@@ -1428,7 +1438,7 @@ int OssClient::upload_part_copy(void* context, off_t offset, size_t count,
   oss_multipart_context* ctx = (oss_multipart_context*)context;
   assert(!ctx->upload_id.empty());
 
-  OssUrl oss_url(m_endpoint, m_bucket, ctx->obj_path, m_is_http);
+  auto oss_url = make_oss_url(ctx->obj_path);
 
   estring part_num_str = std::to_string(part_number);
 
@@ -1499,7 +1509,7 @@ int OssClient::complete_multipart_upload(void* context,
   struct iovec iov{(void*)(req_body.data()), req_body.size()};
 
   iovector_view view(&iov, 1);
-  OssUrl oss_url(m_endpoint, m_bucket, ctx->obj_path, m_is_http);
+  auto oss_url = make_oss_url(ctx->obj_path);
 
   DEFER(delete ctx);
 
@@ -1523,7 +1533,7 @@ int OssClient::abort_multipart_upload(void* context) {
   oss_multipart_context* ctx = (oss_multipart_context*)context;
   assert(!ctx->upload_id.empty());
 
-  OssUrl oss_url(m_endpoint, m_bucket, ctx->obj_path, m_is_http);
+  auto oss_url = make_oss_url(ctx->obj_path);
 
   DEFER(delete ctx);
 
@@ -1542,7 +1552,7 @@ int OssClient::get_object_meta(std::string_view object, ObjectMeta& meta) {
                                             // must appear in dictionary order!
                                             {OSS_PARAM_KEY_OBJECT_META, ""},
                                         });
-  OssUrl oss_url(m_endpoint, m_bucket, object, m_is_http);
+  auto oss_url = make_oss_url(object);
   DEFINE_ONSTACK_OP(m_client, Verb::HEAD, oss_url.append_params(query_params));
   int r = sign_and_call(op, Verb::HEAD, oss_url, query_params);
   if (r < 0) return r;
@@ -1550,7 +1560,7 @@ int OssClient::get_object_meta(std::string_view object, ObjectMeta& meta) {
 }
 
 int OssClient::delete_object(std::string_view obj_path) {
-  OssUrl oss_url(m_endpoint, m_bucket, obj_path, m_is_http);
+  auto oss_url = make_oss_url(obj_path);
   return do_delete_object(oss_url);
 }
 

--- a/ecosystem/oss.h
+++ b/ecosystem/oss.h
@@ -47,6 +47,9 @@ struct ClientOptions {
   int max_list_ret_cnt = 1000;
   std::string user_agent = "Photon-ObjStore-Client";
   std::string bind_ips;
+  // use path-style requests: http(s)://endpoint/bucket/object, instead of
+  // the virtual-hosted style http(s)://bucket.endpoint/object
+  bool path_style = false;
   uint64_t request_timeout_us = 60ull * 1000 * 1000;
   int retry_times = 2;
 

--- a/ecosystem/test/test_oss.cpp
+++ b/ecosystem/test/test_oss.cpp
@@ -25,6 +25,7 @@ DEFINE_string(sk, "", "OSS Access Key Secret");
 DEFINE_string(endpoint, "", "OSS Endpoint");
 DEFINE_string(bucket, "", "OSS Bucket Name");
 DEFINE_string(region, "", "OSS Region");
+DEFINE_bool(path_style, false, "Use path-style requests");
 
 using namespace photon::objstore;
 
@@ -47,6 +48,7 @@ class BasicAuthOssTest : public ::testing::Test {
     opts_.bucket = FLAGS_bucket;
     opts_.endpoint = FLAGS_endpoint;
     opts_.max_list_ret_cnt = 2;
+    opts_.path_style = FLAGS_path_style;
 
     // v4 signature with non-empty region, otherwise v1 signature.
     opts_.region = FLAGS_region;
@@ -166,6 +168,7 @@ void BasicAuthOssTest::bucket_operations() {
   opts.bucket = bucket_name;
   opts.endpoint = FLAGS_endpoint;
   opts.region = FLAGS_region;
+  opts.path_style = FLAGS_path_style;
   auto auth = new_basic_oss_authenticator({FLAGS_ak, FLAGS_sk, ""});
   Client* bclient = new_oss_client(opts, auth);
   ASSERT_NE(bclient, nullptr);

--- a/ecosystem/test/test_oss_custom_headers.cpp
+++ b/ecosystem/test/test_oss_custom_headers.cpp
@@ -17,6 +17,8 @@ using namespace photon::net;
 using namespace photon::net::http;
 
 static std::map<std::string, std::string> g_captured_headers;
+static std::string g_captured_target;
+static std::string g_captured_host;
 static photon::mutex g_mutex;
 
 static int capture_handler(void*, Request& req, Response& resp,
@@ -27,6 +29,8 @@ static int capture_handler(void*, Request& req, Response& resp,
     for (auto kv : req.headers) {
       g_captured_headers[std::string(kv.first)] = std::string(kv.second);
     }
+    g_captured_target = std::string(req.target());
+    g_captured_host = std::string(req.host());
   }
   char body[] = "x";
   resp.set_result(200);
@@ -85,6 +89,18 @@ class OssCustomHeaderTest : public ::testing::Test {
                                    tcp_server->getsockname().port);
     opts.retry_times = 0;
     return opts;
+  }
+
+  void send_style_probes(bool path_style) {
+    auto opts = make_opts();
+    opts.path_style = path_style;
+
+    auto client = new_oss_client(opts, new NoopAuthenticator());
+    ASSERT_NE(client, nullptr);
+    DEFER(delete client);
+
+    // copy_object emits x-oss-copy-source built from OssUrl bucket()/object()
+    client->copy_object("src-obj", "test-obj");
   }
 };
 
@@ -167,4 +183,26 @@ TEST_F(OssCustomHeaderTest, case_insensitive_insert_prevents_override) {
   auto date_it = g_captured_headers.find("Date");
   ASSERT_NE(date_it, g_captured_headers.end());
   EXPECT_EQ(date_it->second, "Tue, 10 Jun 2026 00:00:00 GMT");
+}
+
+TEST_F(OssCustomHeaderTest, virtual_hosted_style_url) {
+  send_style_probes(false);
+
+  SCOPED_LOCK(g_mutex);
+  EXPECT_EQ(g_captured_host, "test-bucket.oss-test.example.com");
+  EXPECT_NE(g_captured_target.find("/test-obj"), std::string::npos);
+  EXPECT_EQ(g_captured_target.find("/test-bucket/"), std::string::npos);
+  EXPECT_EQ(g_captured_headers["x-oss-copy-source"],
+            "/test-bucket/src-obj");
+}
+
+TEST_F(OssCustomHeaderTest, path_style_url) {
+  send_style_probes(true);
+
+  SCOPED_LOCK(g_mutex);
+  EXPECT_EQ(g_captured_host, "oss-test.example.com");
+  EXPECT_NE(g_captured_target.find("/test-bucket/test-obj"),
+            std::string::npos);
+  EXPECT_EQ(g_captured_headers["x-oss-copy-source"],
+            "/test-bucket/src-obj");
 }


### PR DESCRIPTION
> feat(ecosystem): support path-style requests in OSS client (#1625)

Add ClientOptions::path_style so requests can use the
http(s)://endpoint/bucket/object layout instead of the default
virtual-hosted style, for S3-compatible endpoints that require it.
Signing already uses the style-independent /bucket/object canonical
resource, so no authenticator changes are needed.

Tests: unit tests asserting request Host/target and x-oss-copy-source
for both styles; add --path_style flag to the test_oss integration
suite.
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.