### PR TITLE
[Backport][0.9 to 0.8] | | fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627) (#1628)

### DIFF
--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -9,7 +9,7 @@ function(build_from_src [dep])
         ExternalProject_Add(
                 aio
                 URL ${PHOTON_AIO_SOURCE}
-                URL_MD5 605237f35de238dfacc83bcae406d95d
+                URL_MD5 7d5be185f20eeaae15e267419950aaf7
                 UPDATE_DISCONNECTED ON
                 BUILD_IN_SOURCE ON
                 CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ option(PHOTON_ENABLE_LIBCURL "enable libcurl" ON)
 set(PHOTON_DEFAULT_LOG_LEVEL "0" CACHE STRING "default log level")
 
 option(PHOTON_BUILD_DEPENDENCIES "" OFF)
-set(PHOTON_AIO_SOURCE "https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz" CACHE STRING "")
+set(PHOTON_AIO_SOURCE "https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz" CACHE STRING "")
 set(PHOTON_ZLIB_SOURCE "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz" CACHE STRING "")
 set(PHOTON_OPENSSL_SOURCE "https://github.com/openssl/openssl/archive/refs/heads/OpenSSL_1_0_2-stable.tar.gz" CACHE STRING "")
 set(PHOTON_CURL_SOURCE "https://github.com/curl/curl/archive/refs/tags/curl-7_42_1.tar.gz" CACHE STRING "")

--- a/doc/docs/introduction/how-to-build.md
+++ b/doc/docs/introduction/how-to-build.md
@@ -183,7 +183,7 @@ cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 -D PHOTON_BUILD_TESTING=ON \
 -D PHOTON_BUILD_DEPENDENCIES=ON \
 -D PHOTON_ENABLE_URING=ON \
--D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_AIO_SOURCE=https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz \
 -D PHOTON_ZLIB_SOURCE=https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz \
 -D PHOTON_URING_SOURCE=https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz \
 -D PHOTON_CURL_SOURCE=https://github.com/curl/curl/archive/refs/tags/curl-7_42_1.tar.gz \
@@ -197,7 +197,7 @@ cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 ```bash
 cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 -D PHOTON_BUILD_DEPENDENCIES=ON \
--D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_AIO_SOURCE=https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz \
 -D PHOTON_CURL_SOURCE="" \
 -D PHOTON_OPENSSL_SOURCE=""
 ```

--- a/doc/i18n/cn/docusaurus-plugin-content-docs/current/introduction/how-to-build.md
+++ b/doc/i18n/cn/docusaurus-plugin-content-docs/current/introduction/how-to-build.md
@@ -187,7 +187,7 @@ cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 -D PHOTON_BUILD_TESTING=ON \
 -D PHOTON_BUILD_DEPENDENCIES=ON \
 -D PHOTON_ENABLE_URING=ON \
--D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_AIO_SOURCE=https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz \
 -D PHOTON_ZLIB_SOURCE=https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz \
 -D PHOTON_URING_SOURCE=https://github.com/axboe/liburing/archive/refs/tags/liburing-2.3.tar.gz \
 -D PHOTON_CURL_SOURCE=https://github.com/curl/curl/archive/refs/tags/curl-7_42_1.tar.gz \
@@ -203,7 +203,7 @@ cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 ```bash
 cmake -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo \
 -D PHOTON_BUILD_DEPENDENCIES=ON \
--D PHOTON_AIO_SOURCE=https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz \
+-D PHOTON_AIO_SOURCE=https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz \
 -D PHOTON_CURL_SOURCE="" \
 -D PHOTON_OPENSSL_SOURCE=""
 ```


### PR DESCRIPTION
> [Backport][main to 0.9] | fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627) (#1628)

* fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627)

pagure.io code hosting was sunset in mid-2026, breaking the archive
download path used to build libaio from source.

libaio is not a Fedora-entity project, so it was not moved to
forge.fedoraproject.org; its upstream git repository now lives on
Codeberg at jmoyer/libaio (maintained by Jeff Moyer). That repo
publishes a static release asset for libaio-0.3.113 which is
byte-identical to the previous canonical release tarball
(sha512 65c30a10..., md5 7d5be185...), verified against the
published .sha512sum.

Point the default PHOTON_AIO_SOURCE at the Codeberg release asset
(a static upload, not a dynamic git-archive, so its checksum is
stable for URL_MD5 pinning). Update URL_MD5 to match the release
tarball (605237f3... -> 7d5be185...). The archive still extracts to
libaio-0.3.113/ with the same Makefile layout, so the build command
is unchanged. Update the build docs (en/cn) accordingly.

* Update CMakeLists.txt

---------

Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.