### PR TITLE
[Backport][0.9 to 0.8] | ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631)

### DIFF
--- a/.github/workflows/auto-pr-backport.yml
+++ b/.github/workflows/auto-pr-backport.yml
@@ -70,10 +70,11 @@ jobs:
           const isManual = '${{ github.event_name }}' === 'workflow_dispatch';
           const commit = '${{ steps.inputs.outputs.COMMIT }}';
           if (isManual) {
-            core.info('Manual trigger: bypassing source PR / bugfix label checks');
+            core.info('Manual trigger: bypassing source PR / need-backport label checks');
             core.setOutput('SKIP', 'false');
             core.setOutput('SOURCE_HEAD_REF', '');
-            core.setOutput('HAS_BUGFIX', 'true');
+            core.setOutput('SOURCE_LABELS', '[]');
+            core.setOutput('HAS_NEED_BACKPORT', 'true');
             return;
           }
           const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -87,23 +88,40 @@ jobs:
             core.info(`no merged PR associated with ${commit}; skipping backport`);
             core.setOutput('SKIP', 'true');
             core.setOutput('SOURCE_HEAD_REF', '');
-            core.setOutput('HAS_BUGFIX', 'false');
+            core.setOutput('SOURCE_LABELS', '[]');
+            core.setOutput('HAS_NEED_BACKPORT', 'false');
             return;
           }
           const pr = merged[0];
           const headRef = (pr.head && pr.head.ref) ? pr.head.ref : '';
           const labels = (pr.labels || []).map(l => l.name);
-          const hasBugfix = labels.includes('bugfix');
+          const isBackportPr = /^backport-pr-[a-f0-9]+-/.test(headRef);
           core.info(`source PR #${pr.number}, head=${headRef}, labels=[${labels.join(', ')}]`);
           core.setOutput('SOURCE_HEAD_REF', headRef);
-          core.setOutput('HAS_BUGFIX', hasBugfix ? 'true' : 'false');
+          // 'needs-manual-merge' records one hop's cherry-pick outcome, so it is not inherited
+          core.setOutput('SOURCE_LABELS', JSON.stringify(labels.filter(l => l !== 'needs-manual-merge')));
           if (/^auto-pr-[a-f0-9]+-/.test(headRef)) {
             core.info('source PR head is auto-pr-* (precise); skipping backport to avoid loop');
             core.setOutput('SKIP', 'true');
+            core.setOutput('HAS_NEED_BACKPORT', 'false');
             return;
           }
-          if (!hasBugfix) {
-            core.info('source PR lacks bugfix label; skipping backport');
+          // The cascade is driven solely by 'need-backport'. A hand-authored bugfix PR seeds it
+          // here, so dropping the label from a backport PR stops the chain at that hop. Failure
+          // to label is left to throw: silently losing a backport is worse than a red run.
+          let hasNeedBackport = labels.includes('need-backport');
+          if (!hasNeedBackport && !isBackportPr && labels.includes('bugfix')) {
+            core.info(`source PR #${pr.number} is labelled bugfix; promoting to need-backport`);
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: pr.number,
+              labels: ['need-backport'],
+            });
+            hasNeedBackport = true;
+          }
+          core.setOutput('HAS_NEED_BACKPORT', hasNeedBackport ? 'true' : 'false');
+          if (!hasNeedBackport) {
+            core.info('source PR lacks need-backport label; skipping backport');
             core.setOutput('SKIP', 'true');
             return;
           }
@@ -221,6 +239,7 @@ jobs:
           HAS_CONFLICT: ${{steps.merge-changes.outputs.HAS_CONFLICT}}
           CONFLICT_NOTE: ${{steps.merge-changes.outputs.CONFLICT_NOTE}}
           DROPPED_FILES: ${{steps.merge-changes.outputs.DROPPED_FILES}}
+          SOURCE_LABELS: ${{steps.detect.outputs.SOURCE_LABELS}}
       with:
         github-token: ${{ secrets.AUTOPR_SECRET }}
         script: |
@@ -247,7 +266,10 @@ jobs:
             body,
             draft: hasConflict,
           });
-          const labels = ['bugfix'];
+          // Inherit the source PR's labels so a bugfix / feature PR stays traceable along the
+          // whole backport chain; 'need-backport' carries the cascade to the next hop.
+          const inherited = JSON.parse(process.env.SOURCE_LABELS || '[]');
+          const labels = [...new Set([...inherited, 'need-backport'])];
           if (hasConflict) labels.push('needs-manual-merge');
           await github.rest.issues.addLabels({
             ...context.repo,

--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -1,19 +1,20 @@
 name: Linux ARM
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
   arm-linux-build-and-test:
+<<<<<<< HEAD
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-24.04-arm
 
@@ -21,6 +22,30 @@ jobs:
       image: ghcr.io/alibaba/photon-ut-base:latest
       options: --cpus 4
 
+=======
+    name: gcc${{ matrix.gcc }}-C++${{ matrix.cxx }}
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: arc-runner-set-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - gcc: 8
+            cxx: 14
+          - gcc: 9
+            cxx: 14
+          - gcc: 10
+            cxx: 17
+          - gcc: 11
+            cxx: 17
+          - gcc: 12
+            cxx: 20
+          - gcc: 13
+            cxx: 20
+          - gcc: 14
+            cxx: 23
+            run_test: true
+>>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))
     steps:
       - uses: szenius/set-timezone@v2.0
         with:
@@ -92,3 +117,31 @@ jobs:
         run: |
           cd build
           ctest -E test-lockfree --timeout 3600 -V
+<<<<<<< HEAD
+=======
+          pkill redis-server
+
+  debug-build-from-source:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-26.04-arm
+    container:
+      image: almalinux:8
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled powertools
+          dnf -q -y install git gcc-c++ cmake gcc-toolset-9-gcc-c++ nasm
+          source /opt/rh/gcc-toolset-9/enable
+          cmake -B build -D CMAKE_BUILD_TYPE=Debug        \
+                         -D PHOTON_BUILD_DEPENDENCIES=ON  \
+                         -D PHOTON_BUILD_TESTING=ON       \
+                         -D PHOTON_ENABLE_ECOSYSTEM=ON    \
+                         -D PHOTON_ENABLE_SASL=OFF        \
+                         -D PHOTON_ENABLE_FUSE=OFF        \
+                         -D PHOTON_ENABLE_URING=ON        \
+                         -D PHOTON_ENABLE_LIBCURL=OFF     \
+                         -D PHOTON_ENABLE_EXTFS=OFF
+          cmake --build build -j $(nproc)
+>>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))

--- a/.github/workflows/ci.linux.arm.yml
+++ b/.github/workflows/ci.linux.arm.yml
@@ -14,38 +14,13 @@ on:
 
 jobs:
   arm-linux-build-and-test:
-<<<<<<< HEAD
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04-arm
 
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
       options: --cpus 4
 
-=======
-    name: gcc${{ matrix.gcc }}-C++${{ matrix.cxx }}
-    if: ${{ !github.event.pull_request.draft }}
-    runs-on: arc-runner-set-arm
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - gcc: 8
-            cxx: 14
-          - gcc: 9
-            cxx: 14
-          - gcc: 10
-            cxx: 17
-          - gcc: 11
-            cxx: 17
-          - gcc: 12
-            cxx: 20
-          - gcc: 13
-            cxx: 20
-          - gcc: 14
-            cxx: 23
-            run_test: true
->>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))
     steps:
       - uses: szenius/set-timezone@v2.0
         with:
@@ -117,31 +92,3 @@ jobs:
         run: |
           cd build
           ctest -E test-lockfree --timeout 3600 -V
-<<<<<<< HEAD
-=======
-          pkill redis-server
-
-  debug-build-from-source:
-    if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-26.04-arm
-    container:
-      image: almalinux:8
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build
-        run: |
-          dnf install -y 'dnf-command(config-manager)'
-          dnf config-manager --set-enabled powertools
-          dnf -q -y install git gcc-c++ cmake gcc-toolset-9-gcc-c++ nasm
-          source /opt/rh/gcc-toolset-9/enable
-          cmake -B build -D CMAKE_BUILD_TYPE=Debug        \
-                         -D PHOTON_BUILD_DEPENDENCIES=ON  \
-                         -D PHOTON_BUILD_TESTING=ON       \
-                         -D PHOTON_ENABLE_ECOSYSTEM=ON    \
-                         -D PHOTON_ENABLE_SASL=OFF        \
-                         -D PHOTON_ENABLE_FUSE=OFF        \
-                         -D PHOTON_ENABLE_URING=ON        \
-                         -D PHOTON_ENABLE_LIBCURL=OFF     \
-                         -D PHOTON_ENABLE_EXTFS=OFF
-          cmake --build build -j $(nproc)
->>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -13,23 +13,12 @@ on:
     branches: [ "main", "release/*" ]
 
 jobs:
-<<<<<<< HEAD
   gcc850:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
       options: --cpus 4 --privileged
-=======
-  gcc-test:
-    name: gcc-${{ matrix.gcc }}
-    if: ${{ !github.event.pull_request.draft }}
-    runs-on: arc-acs-runner-set
-    strategy:
-      fail-fast: false
-      matrix:
-        gcc: [8, 9, 10, 11, 12, 13, 14]
->>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))
     steps:
       - uses: szenius/set-timezone@v2.0
         with:
@@ -61,7 +50,7 @@ jobs:
           cd build && ctest -E test-lockfree --timeout 3600 -V
 
   gcc921:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -98,7 +87,7 @@ jobs:
           cd build && ctest -E test-lockfree --timeout 3600 -V
 
   gcc1031:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -135,7 +124,7 @@ jobs:
           cd build && ctest -E test-lockfree --timeout 3600 -V
 
   gcc1121:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -172,7 +161,7 @@ jobs:
           cd build && ctest -E test-lockfree --timeout 3600 -V
 
   gcc1211:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
@@ -209,13 +198,8 @@ jobs:
           cd build && ctest -E test-lockfree --timeout 3600 -V
 
   fstack:
-<<<<<<< HEAD
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
-    runs-on: ubuntu-latest
-=======
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-26.04
->>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-fstack:latest
       options: --cpus 4 --privileged
@@ -227,29 +211,3 @@ jobs:
             -D PHOTON_BUILD_TESTING=ON \
             -D PHOTON_ENABLE_FSTACK_DPDK=ON
           cmake --build build -j $(nproc) -t fstack-dpdk-demo
-<<<<<<< HEAD
-=======
-
-  RocksDB:
-    if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-26.04
-    container:
-      image: almalinux:8
-      options: --cpus 4 --privileged
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build
-        run: |
-          export PHOTON_SRC_DIR=`pwd`
-          dnf install -q -y git gcc-c++ cmake openssl-devel libcurl-devel libaio-devel zlib-devel epel-release
-          dnf config-manager --set-enabled powertools
-          dnf install -q -y gflags-devel snappy-devel zlib-devel bzip2-devel lz4-devel libzstd-devel nasm
-          git clone -b photon-on-6.1.2 https://github.com/data-accelerator/rocksdb.git /opt/rocksdb
-          cd /opt/rocksdb
-          rm -rf third-party/PhotonLibOS
-          ln -s $PHOTON_SRC_DIR third-party/PhotonLibOS
-          ./photon-auto-convert.sh
-          cmake -B build -D WITH_TESTS=on -D INIT_PHOTON_IN_ENV=on -D WITH_LZ4=on -D WITH_SNAPPY=on \
-            -D CMAKE_BUILD_TYPE=Debug
-          cmake --build build -j `nproc`
->>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))

--- a/.github/workflows/ci.linux.x86_64.yml
+++ b/.github/workflows/ci.linux.x86_64.yml
@@ -1,24 +1,35 @@
 name: Linux x86_64
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
+<<<<<<< HEAD
   gcc850:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/alibaba/photon-ut-base:latest
       options: --cpus 4 --privileged
+=======
+  gcc-test:
+    name: gcc-${{ matrix.gcc }}
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: arc-acs-runner-set
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc: [8, 9, 10, 11, 12, 13, 14]
+>>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))
     steps:
       - uses: szenius/set-timezone@v2.0
         with:
@@ -198,8 +209,13 @@ jobs:
           cd build && ctest -E test-lockfree --timeout 3600 -V
 
   fstack:
+<<<<<<< HEAD
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: ubuntu-latest
+=======
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-26.04
+>>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))
     container:
       image: ghcr.io/alibaba/photon-ut-fstack:latest
       options: --cpus 4 --privileged
@@ -211,3 +227,29 @@ jobs:
             -D PHOTON_BUILD_TESTING=ON \
             -D PHOTON_ENABLE_FSTACK_DPDK=ON
           cmake --build build -j $(nproc) -t fstack-dpdk-demo
+<<<<<<< HEAD
+=======
+
+  RocksDB:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-26.04
+    container:
+      image: almalinux:8
+      options: --cpus 4 --privileged
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          export PHOTON_SRC_DIR=`pwd`
+          dnf install -q -y git gcc-c++ cmake openssl-devel libcurl-devel libaio-devel zlib-devel epel-release
+          dnf config-manager --set-enabled powertools
+          dnf install -q -y gflags-devel snappy-devel zlib-devel bzip2-devel lz4-devel libzstd-devel nasm
+          git clone -b photon-on-6.1.2 https://github.com/data-accelerator/rocksdb.git /opt/rocksdb
+          cd /opt/rocksdb
+          rm -rf third-party/PhotonLibOS
+          ln -s $PHOTON_SRC_DIR third-party/PhotonLibOS
+          ./photon-auto-convert.sh
+          cmake -B build -D WITH_TESTS=on -D INIT_PHOTON_IN_ENV=on -D WITH_LZ4=on -D WITH_SNAPPY=on \
+            -D CMAKE_BUILD_TYPE=Debug
+          cmake --build build -j `nproc`
+>>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631))

--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -13,26 +13,9 @@ on:
     branches: [ "main", "release/*" ]
 
 jobs:
-<<<<<<< HEAD:.github/workflows/ci.macos.arm.yml
   macOS14-arm:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
-    runs-on: macos-15
-=======
-  macos:
-    name: macOS-${{ matrix.arch }}
     if: ${{ !github.event.pull_request.draft }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: arm
-            runner: macos-15
-            extra_brew: ""
-          - arch: x86_64
-            runner: macos-15-intel
-            extra_brew: "nasm"
-    runs-on: ${{ matrix.runner }}
->>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631)):.github/workflows/ci.macos.yml
+    runs-on: macos-15
 
     steps:
       - uses: szenius/set-timezone@v2.0

--- a/.github/workflows/ci.macos.arm.yml
+++ b/.github/workflows/ci.macos.arm.yml
@@ -1,21 +1,38 @@
 name: macOS-matrix
 
-# Runs triggered by removing an irrelevant label would have all jobs skipped, but they
-# still enter the concurrency group and would cancel an in-progress CI run. Divert them
-# into a separate '-noop' group so they never interfere with real CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.event.action == 'unlabeled' && github.event.label.name != 'needs-manual-merge') && '-noop' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
+<<<<<<< HEAD:.github/workflows/ci.macos.arm.yml
   macOS14-arm:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
     runs-on: macos-15
+=======
+  macos:
+    name: macOS-${{ matrix.arch }}
+    if: ${{ !github.event.pull_request.draft }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm
+            runner: macos-15
+            extra_brew: ""
+          - arch: x86_64
+            runner: macos-15-intel
+            extra_brew: "nasm"
+    runs-on: ${{ matrix.runner }}
+>>>>>>> 3bc0d38 (ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631)):.github/workflows/ci.macos.yml
 
     steps:
       - uses: szenius/set-timezone@v2.0

--- a/.github/workflows/ci.macos.x86_64.yml
+++ b/.github/workflows/ci.macos.x86_64.yml
@@ -1,13 +1,16 @@
 name: macOS x86_64
 
+# Draft PRs don't run CI. Auto-PR opens conflicted backports as drafts, whose conflict
+# markers would fail the build anyway; marking one ready for review triggers a full run
+# against a freshly computed merge ref.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main", "release/*" ]
 
 jobs:
   macOS13-x86:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'needs-manual-merge') && (github.event.action != 'unlabeled' || github.event.label.name == 'needs-manual-merge') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: macos-15
 
     steps:


### PR DESCRIPTION
> ci: gate PR builds on ready-for-review, split backport control into need-backport (#1630) (#1631)

* ci: gate PR builds on draft state instead of labels

Removing any label from a PR fired the `unlabeled` trigger, creating a
workflow run whose jobs were all skipped by the label guard. Such a run
is the newest one on the PR, and because a job-level `if` skips before
matrix expansion its check names are the raw templates (`gcc-${{
matrix.gcc }}`), which never occur in a real run and are therefore never
superseded. The result is a PR status list where phantom skipped checks
sit on top of, and obscure, the genuine CI results.

Auto-PR already opens conflicted backports as drafts, so draft state
carries exactly the same information as the needs-manual-merge label.
Gate on it and trigger on ready_for_review, which as a real event also
recomputes the merge ref, letting a backport pick up a base branch that
has moved on. The -noop concurrency group existed only to keep
label-triggered runs from cancelling real ones, and is no longer needed.

* ci(autopr): drive the backport cascade with a need-backport label

The bugfix label conflated two independent questions: what kind of change
this is, and whether it should keep propagating down the release
branches. need-backport now answers the second one. A hand-authored PR
labelled bugfix is promoted to need-backport once, and from then on the
cascade reads need-backport alone, so dropping that label from a backport
PR stops the chain at that hop without touching bugfix. Promotion is
deliberately allowed to throw: silently losing a backport is worse than a
red run.

Labels are inherited from the source PR rather than hardcoding bugfix, so
a bugfix or feature PR stays traceable along the whole chain.
needs-manual-merge is excluded from inheritance because it records one
hop's cherry-pick outcome, not a property of the change.

Backport PRs opened before this change carry bugfix only; they need
need-backport added by hand before merging, or their cascade stops there.

Co-authored-by: Coldwings <coldwings@me.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- 3bc0d38f39dbda57c312df811467916d126447e7: .github/workflows/ci.linux.arm.yml,.github/workflows/ci.linux.x86_64.yml,.github/workflows/ci.macos.arm.yml