### PR TITLE
[Backport][0.7 to 0.6] | | | fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627) (#1628) (#1633) (#1635)

### DIFF
--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -8,7 +8,12 @@ function(build_from_src [dep])
         ExternalProject_Add(
                 aio
                 URL ${PHOTON_AIO_SOURCE}
+<<<<<<< HEAD
                 URL_MD5 605237f35de238dfacc83bcae406d95d
+=======
+                URL_MD5 7d5be185f20eeaae15e267419950aaf7
+                UPDATE_DISCONNECTED ON
+>>>>>>> 7df9495 ([Backport][0.8 to 0.7] | | fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627) (#1628) (#1633) (#1635))
                 BUILD_IN_SOURCE ON
                 CONFIGURE_COMMAND ""
                 BUILD_COMMAND make prefix=${BINARY_DIR} install -j

--- a/CMake/build-from-src.cmake
+++ b/CMake/build-from-src.cmake
@@ -8,12 +8,8 @@ function(build_from_src [dep])
         ExternalProject_Add(
                 aio
                 URL ${PHOTON_AIO_SOURCE}
-<<<<<<< HEAD
-                URL_MD5 605237f35de238dfacc83bcae406d95d
-=======
                 URL_MD5 7d5be185f20eeaae15e267419950aaf7
                 UPDATE_DISCONNECTED ON
->>>>>>> 7df9495 ([Backport][0.8 to 0.7] | | fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627) (#1628) (#1633) (#1635))
                 BUILD_IN_SOURCE ON
                 CONFIGURE_COMMAND ""
                 BUILD_COMMAND make prefix=${BINARY_DIR} install -j

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ option(PHOTON_ENABLE_EXTFS "enable extfs" OFF)
 option(PHOTON_ENABLE_RESIZE "enable resize_extfs (requires external resize_fs)" OFF)
 
 option(PHOTON_BUILD_DEPENDENCIES "" OFF)
-set(PHOTON_AIO_SOURCE "https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz" CACHE STRING "")
+set(PHOTON_AIO_SOURCE "https://codeberg.org/jmoyer/libaio/releases/download/libaio-0.3.113/libaio-0.3.113.tar.gz" CACHE STRING "")
 set(PHOTON_ZLIB_SOURCE "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz" CACHE STRING "")
 set(PHOTON_OPENSSL_SOURCE "" CACHE STRING "")
 set(PHOTON_CURL_SOURCE "" CACHE STRING "")


### PR DESCRIPTION
> [Backport][0.8 to 0.7] | | fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627) (#1628) (#1633) (#1635)

* [Backport][main to 0.9] | fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627) (#1628) (#1633)

* fix(build): migrate libaio source from sunset pagure.io to Codeberg upstream (#1627)

pagure.io code hosting was sunset in mid-2026, breaking the archive
download path used to build libaio from source.

libaio is not a Fedora-entity project, so it was not moved to
forge.fedoraproject.org; its upstream git repository now lives on
Codeberg at jmoyer/libaio (maintained by Jeff Moyer). That repo
publishes a static release asset for libaio-0.3.113 which is
byte-identical to the previous canonical release tarball
(sha512 65c30a10..., md5 7d5be185...), verified against the
published .sha512sum.

Point the default PHOTON_AIO_SOURCE at the Codeberg release asset
(a static upload, not a dynamic git-archive, so its checksum is
stable for URL_MD5 pinning). Update URL_MD5 to match the release
tarball (605237f3... -> 7d5be185...). The archive still extracts to
libaio-0.3.113/ with the same Makefile layout, so the build command
is unchanged. Update the build docs (en/cn) accordingly.

* Update CMakeLists.txt

---------

Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>

* chore: drop files not present in 0.7

* Update how-to-build.md

---------

Co-authored-by: Coldwings <coldwings@me.com>
Co-authored-by: Huiba Li <huiba.lhb@alibaba-inc.com>
Co-authored-by: lihuiba <282919+lihuiba@users.noreply.github.com>
Generated by Backport Auto PR, by cherry-pick related commits.

Please review and decide whether to merge or close this backport PR.

## Conflicts

Cherry-pick produced conflicts. Conflict markers are committed as-is; please resolve them manually before merging.

- 7df949517031e50de48f82ce7f73ac2b89ac4698: CMake/build-from-src.cmake