### PR TITLE
ci: gate PR builds on ready-for-review, split backport control into need-backport

### DIFF
--- a/.github/workflows/auto-pr-backport.yml
+++ b/.github/workflows/auto-pr-backport.yml
@@ -70,10 +70,11 @@ jobs:
           const isManual = '${{ github.event_name }}' === 'workflow_dispatch';
           const commit = '${{ steps.inputs.outputs.COMMIT }}';
           if (isManual) {
-            core.info('Manual trigger: bypassing source PR / bugfix label checks');
+            core.info('Manual trigger: bypassing source PR / need-backport label checks');
             core.setOutput('SKIP', 'false');
             core.setOutput('SOURCE_HEAD_REF', '');
-            core.setOutput('HAS_BUGFIX', 'true');
+            core.setOutput('SOURCE_LABELS', '[]');
+            core.setOutput('HAS_NEED_BACKPORT', 'true');
             return;
           }
           const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -87,23 +88,40 @@ jobs:
             core.info(`no merged PR associated with ${commit}; skipping backport`);
             core.setOutput('SKIP', 'true');
             core.setOutput('SOURCE_HEAD_REF', '');
-            core.setOutput('HAS_BUGFIX', 'false');
+            core.setOutput('SOURCE_LABELS', '[]');
+            core.setOutput('HAS_NEED_BACKPORT', 'false');
             return;
           }
           const pr = merged[0];
           const headRef = (pr.head && pr.head.ref) ? pr.head.ref : '';
           const labels = (pr.labels || []).map(l => l.name);
-          const hasBugfix = labels.includes('bugfix');
+          const isBackportPr = /^backport-pr-[a-f0-9]+-/.test(headRef);
           core.info(`source PR #${pr.number}, head=${headRef}, labels=[${labels.join(', ')}]`);
           core.setOutput('SOURCE_HEAD_REF', headRef);
-          core.setOutput('HAS_BUGFIX', hasBugfix ? 'true' : 'false');
+          // 'needs-manual-merge' records one hop's cherry-pick outcome, so it is not inherited
+          core.setOutput('SOURCE_LABELS', JSON.stringify(labels.filter(l => l !== 'needs-manual-merge')));
           if (/^auto-pr-[a-f0-9]+-/.test(headRef)) {
             core.info('source PR head is auto-pr-* (precise); skipping backport to avoid loop');
             core.setOutput('SKIP', 'true');
+            core.setOutput('HAS_NEED_BACKPORT', 'false');
             return;
           }
-          if (!hasBugfix) {
-            core.info('source PR lacks bugfix label; skipping backport');
+          // The cascade is driven solely by 'need-backport'. A hand-authored bugfix PR seeds it
+          // here, so dropping the label from a backport PR stops the chain at that hop. Failure
+          // to label is left to throw: silently losing a backport is worse than a red run.
+          let hasNeedBackport = labels.includes('need-backport');
+          if (!hasNeedBackport && !isBackportPr && labels.includes('bugfix')) {
+            core.info(`source PR #${pr.number} is labelled bugfix; promoting to need-backport`);
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: pr.number,
+              labels: ['need-backport'],
+            });
+            hasNeedBackport = true;
+          }
+          core.setOutput('HAS_NEED_BACKPORT', hasNeedBackport ? 'true' : 'false');
+          if (!hasNeedBackport) {
+            core.info('source PR lacks need-backport label; skipping backport');
             core.setOutput('SKIP', 'true');
             return;
           }
@@ -221,6 +239,7 @@ jobs:
           HAS_CONFLICT: ${{steps.merge-changes.outputs.HAS_CONFLICT}}
           CONFLICT_NOTE: ${{steps.merge-changes.outputs.CONFLICT_NOTE}}
           DROPPED_FILES: ${{steps.merge-changes.outputs.DROPPED_FILES}}
+          SOURCE_LABELS: ${{steps.detect.outputs.SOURCE_LABELS}}
       with:
         github-token: ${{ secrets.AUTOPR_SECRET }}
         script: |
@@ -247,7 +266,10 @@ jobs:
             body,
             draft: hasConflict,
           });
-          const labels = ['bugfix'];
+          // Inherit the source PR's labels so a bugfix / feature PR stays traceable along the
+          // whole backport chain; 'need-backport' carries the cascade to the next hop.
+          const inherited = JSON.parse(process.env.SOURCE_LABELS || '[]');
+          const labels = [...new Set([...inherited, 'need-backport'])];
           if (hasConflict) labels.push('needs-manual-merge');
           await github.rest.issues.addLabels({
             ...context.repo,

--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -1,21 +1,21 @@
 name: Linux ARM
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
   arm-linux-build-and-test:
     name: gcc${{ matrix.gcc }}-C++${{ matrix.cxx }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: arc-runner-set-arm
     strategy:
       fail-fast: false
@@ -71,7 +71,7 @@ jobs:
           pkill redis-server
 
   debug-build-from-source:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-26.04-arm
     container:
       image: almalinux:8

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -1,21 +1,21 @@
 name: Linux x86_64
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
   gcc-test:
     name: gcc-${{ matrix.gcc }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: arc-acs-runner-set
     strategy:
       fail-fast: false
@@ -63,7 +63,7 @@ jobs:
           pkill redis-server
 
   fstack:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-26.04
     container:
       image: ghcr.io/alibaba/photon-ut-fstack:latest
@@ -78,7 +78,7 @@ jobs:
           cmake --build build -j $(nproc) -t fstack-dpdk-demo
 
   RocksDB:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-26.04
     container:
       image: almalinux:8

--- a/.github/workflows/ci.macos.yml
+++ b/.github/workflows/ci.macos.yml
@@ -1,21 +1,21 @@
 name: macOS-matrix
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
   macos:
     name: macOS-${{ matrix.arch }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Removing an unrelated label from a PR used to spawn a workflow run whose jobs were all
skipped, and those phantom runs obscured the results of the genuine CI run. This replaces the
label-based CI guard with the PR's draft state, and splits the overloaded `bugfix` label into
`bugfix` (what kind of change this is) and `need-backport` (whether the change should keep
propagating down the release branches).

## Changes

**CI gating** (`ci.linux.x86_64.yml`, `ci.linux.arm.yml`, `ci.macos.yml`)

- Trigger on `ready_for_review` instead of `unlabeled`; gate every job on
  `!github.event.pull_request.draft`.
- Drop the `-noop` concurrency group, which existed only to keep label-triggered runs from
  cancelling real ones.

**Backport cascade** (`auto-pr-backport.yml`)

- The cascade is now driven solely by `need-backport`. A hand-authored PR labelled `bugfix` is
  promoted to `need-backport` once; backport PRs are never promoted, so dropping the label from
  one stops the chain at that hop. Promotion is allowed to throw rather than warn, because
  silently losing a backport is worse than a red run.
- Labels are inherited from the source PR instead of hardcoding `bugfix`, so a `bugfix` or
  `feature` PR stays traceable along the whole chain. `needs-manual-merge` is excluded, as it
  records one hop's cherry-pick outcome rather than a property of the change.

## Motivation

`on.pull_request` cannot filter by label name, so listening for `unlabeled` — needed only to
resume CI after `needs-manual-merge` is cleared — made every label removal create a run. Worse,
a job-level `if` skips before matrix expansion, so those runs register check names as raw
templates (`gcc-${{ matrix.gcc }}`, `macOS-${{ matrix.arch }}`) that never occur in a real run
and are therefore never superseded.

Auto-PR already opens conflicted backports as drafts (`draft: hasConflict` alongside the
`needs-manual-merge` label), so draft state carries the same information and has a native
trigger. As a real event, `ready_for_review` also recomputes the merge ref, which lets a
backport pick up a base branch that has moved on — re-running a pinned `pull_request` run
cannot do that.

Separately, `bugfix` was answering two unrelated questions at once, so a maintainer wanting to
stop a cascade had to remove a label that also describes the nature of the change.

## References

- #1629 — three all-skipped runs created by removing `bugfix`, hiding the real CI results
- #1628 — the same guard skipping runs while `needs-manual-merge` was still applied

## Note for reviewers

This must be backported to every active release branch to take effect there, since
`pull_request` events use the workflow file from the **base** branch. Backport PRs opened before
this change carry `bugfix` only and need `need-backport` added by hand before merging, otherwise
their cascade stops (#1628, #1623, #1622).
