### PR TITLE
[Backport][main to 0.9] | ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630)

### DIFF
--- a/.github/workflows/auto-pr-backport.yml
+++ b/.github/workflows/auto-pr-backport.yml
@@ -70,10 +70,11 @@ jobs:
           const isManual = '${{ github.event_name }}' === 'workflow_dispatch';
           const commit = '${{ steps.inputs.outputs.COMMIT }}';
           if (isManual) {
-            core.info('Manual trigger: bypassing source PR / bugfix label checks');
+            core.info('Manual trigger: bypassing source PR / need-backport label checks');
             core.setOutput('SKIP', 'false');
             core.setOutput('SOURCE_HEAD_REF', '');
-            core.setOutput('HAS_BUGFIX', 'true');
+            core.setOutput('SOURCE_LABELS', '[]');
+            core.setOutput('HAS_NEED_BACKPORT', 'true');
             return;
           }
           const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -87,23 +88,40 @@ jobs:
             core.info(`no merged PR associated with ${commit}; skipping backport`);
             core.setOutput('SKIP', 'true');
             core.setOutput('SOURCE_HEAD_REF', '');
-            core.setOutput('HAS_BUGFIX', 'false');
+            core.setOutput('SOURCE_LABELS', '[]');
+            core.setOutput('HAS_NEED_BACKPORT', 'false');
             return;
           }
           const pr = merged[0];
           const headRef = (pr.head && pr.head.ref) ? pr.head.ref : '';
           const labels = (pr.labels || []).map(l => l.name);
-          const hasBugfix = labels.includes('bugfix');
+          const isBackportPr = /^backport-pr-[a-f0-9]+-/.test(headRef);
           core.info(`source PR #${pr.number}, head=${headRef}, labels=[${labels.join(', ')}]`);
           core.setOutput('SOURCE_HEAD_REF', headRef);
-          core.setOutput('HAS_BUGFIX', hasBugfix ? 'true' : 'false');
+          // 'needs-manual-merge' records one hop's cherry-pick outcome, so it is not inherited
+          core.setOutput('SOURCE_LABELS', JSON.stringify(labels.filter(l => l !== 'needs-manual-merge')));
           if (/^auto-pr-[a-f0-9]+-/.test(headRef)) {
             core.info('source PR head is auto-pr-* (precise); skipping backport to avoid loop');
             core.setOutput('SKIP', 'true');
+            core.setOutput('HAS_NEED_BACKPORT', 'false');
             return;
           }
-          if (!hasBugfix) {
-            core.info('source PR lacks bugfix label; skipping backport');
+          // The cascade is driven solely by 'need-backport'. A hand-authored bugfix PR seeds it
+          // here, so dropping the label from a backport PR stops the chain at that hop. Failure
+          // to label is left to throw: silently losing a backport is worse than a red run.
+          let hasNeedBackport = labels.includes('need-backport');
+          if (!hasNeedBackport && !isBackportPr && labels.includes('bugfix')) {
+            core.info(`source PR #${pr.number} is labelled bugfix; promoting to need-backport`);
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: pr.number,
+              labels: ['need-backport'],
+            });
+            hasNeedBackport = true;
+          }
+          core.setOutput('HAS_NEED_BACKPORT', hasNeedBackport ? 'true' : 'false');
+          if (!hasNeedBackport) {
+            core.info('source PR lacks need-backport label; skipping backport');
             core.setOutput('SKIP', 'true');
             return;
           }
@@ -221,6 +239,7 @@ jobs:
           HAS_CONFLICT: ${{steps.merge-changes.outputs.HAS_CONFLICT}}
           CONFLICT_NOTE: ${{steps.merge-changes.outputs.CONFLICT_NOTE}}
           DROPPED_FILES: ${{steps.merge-changes.outputs.DROPPED_FILES}}
+          SOURCE_LABELS: ${{steps.detect.outputs.SOURCE_LABELS}}
       with:
         github-token: ${{ secrets.AUTOPR_SECRET }}
         script: |
@@ -247,7 +266,10 @@ jobs:
             body,
             draft: hasConflict,
           });
-          const labels = ['bugfix'];
+          // Inherit the source PR's labels so a bugfix / feature PR stays traceable along the
+          // whole backport chain; 'need-backport' carries the cascade to the next hop.
+          const inherited = JSON.parse(process.env.SOURCE_LABELS || '[]');
+          const labels = [...new Set([...inherited, 'need-backport'])];
           if (hasConflict) labels.push('needs-manual-merge');
           await github.rest.issues.addLabels({
             ...context.repo,

--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -1,21 +1,21 @@
 name: Linux ARM
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
   arm-linux-build-and-test:
     name: gcc${{ matrix.gcc }}-C++${{ matrix.cxx }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: arc-runner-set-arm
     strategy:
       fail-fast: false
@@ -70,7 +70,7 @@ jobs:
           pkill redis-server
 
   debug-build-from-source:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-26.04-arm
     container:
       image: almalinux:8

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -1,21 +1,21 @@
 name: Linux x86_64
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
   gcc-test:
     name: gcc-${{ matrix.gcc }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: arc-acs-runner-set
     strategy:
       fail-fast: false
@@ -62,7 +62,7 @@ jobs:
           pkill redis-server
 
   fstack:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-26.04
     container:
       image: ghcr.io/alibaba/photon-ut-fstack:latest
@@ -77,7 +77,7 @@ jobs:
           cmake --build build -j $(nproc) -t fstack-dpdk-demo
 
   RocksDB:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-26.04
     container:
       image: almalinux:8

--- a/.github/workflows/ci.macos.yml
+++ b/.github/workflows/ci.macos.yml
@@ -1,21 +1,21 @@
 name: macOS-matrix
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
   macos:
     name: macOS-${{ matrix.arch }}
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
> ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630)

* ci: gate PR builds on draft state instead of labels

Removing any label from a PR fired the `unlabeled` trigger, creating a
workflow run whose jobs were all skipped by the label guard. Such a run
is the newest one on the PR, and because a job-level `if` skips before
matrix expansion its check names are the raw templates (`gcc-${{
matrix.gcc }}`), which never occur in a real run and are therefore never
superseded. The result is a PR status list where phantom skipped checks
sit on top of, and obscure, the genuine CI results.

Auto-PR already opens conflicted backports as drafts, so draft state
carries exactly the same information as the needs-manual-merge label.
Gate on it and trigger on ready_for_review, which as a real event also
recomputes the merge ref, letting a backport pick up a base branch that
has moved on. The -noop concurrency group existed only to keep
label-triggered runs from cancelling real ones, and is no longer needed.

* ci(autopr): drive the backport cascade with a need-backport label

The bugfix label conflated two independent questions: what kind of change
this is, and whether it should keep propagating down the release
branches. need-backport now answers the second one. A hand-authored PR
labelled bugfix is promoted to need-backport once, and from then on the
cascade reads need-backport alone, so dropping that label from a backport
PR stops the chain at that hop without touching bugfix. Promotion is
deliberately allowed to throw: silently losing a backport is worse than a
red run.

Labels are inherited from the source PR rather than hardcoding bugfix, so
a bugfix or feature PR stays traceable along the whole chain.
needs-manual-merge is excluded from inheritance because it records one
hop's cherry-pick outcome, not a property of the change.

Backport PRs opened before this change carry bugfix only; they need
need-backport added by hand before merging, or their cascade stops there.
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.